### PR TITLE
Calculate input_frames of duplex stream after counting missing frames

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -638,15 +638,6 @@ extern "C" fn audiounit_output_callback(
         // Also get the input buffer if the stream is duplex
         let (input_buffer, mut input_frames) = if !stm.core_stream_data.input_unit.is_null() {
             assert!(stm.core_stream_data.input_linear_buffer.is_some());
-            let input_frames = stm
-                .core_stream_data
-                .input_linear_buffer
-                .as_ref()
-                .unwrap()
-                .elements()
-                / stm.core_stream_data.input_desc.mChannelsPerFrame as usize;
-            cubeb_logv!("Total input frames: {}", input_frames);
-
             assert_ne!(stm.core_stream_data.input_desc.mChannelsPerFrame, 0);
             // If the output callback came first and this is a duplex stream, we need to
             // fill in some additional silence in the resampler.
@@ -683,6 +674,14 @@ extern "C" fn audiounit_output_callback(
                     missing_frames
                 );
             }
+            let input_frames = stm
+                .core_stream_data
+                .input_linear_buffer
+                .as_ref()
+                .unwrap()
+                .elements()
+                / stm.core_stream_data.input_desc.mChannelsPerFrame as usize;
+            cubeb_logv!("Total input frames: {}", input_frames);
             (
                 stm.core_stream_data
                     .input_linear_buffer

--- a/todo.md
+++ b/todo.md
@@ -65,3 +65,6 @@
 - Rewrite some tests under _cubeb/test/*_ in _Rust_ as part of the integration tests
     - Add tests for capturing/recording, output, duplex streams
 - Tests cleaned up: Only tests under *aggregate_device.rs* left now.
+-  Create a test for [BMO 1570077][b1570077]
+
+[b1570077]: https://bugzilla.mozilla.org/show_bug.cgi?id=1570077


### PR DESCRIPTION
The frame length to the resampler will be incorrect if the missing
frames are not counted. This solves the crash on [BMO 1570077.](https://bugzilla.mozilla.org/show_bug.cgi?id=1570077)