### PR TITLE
Basic implementations for stream and context for Cubeb

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/target
+**/*.rs.bk
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 authors = ["Chun-Min Chang <chun.m.chang@gmail.com>"]
 
 [dependencies]
+cubeb-backend = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "cubeb-coreaudio"
+version = "0.1.0"
+authors = ["Chun-Min Chang <chun.m.chang@gmail.com>"]
+
+[dependencies]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # cubeb-coreaudio-rs
 
-Implementation of MacOS Audio backend in CoreAudio framework for Cubeb written in Rust.
+Implementation of MacOS Audio backend in CoreAudio framework for [Cubeb][cubeb] written in Rust.
+
+[cubeb]: https://github.com/kinetiknz/cubeb "Cross platform audio library"

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,0 +1,136 @@
+// Copyright © 2018 Mozilla Foundation
+//
+// This program is made available under an ISC-style license.  See the
+// accompanying file LICENSE for details.
+
+use cubeb_backend::{
+    ffi, Context, ContextOps, DeviceCollectionRef, DeviceId, DeviceRef, DeviceType, Error, Ops,
+    Result, Stream, StreamOps, StreamParams, StreamParamsRef,
+};
+use std::ffi::CStr;
+use std::os::raw::{c_char, c_void};
+use std::ptr;
+
+pub const OPS: Ops = capi_new!(AudioUnitContext, AudioUnitStream);
+
+pub struct AudioUnitContext {
+    pub ops: *const Ops,
+}
+
+impl ContextOps for AudioUnitContext {
+    fn init(_context_name: Option<&CStr>) -> Result<Context> {
+        // The context must be boxed since capi_destroy releases the context
+        // by Box::from_raw.
+        let ctx = Box::new(AudioUnitContext {
+            ops: &OPS as *const Ops,
+        });
+        Ok(unsafe { Context::from_ptr(Box::into_raw(ctx) as *mut ffi::cubeb) })
+    }
+
+    fn backend_id(&mut self) -> &'static CStr {
+        unsafe { CStr::from_ptr(b"audiounit-rust\0".as_ptr() as *const c_char) }
+    }
+    fn max_channel_count(&mut self) -> Result<u32> {
+        Ok(256u32)
+    }
+    fn min_latency(&mut self, _params: StreamParams) -> Result<u32> {
+        Ok(256u32)
+    }
+    fn preferred_sample_rate(&mut self) -> Result<u32> {
+        Ok(48000u32)
+    }
+    fn enumerate_devices(
+        &mut self,
+        _devtype: DeviceType,
+        collection: &DeviceCollectionRef,
+    ) -> Result<()> {
+        let coll = unsafe { &mut *collection.as_ptr() };
+        coll.device = 0xDEAD_BEEF as *mut ffi::cubeb_device_info;
+        coll.count = usize::max_value();
+        Err(Error::not_supported())
+    }
+    fn device_collection_destroy(&mut self, collection: &mut DeviceCollectionRef) -> Result<()> {
+        let coll = unsafe { &mut *collection.as_ptr() };
+        assert_eq!(coll.device, 0xDEAD_BEEF as *mut ffi::cubeb_device_info);
+        assert_eq!(coll.count, usize::max_value());
+        coll.device = ptr::null_mut();
+        coll.count = 0;
+        Err(Error::not_supported())
+    }
+    fn stream_init(
+        &mut self,
+        _stream_name: Option<&CStr>,
+        _input_device: DeviceId,
+        _input_stream_params: Option<&StreamParamsRef>,
+        _output_device: DeviceId,
+        _output_stream_params: Option<&StreamParamsRef>,
+        _latency_frame: u32,
+        _data_callback: ffi::cubeb_data_callback,
+        _state_callback: ffi::cubeb_state_callback,
+        _user_ptr: *mut c_void,
+    ) -> Result<Stream> {
+        Err(Error::not_supported())
+    }
+    fn register_device_collection_changed(
+        &mut self,
+        dev_type: DeviceType,
+        collection_changed_callback: ffi::cubeb_device_collection_changed_callback,
+        user_ptr: *mut c_void,
+    ) -> Result<()> {
+        assert!(dev_type.contains(DeviceType::INPUT | DeviceType::OUTPUT));
+        assert!(collection_changed_callback.is_some());
+        assert_eq!(user_ptr, 0xDEAD_BEEF as *mut c_void);
+        Err(Error::not_supported())
+    }
+}
+
+struct AudioUnitStream {}
+
+impl StreamOps for AudioUnitStream {
+    fn start(&mut self) -> Result<()> {
+        Err(Error::not_supported())
+    }
+    fn stop(&mut self) -> Result<()> {
+        Err(Error::not_supported())
+    }
+    fn reset_default_device(&mut self) -> Result<()> {
+        Err(Error::not_supported())
+    }
+    fn position(&mut self) -> Result<u64> {
+        Ok(0u64)
+    }
+    fn latency(&mut self) -> Result<u32> {
+        Ok(0u32)
+    }
+    fn set_volume(&mut self, volume: f32) -> Result<()> {
+        // Most floating-point numbers are slightly imprecise. Using EPSILON
+        // to check the equalitiy might not be correct all th time, but it's
+        // enough for our case for now.
+        use std::f32;
+        assert!((volume - 0.5f32).abs() < f32::EPSILON);
+        Err(Error::not_supported())
+    }
+    fn set_panning(&mut self, panning: f32) -> Result<()> {
+        // The reason for using EPSILON is same as above.
+        use std::f32;
+        assert!((panning - 0.5f32).abs() < f32::EPSILON);
+        Err(Error::not_supported())
+    }
+    fn current_device(&mut self) -> Result<&DeviceRef> {
+        Ok(unsafe { DeviceRef::from_ptr(0xDEAD_BEEF as *mut ffi::cubeb_device) })
+    }
+    fn device_destroy(&mut self, device: &DeviceRef) -> Result<()> {
+        assert_eq!(device.as_ptr(), 0xDEAD_BEEF as *mut ffi::cubeb_device);
+        Err(Error::not_supported())
+    }
+    fn register_device_changed_callback(
+        &mut self,
+        device_changed_callback: ffi::cubeb_device_changed_callback,
+    ) -> Result<()> {
+        assert!(device_changed_callback.is_some());
+        Err(Error::not_supported())
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/src/backend/test.rs
+++ b/src/backend/test.rs
@@ -1,0 +1,260 @@
+// Copyright © 2018 Mozilla Foundation
+//
+// This program is made available under an ISC-style license.  See the
+// accompanying file LICENSE for details.
+
+use super::*;
+
+// The following tests are sorted by the order of Ops in cubeb-backend.
+#[test]
+fn test_ops_context_init() {
+    let mut c: *mut ffi::cubeb = ptr::null_mut();
+    assert_eq!(
+        unsafe { OPS.init.unwrap()(&mut c, ptr::null()) },
+        ffi::CUBEB_OK
+    );
+    unsafe {
+        OPS.destroy.unwrap()(c);
+    }
+}
+
+#[test]
+fn test_ops_context_backend_id() {
+    let c: *mut ffi::cubeb = ptr::null_mut();
+    let backend = unsafe {
+        let ptr = OPS.get_backend_id.unwrap()(c);
+        CStr::from_ptr(ptr).to_string_lossy().into_owned()
+    };
+    assert_eq!(backend, "audiounit-rust");
+}
+
+#[test]
+fn test_ops_context_max_channel_count() {
+    let c: *mut ffi::cubeb = ptr::null_mut();
+    let mut max_channel_count = u32::max_value();
+    assert_eq!(
+        unsafe { OPS.get_max_channel_count.unwrap()(c, &mut max_channel_count) },
+        ffi::CUBEB_OK
+    );
+    assert_eq!(max_channel_count, 256);
+}
+
+#[test]
+fn test_ops_context_min_latency() {
+    let c: *mut ffi::cubeb = ptr::null_mut();
+    let params: ffi::cubeb_stream_params = unsafe { ::std::mem::zeroed() };
+    let mut latency = u32::max_value();
+    assert_eq!(
+        unsafe { OPS.get_min_latency.unwrap()(c, params, &mut latency) },
+        ffi::CUBEB_OK
+    );
+    assert_eq!(latency, 256);
+}
+
+#[test]
+fn test_ops_context_preferred_sample_rate() {
+    let c: *mut ffi::cubeb = ptr::null_mut();
+    let mut rate = u32::max_value();
+    assert_eq!(
+        unsafe { OPS.get_preferred_sample_rate.unwrap()(c, &mut rate) },
+        ffi::CUBEB_OK
+    );
+    assert_eq!(rate, 48000);
+}
+
+#[test]
+fn test_ops_context_enumerate_devices() {
+    let c: *mut ffi::cubeb = ptr::null_mut();
+    let mut coll = ffi::cubeb_device_collection {
+        device: ptr::null_mut(),
+        count: 0,
+    };
+    assert_eq!(
+        unsafe { OPS.enumerate_devices.unwrap()(c, 0, &mut coll) },
+        ffi::CUBEB_ERROR_NOT_SUPPORTED
+    );
+    assert_eq!(coll.device, 0xDEAD_BEEF as *mut ffi::cubeb_device_info);
+    assert_eq!(coll.count, usize::max_value());
+}
+
+#[test]
+fn test_ops_context_device_collection_destroy() {
+    let c: *mut ffi::cubeb = ptr::null_mut();
+    let mut coll = ffi::cubeb_device_collection {
+        device: 0xDEAD_BEEF as *mut ffi::cubeb_device_info,
+        count: usize::max_value(),
+    };
+    // capi_device_collection_destroy will return ffi::CUBEB_OK anyway
+    // no matter what device_collection_destroy returns (we throw a
+    // not_supported error in our implementation). Change CUBEB_OK
+    // to CUBEB_ERROR_NOT_SUPPORTED after cubeb-rs is updated to the
+    // newest version that fixes this problem.
+    // https://github.com/djg/cubeb-rs/pull/37
+    assert_eq!(
+        unsafe { OPS.device_collection_destroy.unwrap()(c, &mut coll) },
+        ffi::CUBEB_OK
+    );
+    assert_eq!(coll.device, ptr::null_mut());
+    assert_eq!(coll.count, 0);
+}
+
+#[test]
+fn test_ops_context_stream_init() {
+    use std::ffi::CString;
+
+    let mut c: *mut ffi::cubeb = ptr::null_mut();
+    assert_eq!(
+        unsafe { OPS.init.unwrap()(&mut c, ptr::null()) },
+        ffi::CUBEB_OK
+    );
+
+    let mut stream: *mut ffi::cubeb_stream = ptr::null_mut();
+    let name = CString::new("test").unwrap().as_ptr();
+    assert_eq!(
+        unsafe {
+            OPS.stream_init.unwrap()(
+                c,
+                &mut stream,
+                name,
+                ptr::null(),
+                ptr::null_mut(),
+                ptr::null(),
+                ptr::null_mut(),
+                4096,
+                None,
+                None,
+                ptr::null_mut(),
+            )
+        },
+        ffi::CUBEB_ERROR_NOT_SUPPORTED
+    );
+
+    unsafe {
+        OPS.destroy.unwrap()(c);
+    };
+}
+
+// The stream must be boxed since capi_stream_destroy releases the stream
+// by Box::from_raw.
+// stream_destroy: Some($crate::capi::capi_stream_destroy::<$stm>),
+
+#[test]
+fn test_ops_stream_start() {
+    let s: *mut ffi::cubeb_stream = ptr::null_mut();
+    assert_eq!(
+        unsafe { OPS.stream_start.unwrap()(s) },
+        ffi::CUBEB_ERROR_NOT_SUPPORTED
+    );
+}
+
+#[test]
+fn test_ops_stream_stop() {
+    let s: *mut ffi::cubeb_stream = ptr::null_mut();
+    assert_eq!(
+        unsafe { OPS.stream_stop.unwrap()(s) },
+        ffi::CUBEB_ERROR_NOT_SUPPORTED
+    );
+}
+
+#[test]
+fn test_ops_stream_reset_default_device() {
+    let s: *mut ffi::cubeb_stream = ptr::null_mut();
+    assert_eq!(
+        unsafe { OPS.stream_reset_default_device.unwrap()(s) },
+        ffi::CUBEB_ERROR_NOT_SUPPORTED
+    );
+}
+
+#[test]
+fn test_ops_stream_position() {
+    let s: *mut ffi::cubeb_stream = ptr::null_mut();
+    let mut position = u64::max_value();
+    assert_eq!(
+        unsafe { OPS.stream_get_position.unwrap()(s, &mut position) },
+        ffi::CUBEB_OK
+    );
+    assert_eq!(position, 0);
+}
+
+#[test]
+fn test_ops_stream_latency() {
+    let s: *mut ffi::cubeb_stream = ptr::null_mut();
+    let mut latency = u32::max_value();
+    assert_eq!(
+        unsafe { OPS.stream_get_latency.unwrap()(s, &mut latency) },
+        ffi::CUBEB_OK
+    );
+    assert_eq!(latency, 0);
+}
+
+#[test]
+fn test_ops_stream_set_volume() {
+    let s: *mut ffi::cubeb_stream = ptr::null_mut();
+    assert_eq!(
+        unsafe { OPS.stream_set_volume.unwrap()(s, 0.5) },
+        ffi::CUBEB_ERROR_NOT_SUPPORTED
+    );
+}
+
+#[test]
+fn test_ops_stream_set_panning() {
+    let s: *mut ffi::cubeb_stream = ptr::null_mut();
+    assert_eq!(
+        unsafe { OPS.stream_set_panning.unwrap()(s, 0.5) },
+        ffi::CUBEB_ERROR_NOT_SUPPORTED
+    );
+}
+
+#[test]
+fn test_ops_stream_current_device() {
+    let s: *mut ffi::cubeb_stream = ptr::null_mut();
+    let mut device: *mut ffi::cubeb_device = ptr::null_mut();
+    assert_eq!(
+        unsafe { OPS.stream_get_current_device.unwrap()(s, &mut device) },
+        ffi::CUBEB_OK
+    );
+    assert_eq!(device, 0xDEAD_BEEF as *mut ffi::cubeb_device);
+}
+
+#[test]
+fn test_ops_stream_device_destroy() {
+    let s: *mut ffi::cubeb_stream = ptr::null_mut();
+    unsafe {
+        OPS.stream_device_destroy.unwrap()(s, 0xDEAD_BEEF as *mut ffi::cubeb_device);
+    }
+}
+
+// Enable this after cubeb-rs is updated to the newest version that
+// implements stream_register_device_changed_callback operation.
+// https://github.com/djg/cubeb-rs/pull/36
+// #[test]
+// fn test_ops_stream_register_device_changed_callback() {
+//     let s: *mut ffi::cubeb_stream = ptr::null_mut();
+//     extern "C" fn callback(_: *mut c_void) {}
+//     assert_eq!(
+//         unsafe {
+//             OPS.stream_register_device_changed_callback.unwrap()(
+//                 s,
+//                 Some(callback)
+//             )
+//         },
+//         ffi::CUBEB_ERROR_NOT_SUPPORTED
+//     );
+// }
+
+#[test]
+fn test_ops_context_register_device_collection_changed() {
+    let c: *mut ffi::cubeb = ptr::null_mut();
+    extern "C" fn callback(_: *mut ffi::cubeb, _: *mut c_void) {}
+    assert_eq!(
+        unsafe {
+            OPS.register_device_collection_changed.unwrap()(
+                c,
+                ffi::CUBEB_DEVICE_TYPE_INPUT | ffi::CUBEB_DEVICE_TYPE_OUTPUT,
+                Some(callback),
+                0xDEAD_BEEF as *mut c_void,
+            )
+        },
+        ffi::CUBEB_ERROR_NOT_SUPPORTED
+    );
+}

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -1,0 +1,17 @@
+// Copyright © 2018 Mozilla Foundation
+//
+// This program is made available under an ISC-style license.  See the
+// accompanying file LICENSE for details.
+
+use backend::AudioUnitContext;
+use cubeb_backend::{capi, ffi};
+use std::os::raw::{c_char, c_int};
+
+// Entry point from C code.
+#[no_mangle]
+pub unsafe extern "C" fn audiounit_rust_init(
+    c: *mut *mut ffi::cubeb,
+    context_name: *const c_char,
+) -> c_int {
+    capi::capi_init::<AudioUnitContext>(c, context_name)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,12 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}
+// Copyright © 2018 Mozilla Foundation
+//
+// This program is made available under an ISC-style license.  See the
+// accompanying file LICENSE for details.
+
+#[macro_use]
+extern crate cubeb_backend;
+
+mod backend;
+mod capi;
+
+pub use capi::audiounit_rust_init;


### PR DESCRIPTION
Implement a dummy [*cubeb*][cubeb] stream and a dummy *cubeb* context and add tests for them. Those tests are called via [*cubeb-rs*][cubeb-rs], which is the *Rust* interface for *cubeb* implementations on different platforms.

[cubeb]: https://github.com/kinetiknz/cubeb "kinetiknz/cubeb"
[cubeb-rs]: https://github.com/djg/cubeb-rs "djg/cubeb-rs"