### PR TITLE
Avoid re-initializing stream with a nonexistent device

### DIFF
--- a/src/backend/aggregate_device.rs
+++ b/src/backend/aggregate_device.rs
@@ -341,8 +341,8 @@ impl AggregateDevice {
         assert_ne!(output_id, kAudioObjectUnknown);
         assert_ne!(input_id, output_id);
 
-        let output_sub_devices = audiounit_get_sub_devices(output_id);
-        let input_sub_devices = audiounit_get_sub_devices(input_id);
+        let output_sub_devices = Self::get_sub_devices(output_id);
+        let input_sub_devices = Self::get_sub_devices(input_id);
 
         unsafe {
             let sub_devices = CFArrayCreateMutable(ptr::null(), 0, &kCFTypeArrayCallBacks);
@@ -379,6 +379,43 @@ impl AggregateDevice {
         }
     }
 
+    pub fn get_sub_devices(device_id: AudioDeviceID) -> Vec<AudioObjectID> {
+        assert_ne!(device_id, kAudioObjectUnknown);
+
+        let mut sub_devices = Vec::new();
+        let address = AudioObjectPropertyAddress {
+            mSelector: kAudioAggregateDevicePropertyActiveSubDeviceList,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMaster,
+        };
+        let mut size: usize = 0;
+        let rv = audio_object_get_property_data_size(device_id, &address, &mut size);
+
+        if rv != NO_ERR {
+            sub_devices.push(device_id);
+            return sub_devices;
+        }
+
+        assert_ne!(size, 0);
+
+        let count = size / mem::size_of::<AudioObjectID>();
+        sub_devices = allocate_array(count);
+        let rv = audio_object_get_property_data(
+            device_id,
+            &address,
+            &mut size,
+            sub_devices.as_mut_ptr(),
+        );
+
+        if rv != NO_ERR {
+            sub_devices.clear();
+            sub_devices.push(device_id);
+        } else {
+            cubeb_log!("Found {} sub-devices", count);
+        }
+        sub_devices
+    }
+
     pub fn set_master_device(device_id: AudioDeviceID) -> std::result::Result<(), OSStatus> {
         assert_ne!(device_id, kAudioObjectUnknown);
         let address = AudioObjectPropertyAddress {
@@ -390,7 +427,7 @@ impl AggregateDevice {
         // Master become the 1st output sub device
         let output_device_id = audiounit_get_default_device_id(DeviceType::OUTPUT);
         assert_ne!(output_device_id, kAudioObjectUnknown);
-        let output_sub_devices = audiounit_get_sub_devices(output_device_id);
+        let output_sub_devices = Self::get_sub_devices(output_device_id);
         assert!(!output_sub_devices.is_empty());
         let master_sub_device = get_device_name(output_sub_devices[0]);
         let size = mem::size_of::<CFStringRef>();

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -638,15 +638,6 @@ extern "C" fn audiounit_output_callback(
         // Also get the input buffer if the stream is duplex
         let (input_buffer, mut input_frames) = if !stm.core_stream_data.input_unit.is_null() {
             assert!(stm.core_stream_data.input_linear_buffer.is_some());
-            let input_frames = stm
-                .core_stream_data
-                .input_linear_buffer
-                .as_ref()
-                .unwrap()
-                .elements()
-                / stm.core_stream_data.input_desc.mChannelsPerFrame as usize;
-            cubeb_logv!("Total input frames: {}", input_frames);
-
             assert_ne!(stm.core_stream_data.input_desc.mChannelsPerFrame, 0);
             // If the output callback came first and this is a duplex stream, we need to
             // fill in some additional silence in the resampler.
@@ -683,6 +674,14 @@ extern "C" fn audiounit_output_callback(
                     missing_frames
                 );
             }
+            let input_frames = stm
+                .core_stream_data
+                .input_linear_buffer
+                .as_ref()
+                .unwrap()
+                .elements()
+                / stm.core_stream_data.input_desc.mChannelsPerFrame as usize;
+            cubeb_logv!("Total input frames: {}", input_frames);
             (
                 stm.core_stream_data
                     .input_linear_buffer

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2816,7 +2816,11 @@ impl<'ctx> CoreStreamData<'ctx> {
 
             stream.frames_read.store(0, Ordering::SeqCst);
 
-            cubeb_log!("({:p}) Input audiounit init successfully.", self.stm_ptr);
+            cubeb_log!(
+                "({:p}) Input audiounit init with device {} successfully.",
+                self.stm_ptr,
+                in_dev_info.id
+            );
         }
 
         if self.has_output() {
@@ -2967,7 +2971,11 @@ impl<'ctx> CoreStreamData<'ctx> {
 
             stream.frames_written.store(0, Ordering::SeqCst);
 
-            cubeb_log!("({:p}) Output audiounit init successfully.", self.stm_ptr);
+            cubeb_log!(
+                "({:p}) Output audiounit init with device {} successfully.",
+                self.stm_ptr,
+                out_dev_info.id
+            );
         }
 
         // We use a resampler because input AudioUnit operates

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3390,6 +3390,13 @@ impl<'ctx> AudioUnitStream<'ctx> {
             get_volume(self.core_stream_data.output_unit)
         };
 
+        let has_input = !self.core_stream_data.input_unit.is_null();
+        let input_device = if has_input {
+            self.core_stream_data.input_device.id
+        } else {
+            kAudioObjectUnknown
+        };
+
         self.core_stream_data.close();
 
         // Reinit occurs in one of the following case:
@@ -3398,13 +3405,6 @@ impl<'ctx> AudioUnitStream<'ctx> {
         // - The bluetooth device changed from A2DP to/from HFP/HSP profile
         // We first attempt to re-use the same device id, should that fail we will
         // default to the (potentially new) default device.
-        let has_input = !self.core_stream_data.input_unit.is_null();
-        let input_device = if has_input {
-            self.core_stream_data.input_device.id
-        } else {
-            kAudioObjectUnknown
-        };
-
         if has_input {
             self.core_stream_data.input_device = create_device_info(input_device, DeviceType::INPUT).map_err(|e| {
                 cubeb_log!(

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1132,43 +1132,6 @@ fn audiounit_set_channel_layout(
     Ok(())
 }
 
-fn audiounit_get_sub_devices(device_id: AudioDeviceID) -> Vec<AudioObjectID> {
-    assert_ne!(device_id, kAudioObjectUnknown);
-
-    let mut sub_devices = Vec::new();
-    let property_address = AudioObjectPropertyAddress {
-        mSelector: kAudioAggregateDevicePropertyActiveSubDeviceList,
-        mScope: kAudioObjectPropertyScopeGlobal,
-        mElement: kAudioObjectPropertyElementMaster,
-    };
-    let mut size: usize = 0;
-    let rv = audio_object_get_property_data_size(device_id, &property_address, &mut size);
-
-    if rv != NO_ERR {
-        sub_devices.push(device_id);
-        return sub_devices;
-    }
-
-    assert_ne!(size, 0);
-
-    let count = size / mem::size_of::<AudioObjectID>();
-    sub_devices = allocate_array(count);
-    let rv = audio_object_get_property_data(
-        device_id,
-        &property_address,
-        &mut size,
-        sub_devices.as_mut_ptr(),
-    );
-
-    if rv != NO_ERR {
-        sub_devices.clear();
-        sub_devices.push(device_id);
-    } else {
-        cubeb_log!("Found {} sub-devices", count);
-    }
-    sub_devices
-}
-
 fn get_device_name(id: AudioDeviceID) -> CFStringRef {
     let mut size = mem::size_of::<CFStringRef>();
     let mut uiname: CFStringRef = ptr::null();

--- a/src/backend/tests/aggregate_device.rs
+++ b/src/backend/tests/aggregate_device.rs
@@ -75,7 +75,7 @@ fn test_aggregate_get_sub_devices_for_blank_aggregate_devices() {
     let aggregate_device_id = AggregateDevice::create_blank_device_sync(plugin_id).unwrap();
     assert_ne!(aggregate_device_id, kAudioObjectUnknown);
     // There is no sub devices for a blank aggregate device!
-    let devices = audiounit_get_sub_devices(aggregate_device_id);
+    let devices = AggregateDevice::get_sub_devices(aggregate_device_id);
     assert!(devices.is_empty());
     assert!(AggregateDevice::destroy_device(plugin_id, aggregate_device_id).is_ok());
 }
@@ -217,8 +217,8 @@ fn test_aggregate_set_sub_devices() {
         return;
     }
 
-    let input_sub_devices = audiounit_get_sub_devices(input_id);
-    let output_sub_devices = audiounit_get_sub_devices(output_id);
+    let input_sub_devices = AggregateDevice::get_sub_devices(input_id);
+    let output_sub_devices = AggregateDevice::get_sub_devices(output_id);
 
     // Create a blank aggregate device.
     let plugin_id = AggregateDevice::get_system_plugin_id().unwrap();
@@ -228,7 +228,7 @@ fn test_aggregate_set_sub_devices() {
 
     // Set sub devices for the created aggregate device.
     assert!(AggregateDevice::set_sub_devices(aggregate_device_id, input_id, output_id).is_ok());
-    let sub_devices = audiounit_get_sub_devices(aggregate_device_id);
+    let sub_devices = AggregateDevice::get_sub_devices(aggregate_device_id);
 
     assert!(sub_devices.len() <= input_sub_devices.len() + output_sub_devices.len());
 
@@ -312,7 +312,7 @@ fn test_aggregate_set_master_device() {
         return;
     }
 
-    let output_sub_devices = audiounit_get_sub_devices(output_id);
+    let output_sub_devices = AggregateDevice::get_sub_devices(output_id);
     if output_sub_devices.is_empty() {
         return;
     }
@@ -466,7 +466,7 @@ fn test_aggregate_activate_clock_drift_compensation() {
         return;
     }
 
-    let output_sub_devices = audiounit_get_sub_devices(output_id);
+    let output_sub_devices = AggregateDevice::get_sub_devices(output_id);
     if output_sub_devices.is_empty() {
         return;
     }

--- a/src/backend/tests/aggregate_device.rs
+++ b/src/backend/tests/aggregate_device.rs
@@ -75,7 +75,7 @@ fn test_aggregate_get_sub_devices_for_blank_aggregate_devices() {
     let aggregate_device_id = AggregateDevice::create_blank_device_sync(plugin_id).unwrap();
     assert_ne!(aggregate_device_id, kAudioObjectUnknown);
     // There is no sub devices for a blank aggregate device!
-    let devices = AggregateDevice::get_sub_devices(aggregate_device_id);
+    let devices = AggregateDevice::get_sub_devices(aggregate_device_id).unwrap();
     assert!(devices.is_empty());
     assert!(AggregateDevice::destroy_device(plugin_id, aggregate_device_id).is_ok());
 }
@@ -217,8 +217,8 @@ fn test_aggregate_set_sub_devices() {
         return;
     }
 
-    let input_sub_devices = AggregateDevice::get_sub_devices(input_id);
-    let output_sub_devices = AggregateDevice::get_sub_devices(output_id);
+    let input_sub_devices = AggregateDevice::get_sub_devices(input_id).unwrap();
+    let output_sub_devices = AggregateDevice::get_sub_devices(output_id).unwrap();
 
     // Create a blank aggregate device.
     let plugin_id = AggregateDevice::get_system_plugin_id().unwrap();
@@ -228,7 +228,7 @@ fn test_aggregate_set_sub_devices() {
 
     // Set sub devices for the created aggregate device.
     assert!(AggregateDevice::set_sub_devices(aggregate_device_id, input_id, output_id).is_ok());
-    let sub_devices = AggregateDevice::get_sub_devices(aggregate_device_id);
+    let sub_devices = AggregateDevice::get_sub_devices(aggregate_device_id).unwrap();
 
     assert!(sub_devices.len() <= input_sub_devices.len() + output_sub_devices.len());
 
@@ -312,7 +312,7 @@ fn test_aggregate_set_master_device() {
         return;
     }
 
-    let output_sub_devices = AggregateDevice::get_sub_devices(output_id);
+    let output_sub_devices = AggregateDevice::get_sub_devices(output_id).unwrap();
     if output_sub_devices.is_empty() {
         return;
     }
@@ -466,7 +466,7 @@ fn test_aggregate_activate_clock_drift_compensation() {
         return;
     }
 
-    let output_sub_devices = AggregateDevice::get_sub_devices(output_id);
+    let output_sub_devices = AggregateDevice::get_sub_devices(output_id).unwrap();
     if output_sub_devices.is_empty() {
         return;
     }

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1098,7 +1098,7 @@ fn test_get_sub_devices() {
         assert_ne!(device, kAudioObjectUnknown);
         // `AggregateDevice::get_sub_devices(device)` will return a single-element vector
         //  containing `device` itself if it's not an aggregate device.
-        let sub_devices = AggregateDevice::get_sub_devices(device);
+        let sub_devices = AggregateDevice::get_sub_devices(device).unwrap();
         // TODO: If the device is a blank aggregate device, then the assertion fails!
         assert!(!sub_devices.is_empty());
     }
@@ -1107,7 +1107,7 @@ fn test_get_sub_devices() {
 #[test]
 #[should_panic]
 fn test_get_sub_devices_for_a_unknown_device() {
-    let devices = AggregateDevice::get_sub_devices(kAudioObjectUnknown);
+    let devices = AggregateDevice::get_sub_devices(kAudioObjectUnknown).unwrap();
     assert!(devices.is_empty());
 }
 

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1029,30 +1029,6 @@ fn test_set_channel_layout_with_null_unit() {
     .is_err());
 }
 
-// get_sub_devices
-// ------------------------------------
-// You can check this by creating an aggregate device in `Audio MIDI Setup`
-// application and print out the sub devices of them!
-#[test]
-fn test_get_sub_devices() {
-    let devices = test_get_all_devices();
-    for device in devices {
-        assert_ne!(device, kAudioObjectUnknown);
-        // `audiounit_get_sub_devices(device)` will return a single-element vector
-        //  containing `device` itself if it's not an aggregate device.
-        let sub_devices = audiounit_get_sub_devices(device);
-        // TODO: If the device is a blank aggregate device, then the assertion fails!
-        assert!(!sub_devices.is_empty());
-    }
-}
-
-#[test]
-#[should_panic]
-fn test_get_sub_devices_for_a_unknown_device() {
-    let devices = audiounit_get_sub_devices(kAudioObjectUnknown);
-    assert!(devices.is_empty());
-}
-
 // get_device_name
 // ------------------------------------
 #[test]
@@ -1109,6 +1085,30 @@ fn test_aggregate_set_sub_devices_for_unknown_devices() {
         kAudioObjectUnknown
     )
     .is_err());
+}
+
+// AggregateDevice::get_sub_devices
+// ------------------------------------
+// You can check this by creating an aggregate device in `Audio MIDI Setup`
+// application and print out the sub devices of them!
+#[test]
+fn test_get_sub_devices() {
+    let devices = test_get_all_devices();
+    for device in devices {
+        assert_ne!(device, kAudioObjectUnknown);
+        // `AggregateDevice::get_sub_devices(device)` will return a single-element vector
+        //  containing `device` itself if it's not an aggregate device.
+        let sub_devices = AggregateDevice::get_sub_devices(device);
+        // TODO: If the device is a blank aggregate device, then the assertion fails!
+        assert!(!sub_devices.is_empty());
+    }
+}
+
+#[test]
+#[should_panic]
+fn test_get_sub_devices_for_a_unknown_device() {
+    let devices = AggregateDevice::get_sub_devices(kAudioObjectUnknown);
+    assert!(devices.is_empty());
 }
 
 // AggregateDevice::set_master_device

--- a/src/backend/tests/utils.rs
+++ b/src/backend/tests/utils.rs
@@ -838,7 +838,7 @@ impl TestDevicePlugger {
     // TODO: This doesn't work as what we expect when the default deivce in the scope is an
     //       aggregate device. We should get the list of all the active sub devices and put
     //       them into the array, if the device is an aggregate device. See the code in
-    //       audiounit_get_sub_devices and audiounit_set_aggregate_sub_device_list.
+    //       AggregateDevice::get_sub_devices and audiounit_set_aggregate_sub_device_list.
     fn get_sub_devices(scope: Scope) -> Option<CFArrayRef> {
         let device = test_get_default_device(scope);
         if device.is_none() {

--- a/todo.md
+++ b/todo.md
@@ -20,8 +20,7 @@
 
 ## Aggregate device
 ### Get sub devices
-- Return the device itself if the device has no `kAudioAggregateDevicePropertyActiveSubDeviceList` property
-  or hit a `InvalidProperty_Error`
+- A better pattern for `AggregateDevice::get_sub_devices`
 ### Set sub devices
 - We will add duplicate devices into the array if there are common devices in
   `output_sub_devices` and `input_sub_devices`

--- a/todo.md
+++ b/todo.md
@@ -65,3 +65,6 @@
 - Rewrite some tests under _cubeb/test/*_ in _Rust_ as part of the integration tests
     - Add tests for capturing/recording, output, duplex streams
 - Tests cleaned up: Only tests under *aggregate_device.rs* left now.
+-  Create a test for [BMO 1570077][b1570077]
+
+[b1570077]: https://bugzilla.mozilla.org/show_bug.cgi?id=1570077

--- a/todo.md
+++ b/todo.md
@@ -65,5 +65,7 @@
     - Add tests for capturing/recording, output, duplex streams
 - Tests cleaned up: Only tests under *aggregate_device.rs* left now.
 -  Create a test for [BMO 1570077][b1570077]
+-  Create a test for [BMO 1570080][b1570080]
 
 [b1570077]: https://bugzilla.mozilla.org/show_bug.cgi?id=1570077
+[b1570080]: https://bugzilla.mozilla.org/show_bug.cgi?id=1570080


### PR DESCRIPTION
The current code will re-initialize the stream with nonexistent input device when uplugging a input device during WebRTC. This change fix the crash on [BMO 1570080](https://bugzilla.mozilla.org/show_bug.cgi?id=1570080).