### PR TITLE
Simplify the APIs to get the device info from hardware

### DIFF
--- a/coreaudio-sys-utils/src/string.rs
+++ b/coreaudio-sys-utils/src/string.rs
@@ -1,7 +1,11 @@
-use core_foundation_sys::base::{kCFAllocatorDefault, kCFAllocatorNull, Boolean, CFIndex};
+use core_foundation_sys::base::{
+    kCFAllocatorDefault, kCFAllocatorNull, Boolean, CFIndex, CFRange, CFRelease,
+};
 use core_foundation_sys::string::{
     kCFStringEncodingUTF8, CFStringCreateWithBytes, CFStringCreateWithBytesNoCopy,
+    CFStringGetBytes, CFStringGetLength, CFStringRef,
 };
+use std::ffi::CString;
 
 pub fn cfstringref_from_static_string(string: &'static str) -> coreaudio_sys::CFStringRef {
     // Set deallocator to kCFAllocatorNull to prevent the the memory of the parameter `string`
@@ -32,11 +36,95 @@ pub fn cfstringref_from_string(string: &str) -> coreaudio_sys::CFStringRef {
     cfstringref as coreaudio_sys::CFStringRef
 }
 
+#[derive(Debug)]
+pub struct StringRef(CFStringRef);
+impl StringRef {
+    pub fn new(string_ref: CFStringRef) -> Self {
+        assert!(!string_ref.is_null());
+        Self(string_ref)
+    }
+
+    pub fn to_string(&self) -> String {
+        String::from_utf8(utf8_from_cfstringref(self.0)).expect("convert bytes to a String")
+    }
+
+    pub fn into_string(self) -> String {
+        self.to_string()
+    }
+
+    pub fn to_cstring(&self) -> CString {
+        unsafe {
+            // Assume that bytes doesn't contain `0` in the middle.
+            CString::from_vec_unchecked(utf8_from_cfstringref(self.0))
+        }
+    }
+
+    pub fn into_cstring(self) -> CString {
+        self.to_cstring()
+    }
+
+    pub fn get_raw(&self) -> CFStringRef {
+        self.0
+    }
+}
+
+impl Drop for StringRef {
+    fn drop(&mut self) {
+        use std::os::raw::c_void;
+        unsafe { CFRelease(self.0 as *mut c_void) };
+    }
+}
+
+fn utf8_from_cfstringref(string_ref: CFStringRef) -> Vec<u8> {
+    use std::ptr;
+
+    assert!(!string_ref.is_null());
+
+    let length: CFIndex = unsafe { CFStringGetLength(string_ref) };
+    assert!(length > 0);
+
+    // Get the buffer size of the string.
+    let range: CFRange = CFRange {
+        location: 0,
+        length,
+    };
+    let mut size: CFIndex = 0;
+    let mut converted_chars: CFIndex = unsafe {
+        CFStringGetBytes(
+            string_ref,
+            range,
+            kCFStringEncodingUTF8,
+            0,
+            false as Boolean,
+            ptr::null_mut() as *mut u8,
+            0,
+            &mut size,
+        )
+    };
+    assert!(converted_chars > 0 && size > 0);
+
+    // Then, allocate the buffer with the required size and actually copy data into it.
+    let mut buffer = vec![b'\x00'; size as usize];
+    converted_chars = unsafe {
+        CFStringGetBytes(
+            string_ref,
+            range,
+            kCFStringEncodingUTF8,
+            0,
+            false as Boolean,
+            buffer.as_mut_ptr(),
+            size,
+            ptr::null_mut() as *mut CFIndex,
+        )
+    };
+    assert!(converted_chars > 0);
+
+    buffer
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
-    use core_foundation_sys::base::{CFRange, CFRelease};
-    use core_foundation_sys::string::{CFStringGetBytes, CFStringGetLength, CFStringRef};
 
     const STATIC_STRING: &str = "static string for testing";
 
@@ -44,7 +132,11 @@ mod test {
     fn test_create_static_cfstring_ref() {
         let stringref =
             StringRef::new(cfstringref_from_static_string(STATIC_STRING) as CFStringRef);
-        assert_eq!(STATIC_STRING, stringref.into_string());
+        assert_eq!(STATIC_STRING, stringref.to_string());
+        assert_eq!(
+            CString::new(STATIC_STRING).unwrap(),
+            stringref.into_cstring()
+        );
         // TODO: Find a way to check the string's inner pointer is same.
     }
 
@@ -52,77 +144,8 @@ mod test {
     fn test_create_cfstring_ref() {
         let expected = "Rustaceans 🦀";
         let stringref = StringRef::new(cfstringref_from_string(expected) as CFStringRef);
-        assert_eq!(expected, stringref.into_string());
+        assert_eq!(expected, stringref.to_string());
+        assert_eq!(CString::new(expected).unwrap(), stringref.into_cstring());
         // TODO: Find a way to check the string's inner pointer is different.
-    }
-
-    #[derive(Debug)]
-    struct StringRef(CFStringRef);
-    impl StringRef {
-        fn new(string_ref: CFStringRef) -> Self {
-            assert!(!string_ref.is_null());
-            Self(string_ref)
-        }
-
-        fn to_string(&self) -> String {
-            String::from_utf8(utf8_from_cfstringref(self.0)).unwrap()
-        }
-
-        fn into_string(self) -> String {
-            self.to_string()
-        }
-    }
-
-    impl Drop for StringRef {
-        fn drop(&mut self) {
-            use std::os::raw::c_void;
-            unsafe { CFRelease(self.0 as *mut c_void) };
-        }
-    }
-
-    fn utf8_from_cfstringref(string_ref: CFStringRef) -> Vec<u8> {
-        use std::ptr;
-
-        assert!(!string_ref.is_null());
-
-        let length: CFIndex = unsafe { CFStringGetLength(string_ref) };
-        assert!(length > 0);
-
-        let range: CFRange = CFRange {
-            location: 0,
-            length,
-        };
-        let mut size: CFIndex = 0;
-        let mut converted_chars: CFIndex = unsafe {
-            CFStringGetBytes(
-                string_ref,
-                range,
-                kCFStringEncodingUTF8,
-                0,
-                false as Boolean,
-                ptr::null_mut() as *mut u8,
-                0,
-                &mut size,
-            )
-        };
-        assert!(converted_chars > 0 && size > 0);
-
-        // Then, allocate the buffer with the required size and actually copy data into it.
-        let mut buffer = vec![b'\x00'; size as usize];
-        converted_chars = unsafe {
-            CFStringGetBytes(
-                string_ref,
-                range,
-                kCFStringEncodingUTF8,
-                0,
-                false as Boolean,
-                buffer.as_mut_ptr(),
-                size,
-                ptr::null_mut() as *mut CFIndex,
-            )
-        };
-        assert!(converted_chars > 0);
-
-        buffer
     }
 }

--- a/src/backend/aggregate_device.rs
+++ b/src/backend/aggregate_device.rs
@@ -349,12 +349,12 @@ impl AggregateDevice {
             // The order of the items in the array is significant and is used to determine the order of the streams
             // of the AudioAggregateDevice.
             for device in output_sub_devices {
-                let uid = get_device_global_uid(device).unwrap();
+                let uid = get_device_global_uid(device)?;
                 CFArrayAppendValue(sub_devices, uid.get_raw() as *const c_void);
             }
 
             for device in input_sub_devices {
-                let uid = get_device_global_uid(device).unwrap();
+                let uid = get_device_global_uid(device)?;
                 CFArrayAppendValue(sub_devices, uid.get_raw() as *const c_void);
             }
 
@@ -547,10 +547,10 @@ impl AggregateDevice {
         assert_ne!(output_id, kAudioObjectUnknown);
         assert_ne!(input_id, output_id);
 
-        let label = get_device_label(input_id, DeviceType::INPUT).unwrap();
+        let label = get_device_label(input_id, DeviceType::INPUT)?;
         let input_label = label.into_string();
 
-        let label = get_device_label(output_id, DeviceType::OUTPUT).unwrap();
+        let label = get_device_label(output_id, DeviceType::OUTPUT)?;
         let output_label = label.into_string();
 
         if input_label.contains("AirPods") && output_label.contains("AirPods") {

--- a/src/backend/aggregate_device.rs
+++ b/src/backend/aggregate_device.rs
@@ -349,15 +349,13 @@ impl AggregateDevice {
             // The order of the items in the array is significant and is used to determine the order of the streams
             // of the AudioAggregateDevice.
             for device in output_sub_devices {
-                let uid = get_device_name(device);
-                assert!(!uid.is_null());
+                let uid = get_device_uid(device).unwrap();
                 CFArrayAppendValue(sub_devices, uid as *const c_void);
                 CFRelease(uid as *const c_void);
             }
 
             for device in input_sub_devices {
-                let uid = get_device_name(device);
-                assert!(!uid.is_null());
+                let uid = get_device_uid(device).unwrap();
                 CFArrayAppendValue(sub_devices, uid as *const c_void);
                 CFRelease(uid as *const c_void);
             }
@@ -432,7 +430,7 @@ impl AggregateDevice {
         assert_ne!(output_device_id, kAudioObjectUnknown);
         let output_sub_devices = Self::get_sub_devices(output_device_id)?;
         assert!(!output_sub_devices.is_empty());
-        let master_sub_device = get_device_name(output_sub_devices[0]);
+        let master_sub_device = get_device_uid(output_sub_devices[0]).unwrap();
         let size = mem::size_of::<CFStringRef>();
         let status = audio_object_set_property_data(device_id, &address, size, &master_sub_device);
         if !master_sub_device.is_null() {

--- a/src/backend/aggregate_device.rs
+++ b/src/backend/aggregate_device.rs
@@ -349,13 +349,13 @@ impl AggregateDevice {
             // The order of the items in the array is significant and is used to determine the order of the streams
             // of the AudioAggregateDevice.
             for device in output_sub_devices {
-                let uid = get_device_uid(device).unwrap();
+                let uid = get_device_global_uid(device).unwrap();
                 CFArrayAppendValue(sub_devices, uid as *const c_void);
                 CFRelease(uid as *const c_void);
             }
 
             for device in input_sub_devices {
-                let uid = get_device_uid(device).unwrap();
+                let uid = get_device_global_uid(device).unwrap();
                 CFArrayAppendValue(sub_devices, uid as *const c_void);
                 CFRelease(uid as *const c_void);
             }
@@ -430,7 +430,7 @@ impl AggregateDevice {
         assert_ne!(output_device_id, kAudioObjectUnknown);
         let output_sub_devices = Self::get_sub_devices(output_device_id)?;
         assert!(!output_sub_devices.is_empty());
-        let master_sub_device = get_device_uid(output_sub_devices[0]).unwrap();
+        let master_sub_device = get_device_global_uid(output_sub_devices[0]).unwrap();
         let size = mem::size_of::<CFStringRef>();
         let status = audio_object_set_property_data(device_id, &address, size, &master_sub_device);
         if !master_sub_device.is_null() {

--- a/src/backend/aggregate_device.rs
+++ b/src/backend/aggregate_device.rs
@@ -559,7 +559,7 @@ impl AggregateDevice {
             let mut input_nominal_rate = 0;
             audiounit_get_available_samplerate(
                 input_id,
-                kAudioObjectPropertyScopeGlobal,
+                DeviceType::INPUT | DeviceType::OUTPUT,
                 &mut input_min_rate,
                 &mut input_max_rate,
                 &mut input_nominal_rate,
@@ -578,7 +578,7 @@ impl AggregateDevice {
             let mut output_nominal_rate = 0;
             audiounit_get_available_samplerate(
                 output_id,
-                kAudioObjectPropertyScopeGlobal,
+                DeviceType::INPUT | DeviceType::OUTPUT,
                 &mut output_min_rate,
                 &mut output_max_rate,
                 &mut output_nominal_rate,

--- a/src/backend/device_property.rs
+++ b/src/backend/device_property.rs
@@ -55,3 +55,37 @@ pub fn get_device_source(id: AudioDeviceID, devtype: DeviceType) -> Result<u32> 
         Err(Error::error())
     }
 }
+
+pub fn get_device_source_name(id: AudioDeviceID, devtype: DeviceType) -> Result<CFStringRef> {
+    assert_ne!(id, kAudioObjectUnknown);
+
+    let mut source: u32 = get_device_source(id, devtype)?;
+    let mut size = mem::size_of::<AudioValueTranslation>();
+    let mut name: CFStringRef = ptr::null();
+    let mut trl = AudioValueTranslation {
+        mInputData: &mut source as *mut u32 as *mut c_void,
+        mInputDataSize: mem::size_of::<u32>() as u32,
+        mOutputData: &mut name as *mut CFStringRef as *mut c_void,
+        mOutputDataSize: mem::size_of::<CFStringRef>() as u32,
+    };
+
+    const GLOBAL: ffi::cubeb_device_type =
+        ffi::CUBEB_DEVICE_TYPE_INPUT | ffi::CUBEB_DEVICE_TYPE_OUTPUT;
+    let address = AudioObjectPropertyAddress {
+        mSelector: kAudioDevicePropertyDataSourceNameForIDCFString,
+        mScope: match devtype.bits() {
+            ffi::CUBEB_DEVICE_TYPE_INPUT => kAudioDevicePropertyScopeInput,
+            ffi::CUBEB_DEVICE_TYPE_OUTPUT => kAudioDevicePropertyScopeOutput,
+            GLOBAL => kAudioObjectPropertyScopeGlobal,
+            _ => panic!("Invalid type"),
+        },
+        mElement: kAudioObjectPropertyElementMaster,
+    };
+
+    let err = audio_object_get_property_data(id, &address, &mut size, &mut trl);
+    if err == NO_ERR {
+        Ok(name)
+    } else {
+        Err(Error::error())
+    }
+}

--- a/src/backend/device_property.rs
+++ b/src/backend/device_property.rs
@@ -85,7 +85,25 @@ pub fn get_device_manufacturer(id: AudioDeviceID, devtype: DeviceType) -> Result
     }
 }
 
+pub fn get_device_buffer_frame_size_range(
+    id: AudioDeviceID,
+    devtype: DeviceType,
+) -> Result<(f64, f64)> {
+    assert_ne!(id, kAudioObjectUnknown);
+
+    let address = get_property_address(Property::DeviceBufferFrameSizeRange, devtype);
+    let mut size = mem::size_of::<AudioValueRange>();
+    let mut range = AudioValueRange::default();
+    let err = audio_object_get_property_data(id, &address, &mut size, &mut range);
+    if err == NO_ERR {
+        Ok((range.mMinimum, range.mMaximum))
+    } else {
+        Err(Error::error())
+    }
+}
+
 enum Property {
+    DeviceBufferFrameSizeRange,
     DeviceManufacturer,
     DeviceName,
     DeviceSource,
@@ -96,6 +114,7 @@ enum Property {
 impl From<Property> for AudioObjectPropertySelector {
     fn from(p: Property) -> Self {
         match p {
+            Property::DeviceBufferFrameSizeRange => kAudioDevicePropertyBufferFrameSizeRange,
             Property::DeviceManufacturer => kAudioObjectPropertyManufacturer,
             Property::DeviceName => kAudioObjectPropertyName,
             Property::DeviceSource => kAudioDevicePropertyDataSource,

--- a/src/backend/device_property.rs
+++ b/src/backend/device_property.rs
@@ -1,10 +1,10 @@
 use super::*;
 
-pub fn get_device_global_uid(id: AudioDeviceID) -> Result<CFStringRef> {
+pub fn get_device_global_uid(id: AudioDeviceID) -> Result<StringRef> {
     get_device_uid(id, DeviceType::INPUT | DeviceType::OUTPUT)
 }
 
-pub fn get_device_uid(id: AudioDeviceID, devtype: DeviceType) -> Result<CFStringRef> {
+pub fn get_device_uid(id: AudioDeviceID, devtype: DeviceType) -> Result<StringRef> {
     assert_ne!(id, kAudioObjectUnknown);
 
     let address = get_property_address(Property::DeviceUID, devtype);
@@ -12,7 +12,7 @@ pub fn get_device_uid(id: AudioDeviceID, devtype: DeviceType) -> Result<CFString
     let mut uid: CFStringRef = ptr::null();
     let err = audio_object_get_property_data(id, &address, &mut size, &mut uid);
     if err == NO_ERR {
-        Ok(uid)
+        Ok(StringRef::new(uid as _))
     } else {
         Err(Error::error())
     }
@@ -32,7 +32,7 @@ pub fn get_device_source(id: AudioDeviceID, devtype: DeviceType) -> Result<u32> 
     }
 }
 
-pub fn get_device_source_name(id: AudioDeviceID, devtype: DeviceType) -> Result<CFStringRef> {
+pub fn get_device_source_name(id: AudioDeviceID, devtype: DeviceType) -> Result<StringRef> {
     assert_ne!(id, kAudioObjectUnknown);
 
     let mut source: u32 = get_device_source(id, devtype)?;
@@ -47,13 +47,13 @@ pub fn get_device_source_name(id: AudioDeviceID, devtype: DeviceType) -> Result<
     };
     let err = audio_object_get_property_data(id, &address, &mut size, &mut trl);
     if err == NO_ERR {
-        Ok(name)
+        Ok(StringRef::new(name as _))
     } else {
         Err(Error::error())
     }
 }
 
-pub fn get_device_name(id: AudioDeviceID, devtype: DeviceType) -> Result<CFStringRef> {
+pub fn get_device_name(id: AudioDeviceID, devtype: DeviceType) -> Result<StringRef> {
     assert_ne!(id, kAudioObjectUnknown);
 
     let address = get_property_address(Property::DeviceName, devtype);
@@ -61,13 +61,13 @@ pub fn get_device_name(id: AudioDeviceID, devtype: DeviceType) -> Result<CFStrin
     let mut name: CFStringRef = ptr::null();
     let err = audio_object_get_property_data(id, &address, &mut size, &mut name);
     if err == NO_ERR {
-        Ok(name)
+        Ok(StringRef::new(name as _))
     } else {
         Err(Error::error())
     }
 }
 
-pub fn get_device_label(id: AudioDeviceID, devtype: DeviceType) -> Result<CFStringRef> {
+pub fn get_device_label(id: AudioDeviceID, devtype: DeviceType) -> Result<StringRef> {
     get_device_source_name(id, devtype).or(get_device_name(id, devtype))
 }
 

--- a/src/backend/device_property.rs
+++ b/src/backend/device_property.rs
@@ -1,10 +1,13 @@
 use super::*;
 
-pub fn get_device_global_uid(id: AudioDeviceID) -> Result<StringRef> {
+pub fn get_device_global_uid(id: AudioDeviceID) -> std::result::Result<StringRef, OSStatus> {
     get_device_uid(id, DeviceType::INPUT | DeviceType::OUTPUT)
 }
 
-pub fn get_device_uid(id: AudioDeviceID, devtype: DeviceType) -> Result<StringRef> {
+pub fn get_device_uid(
+    id: AudioDeviceID,
+    devtype: DeviceType,
+) -> std::result::Result<StringRef, OSStatus> {
     assert_ne!(id, kAudioObjectUnknown);
 
     let address = get_property_address(Property::DeviceUID, devtype);
@@ -14,11 +17,14 @@ pub fn get_device_uid(id: AudioDeviceID, devtype: DeviceType) -> Result<StringRe
     if err == NO_ERR {
         Ok(StringRef::new(uid as _))
     } else {
-        Err(Error::error())
+        Err(err)
     }
 }
 
-pub fn get_device_source(id: AudioDeviceID, devtype: DeviceType) -> Result<u32> {
+pub fn get_device_source(
+    id: AudioDeviceID,
+    devtype: DeviceType,
+) -> std::result::Result<u32, OSStatus> {
     assert_ne!(id, kAudioObjectUnknown);
 
     let address = get_property_address(Property::DeviceSource, devtype);
@@ -28,11 +34,14 @@ pub fn get_device_source(id: AudioDeviceID, devtype: DeviceType) -> Result<u32> 
     if err == NO_ERR {
         Ok(source)
     } else {
-        Err(Error::error())
+        Err(err)
     }
 }
 
-pub fn get_device_source_name(id: AudioDeviceID, devtype: DeviceType) -> Result<StringRef> {
+pub fn get_device_source_name(
+    id: AudioDeviceID,
+    devtype: DeviceType,
+) -> std::result::Result<StringRef, OSStatus> {
     assert_ne!(id, kAudioObjectUnknown);
 
     let mut source: u32 = get_device_source(id, devtype)?;
@@ -49,11 +58,14 @@ pub fn get_device_source_name(id: AudioDeviceID, devtype: DeviceType) -> Result<
     if err == NO_ERR {
         Ok(StringRef::new(name as _))
     } else {
-        Err(Error::error())
+        Err(err)
     }
 }
 
-pub fn get_device_name(id: AudioDeviceID, devtype: DeviceType) -> Result<StringRef> {
+pub fn get_device_name(
+    id: AudioDeviceID,
+    devtype: DeviceType,
+) -> std::result::Result<StringRef, OSStatus> {
     assert_ne!(id, kAudioObjectUnknown);
 
     let address = get_property_address(Property::DeviceName, devtype);
@@ -63,15 +75,21 @@ pub fn get_device_name(id: AudioDeviceID, devtype: DeviceType) -> Result<StringR
     if err == NO_ERR {
         Ok(StringRef::new(name as _))
     } else {
-        Err(Error::error())
+        Err(err)
     }
 }
 
-pub fn get_device_label(id: AudioDeviceID, devtype: DeviceType) -> Result<StringRef> {
+pub fn get_device_label(
+    id: AudioDeviceID,
+    devtype: DeviceType,
+) -> std::result::Result<StringRef, OSStatus> {
     get_device_source_name(id, devtype).or(get_device_name(id, devtype))
 }
 
-pub fn get_device_manufacturer(id: AudioDeviceID, devtype: DeviceType) -> Result<StringRef> {
+pub fn get_device_manufacturer(
+    id: AudioDeviceID,
+    devtype: DeviceType,
+) -> std::result::Result<StringRef, OSStatus> {
     assert_ne!(id, kAudioObjectUnknown);
 
     let address = get_property_address(Property::DeviceManufacturer, devtype);
@@ -81,14 +99,14 @@ pub fn get_device_manufacturer(id: AudioDeviceID, devtype: DeviceType) -> Result
     if err == NO_ERR {
         Ok(StringRef::new(manufacturer as _))
     } else {
-        Err(Error::error())
+        Err(err)
     }
 }
 
 pub fn get_device_buffer_frame_size_range(
     id: AudioDeviceID,
     devtype: DeviceType,
-) -> Result<(f64, f64)> {
+) -> std::result::Result<(f64, f64), OSStatus> {
     assert_ne!(id, kAudioObjectUnknown);
 
     let address = get_property_address(Property::DeviceBufferFrameSizeRange, devtype);
@@ -98,7 +116,7 @@ pub fn get_device_buffer_frame_size_range(
     if err == NO_ERR {
         Ok((range.mMinimum, range.mMaximum))
     } else {
-        Err(Error::error())
+        Err(err)
     }
 }
 

--- a/src/backend/device_property.rs
+++ b/src/backend/device_property.rs
@@ -1,0 +1,19 @@
+use super::*;
+
+pub fn get_device_uid(id: AudioDeviceID) -> Result<CFStringRef> {
+    assert_ne!(id, kAudioObjectUnknown);
+
+    let mut size = mem::size_of::<CFStringRef>();
+    let mut uid: CFStringRef = ptr::null();
+    let address = AudioObjectPropertyAddress {
+        mSelector: kAudioDevicePropertyDeviceUID,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMaster,
+    };
+    let err = audio_object_get_property_data(id, &address, &mut size, &mut uid);
+    if err == NO_ERR {
+        Ok(uid)
+    } else {
+        Err(Error::error())
+    }
+}

--- a/src/backend/device_property.rs
+++ b/src/backend/device_property.rs
@@ -67,6 +67,10 @@ pub fn get_device_name(id: AudioDeviceID, devtype: DeviceType) -> Result<CFStrin
     }
 }
 
+pub fn get_device_label(id: AudioDeviceID, devtype: DeviceType) -> Result<CFStringRef> {
+    get_device_source_name(id, devtype).or(get_device_name(id, devtype))
+}
+
 enum Property {
     DeviceName,
     DeviceSource,

--- a/src/backend/device_property.rs
+++ b/src/backend/device_property.rs
@@ -53,7 +53,22 @@ pub fn get_device_source_name(id: AudioDeviceID, devtype: DeviceType) -> Result<
     }
 }
 
+pub fn get_device_name(id: AudioDeviceID, devtype: DeviceType) -> Result<CFStringRef> {
+    assert_ne!(id, kAudioObjectUnknown);
+
+    let address = get_property_address(Property::DeviceName, devtype);
+    let mut size = mem::size_of::<CFStringRef>();
+    let mut name: CFStringRef = ptr::null();
+    let err = audio_object_get_property_data(id, &address, &mut size, &mut name);
+    if err == NO_ERR {
+        Ok(name)
+    } else {
+        Err(Error::error())
+    }
+}
+
 enum Property {
+    DeviceName,
     DeviceSource,
     DeviceSourceName,
     DeviceUID,
@@ -62,6 +77,7 @@ enum Property {
 impl From<Property> for AudioObjectPropertySelector {
     fn from(p: Property) -> Self {
         match p {
+            Property::DeviceName => kAudioObjectPropertyName,
             Property::DeviceSource => kAudioDevicePropertyDataSource,
             Property::DeviceSourceName => kAudioDevicePropertyDataSourceNameForIDCFString,
             Property::DeviceUID => kAudioDevicePropertyDeviceUID,

--- a/src/backend/device_property.rs
+++ b/src/backend/device_property.rs
@@ -1,13 +1,25 @@
 use super::*;
 
-pub fn get_device_uid(id: AudioDeviceID) -> Result<CFStringRef> {
+pub fn get_device_global_uid(id: AudioDeviceID) -> Result<CFStringRef> {
+    get_device_uid(id, DeviceType::INPUT | DeviceType::OUTPUT)
+}
+
+pub fn get_device_uid(id: AudioDeviceID, devtype: DeviceType) -> Result<CFStringRef> {
     assert_ne!(id, kAudioObjectUnknown);
 
     let mut size = mem::size_of::<CFStringRef>();
     let mut uid: CFStringRef = ptr::null();
+
+    const GLOBAL: ffi::cubeb_device_type =
+        ffi::CUBEB_DEVICE_TYPE_INPUT | ffi::CUBEB_DEVICE_TYPE_OUTPUT;
     let address = AudioObjectPropertyAddress {
         mSelector: kAudioDevicePropertyDeviceUID,
-        mScope: kAudioObjectPropertyScopeGlobal,
+        mScope: match devtype.bits() {
+            ffi::CUBEB_DEVICE_TYPE_INPUT => kAudioDevicePropertyScopeInput,
+            ffi::CUBEB_DEVICE_TYPE_OUTPUT => kAudioDevicePropertyScopeOutput,
+            GLOBAL => kAudioObjectPropertyScopeGlobal,
+            _ => panic!("Invalid type"),
+        },
         mElement: kAudioObjectPropertyElementMaster,
     };
     let err = audio_object_get_property_data(id, &address, &mut size, &mut uid);

--- a/src/backend/device_property.rs
+++ b/src/backend/device_property.rs
@@ -71,7 +71,22 @@ pub fn get_device_label(id: AudioDeviceID, devtype: DeviceType) -> Result<String
     get_device_source_name(id, devtype).or(get_device_name(id, devtype))
 }
 
+pub fn get_device_manufacturer(id: AudioDeviceID, devtype: DeviceType) -> Result<StringRef> {
+    assert_ne!(id, kAudioObjectUnknown);
+
+    let address = get_property_address(Property::DeviceManufacturer, devtype);
+    let mut size = mem::size_of::<CFStringRef>();
+    let mut manufacturer: CFStringRef = ptr::null();
+    let err = audio_object_get_property_data(id, &address, &mut size, &mut manufacturer);
+    if err == NO_ERR {
+        Ok(StringRef::new(manufacturer as _))
+    } else {
+        Err(Error::error())
+    }
+}
+
 enum Property {
+    DeviceManufacturer,
     DeviceName,
     DeviceSource,
     DeviceSourceName,
@@ -81,6 +96,7 @@ enum Property {
 impl From<Property> for AudioObjectPropertySelector {
     fn from(p: Property) -> Self {
         match p {
+            Property::DeviceManufacturer => kAudioObjectPropertyManufacturer,
             Property::DeviceName => kAudioObjectPropertyName,
             Property::DeviceSource => kAudioDevicePropertyDataSource,
             Property::DeviceSourceName => kAudioDevicePropertyDataSourceNameForIDCFString,

--- a/src/backend/device_property.rs
+++ b/src/backend/device_property.rs
@@ -29,3 +29,29 @@ pub fn get_device_uid(id: AudioDeviceID, devtype: DeviceType) -> Result<CFString
         Err(Error::error())
     }
 }
+
+pub fn get_device_source(id: AudioDeviceID, devtype: DeviceType) -> Result<u32> {
+    assert_ne!(id, kAudioObjectUnknown);
+
+    let mut size = mem::size_of::<u32>();
+    let mut source: u32 = 0;
+
+    const GLOBAL: ffi::cubeb_device_type =
+        ffi::CUBEB_DEVICE_TYPE_INPUT | ffi::CUBEB_DEVICE_TYPE_OUTPUT;
+    let address = AudioObjectPropertyAddress {
+        mSelector: kAudioDevicePropertyDataSource,
+        mScope: match devtype.bits() {
+            ffi::CUBEB_DEVICE_TYPE_INPUT => kAudioDevicePropertyScopeInput,
+            ffi::CUBEB_DEVICE_TYPE_OUTPUT => kAudioDevicePropertyScopeOutput,
+            GLOBAL => kAudioObjectPropertyScopeGlobal,
+            _ => panic!("Invalid type"),
+        },
+        mElement: kAudioObjectPropertyElementMaster,
+    };
+    let err = audio_object_get_property_data(id, &address, &mut size, &mut source);
+    if err == NO_ERR {
+        Ok(source)
+    } else {
+        Err(Error::error())
+    }
+}

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1723,6 +1723,12 @@ fn audiounit_create_device_from_hwdev(
 
     *dev_info = ffi::cubeb_device_info::default();
 
+    assert!(
+        mem::size_of::<ffi::cubeb_devid>() >= mem::size_of_val(&devid),
+        "cubeb_devid can't represent devid"
+    );
+    dev_info.devid = devid as ffi::cubeb_devid;
+
     let mut device_id_str: CFStringRef = ptr::null();
     size = mem::size_of::<CFStringRef>();
     adr.mSelector = kAudioDevicePropertyDeviceUID;
@@ -1730,12 +1736,6 @@ fn audiounit_create_device_from_hwdev(
     if ret == NO_ERR && !device_id_str.is_null() {
         let c_string = audiounit_strref_to_cstr_utf8(device_id_str);
         dev_info.device_id = c_string.into_raw();
-
-        assert!(
-            mem::size_of::<ffi::cubeb_devid>() >= mem::size_of_val(&devid),
-            "cubeb_devid can't represent devid"
-        );
-        dev_info.devid = devid as ffi::cubeb_devid;
 
         dev_info.group_id = dev_info.device_id;
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1670,23 +1670,6 @@ fn create_cubeb_device_info(
     devid: AudioObjectID,
     devtype: DeviceType,
 ) -> Result<ffi::cubeb_device_info> {
-    let mut adr = AudioObjectPropertyAddress {
-        mSelector: 0,
-        mScope: match devtype {
-            DeviceType::INPUT => kAudioDevicePropertyScopeInput,
-            DeviceType::OUTPUT => kAudioDevicePropertyScopeOutput,
-            _ => panic!("Invalid type"),
-        },
-        mElement: kAudioObjectPropertyElementMaster,
-    };
-    let mut size: usize = 0;
-
-    adr.mScope = if devtype == DeviceType::OUTPUT {
-        kAudioDevicePropertyScopeOutput
-    } else {
-        kAudioDevicePropertyScopeInput
-    };
-
     let channels = get_channel_count(devid, devtype)?;
     if channels == 0 {
         // Invalid type for this device.

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1676,12 +1676,14 @@ fn create_cubeb_device_info(
         kAudioDevicePropertyScopeInput
     };
 
-    let ch = get_channel_count(devid, devtype)?;
-    if ch == 0 {
+    let channels = get_channel_count(devid, devtype)?;
+    if channels == 0 {
+        // Invalid type for this device.
         return Err(Error::error());
     }
 
     let mut dev_info = ffi::cubeb_device_info::default();
+    dev_info.max_channels = channels;
 
     assert!(
         mem::size_of::<ffi::cubeb_devid>() >= mem::size_of_val(&devid),
@@ -1718,7 +1720,6 @@ fn create_cubeb_device_info(
         ffi::CUBEB_DEVICE_PREF_NONE
     };
 
-    dev_info.max_channels = ch;
     dev_info.format = ffi::CUBEB_DEVICE_FMT_ALL;
     dev_info.default_format = ffi::CUBEB_DEVICE_FMT_F32NE;
     audiounit_get_available_samplerate(

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1736,14 +1736,10 @@ fn create_cubeb_device_info(
     }
 
     let mut friendly_name_str: CFStringRef = ptr::null();
-    let mut ds: u32 = 0;
-    size = mem::size_of::<u32>();
-    adr.mSelector = kAudioDevicePropertyDataSource;
-    let mut ret = audio_object_get_property_data(devid, &adr, &mut size, &mut ds);
-    if ret == NO_ERR {
+    if let Ok(mut source) = get_device_source(devid, devtype) {
         let mut trl = AudioValueTranslation {
-            mInputData: &mut ds as *mut u32 as *mut c_void,
-            mInputDataSize: mem::size_of_val(&ds) as u32,
+            mInputData: &mut source as *mut u32 as *mut c_void,
+            mInputDataSize: mem::size_of_val(&source) as u32,
             mOutputData: &mut friendly_name_str as *mut CFStringRef as *mut c_void,
             mOutputDataSize: mem::size_of::<CFStringRef>() as u32,
         };
@@ -1776,7 +1772,7 @@ fn create_cubeb_device_info(
     let mut vendor_name_str: CFStringRef = ptr::null();
     size = mem::size_of::<CFStringRef>();
     adr.mSelector = kAudioObjectPropertyManufacturer;
-    ret = audio_object_get_property_data(devid, &adr, &mut size, &mut vendor_name_str);
+    let mut ret = audio_object_get_property_data(devid, &adr, &mut size, &mut vendor_name_str);
     if ret == NO_ERR && !vendor_name_str.is_null() {
         let c_string = audiounit_strref_to_cstr_utf8(vendor_name_str);
         dev_info.vendor_name = c_string.into_raw();

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1735,16 +1735,11 @@ fn create_cubeb_device_info(
         }
     }
 
-    let mut friendly_name_str: CFStringRef =
-        get_device_source_name(devid, devtype).unwrap_or(ptr::null());
-
     // If there is no datasource for this device, fall back to the
     // device name.
-    if friendly_name_str.is_null() {
-        size = mem::size_of::<CFStringRef>();
-        adr.mSelector = kAudioObjectPropertyName;
-        audio_object_get_property_data(devid, &adr, &mut size, &mut friendly_name_str);
-    }
+    let friendly_name_str: CFStringRef = get_device_source_name(devid, devtype)
+        .or(get_device_name(devid, devtype))
+        .unwrap_or(ptr::null());
 
     if friendly_name_str.is_null() {
         // Couldn't get a datasource name nor a device name, return a

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1735,18 +1735,8 @@ fn create_cubeb_device_info(
         }
     }
 
-    let mut friendly_name_str: CFStringRef = ptr::null();
-    if let Ok(mut source) = get_device_source(devid, devtype) {
-        let mut trl = AudioValueTranslation {
-            mInputData: &mut source as *mut u32 as *mut c_void,
-            mInputDataSize: mem::size_of_val(&source) as u32,
-            mOutputData: &mut friendly_name_str as *mut CFStringRef as *mut c_void,
-            mOutputDataSize: mem::size_of::<CFStringRef>() as u32,
-        };
-        adr.mSelector = kAudioDevicePropertyDataSourceNameForIDCFString;
-        size = mem::size_of::<AudioValueTranslation>();
-        audio_object_get_property_data(devid, &adr, &mut size, &mut trl);
-    }
+    let mut friendly_name_str: CFStringRef =
+        get_device_source_name(devid, devtype).unwrap_or(ptr::null());
 
     // If there is no datasource for this device, fall back to the
     // device name.

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1705,11 +1705,12 @@ fn create_cubeb_device_info(
         dev_info.vendor_name = vendor_name.into_raw();
     }
 
-    dev_info.device_type = if devtype == DeviceType::OUTPUT {
-        ffi::CUBEB_DEVICE_TYPE_OUTPUT
-    } else {
-        ffi::CUBEB_DEVICE_TYPE_INPUT
+    dev_info.device_type = match devtype {
+        DeviceType::INPUT => ffi::CUBEB_DEVICE_TYPE_INPUT,
+        DeviceType::OUTPUT => ffi::CUBEB_DEVICE_TYPE_OUTPUT,
+        _ => panic!("invalid type"),
     };
+
     dev_info.state = ffi::CUBEB_DEVICE_STATE_ENABLED;
     dev_info.preferred = if devid == audiounit_get_default_device_id(devtype) {
         ffi::CUBEB_DEVICE_PREF_ALL

--- a/src/backend/tests/aggregate_device.rs
+++ b/src/backend/tests/aggregate_device.rs
@@ -626,7 +626,7 @@ fn to_devices_names(devices: &Vec<AudioObjectID>) -> Vec<Option<String>> {
 }
 
 fn to_device_name(id: AudioObjectID) -> Option<String> {
-    let name_ref = get_device_uid(id).unwrap();
+    let name_ref = get_device_global_uid(id).unwrap();
     let name = strref_to_string(name_ref);
     unsafe {
         CFRelease(name_ref as *const c_void);

--- a/src/backend/tests/aggregate_device.rs
+++ b/src/backend/tests/aggregate_device.rs
@@ -626,11 +626,7 @@ fn to_devices_names(devices: &Vec<AudioObjectID>) -> Vec<Option<String>> {
 }
 
 fn to_device_name(id: AudioObjectID) -> Option<String> {
-    let name_ref = get_device_name(id);
-    if name_ref.is_null() {
-        return None;
-    }
-
+    let name_ref = get_device_uid(id).unwrap();
     let name = strref_to_string(name_ref);
     unsafe {
         CFRelease(name_ref as *const c_void);

--- a/src/backend/tests/aggregate_device.rs
+++ b/src/backend/tests/aggregate_device.rs
@@ -631,6 +631,45 @@ fn to_device_name(id: AudioObjectID) -> Option<String> {
 }
 
 fn strref_to_string(strref: CFStringRef) -> String {
-    let cstring = audiounit_strref_to_cstr_utf8(strref);
+    let cstring = cfstringref_to_cstring(strref);
     cstring.into_string().unwrap()
+}
+
+fn cfstringref_to_cstring(strref: CFStringRef) -> CString {
+    use std::os::raw::c_char;
+
+    let empty = CString::default();
+    if strref.is_null() {
+        return empty;
+    }
+
+    let len = unsafe { CFStringGetLength(strref) };
+    // Add 1 to size to allow for '\0' termination character.
+    let size = unsafe { CFStringGetMaximumSizeForEncoding(len, kCFStringEncodingUTF8) + 1 };
+    let mut buffer = vec![b'\x00'; size as usize];
+
+    let success = unsafe {
+        CFStringGetCString(
+            strref,
+            buffer.as_mut_ptr() as *mut c_char,
+            size,
+            kCFStringEncodingUTF8,
+        ) != 0
+    };
+    if !success {
+        buffer.clear();
+        return empty;
+    }
+
+    // CString::new() will consume the input bytes vec and add a '\0' at the
+    // end of the bytes. We need to remove the '\0' from the bytes data
+    // returned from CFStringGetCString by ourselves to avoid memory leaks.
+    // The size returned from CFStringGetMaximumSizeForEncoding is always
+    // greater than or equal to the string length, where the string length
+    // is the number of characters from the beginning to nul-terminator('\0'),
+    // so we should shrink the string vector to fit that size.
+    let str_len = unsafe { libc::strlen(buffer.as_ptr() as *mut c_char) };
+    buffer.truncate(str_len); // Drop the elements from '\0'(including '\0').
+
+    CString::new(buffer).unwrap_or(empty)
 }

--- a/src/backend/tests/aggregate_device.rs
+++ b/src/backend/tests/aggregate_device.rs
@@ -626,12 +626,8 @@ fn to_devices_names(devices: &Vec<AudioObjectID>) -> Vec<Option<String>> {
 }
 
 fn to_device_name(id: AudioObjectID) -> Option<String> {
-    let name_ref = get_device_global_uid(id).unwrap();
-    let name = strref_to_string(name_ref);
-    unsafe {
-        CFRelease(name_ref as *const c_void);
-    }
-    Some(name)
+    let uid = get_device_global_uid(id).unwrap();
+    Some(uid.into_string())
 }
 
 fn strref_to_string(strref: CFStringRef) -> String {

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1029,30 +1029,32 @@ fn test_set_channel_layout_with_null_unit() {
     .is_err());
 }
 
-// get_device_name
+// get_device_uid
 // ------------------------------------
 #[test]
-fn test_get_device_name() {
-    // Unknown device.
-    assert!(get_device_name(kAudioObjectUnknown).is_null());
-
+fn test_get_device_uid() {
     // Input device.
     if let Some(input) = test_get_default_device(Scope::Input) {
-        let name = get_device_name(input);
-        assert!(!name.is_null());
+        let uid = get_device_uid(input).unwrap();
         unsafe {
-            CFRelease(name as *const c_void);
+            CFRelease(uid as *const c_void);
         }
     }
 
     // Output device.
     if let Some(output) = test_get_default_device(Scope::Output) {
-        let name = get_device_name(output);
-        assert!(!name.is_null());
+        let uid = get_device_uid(output).unwrap();
         unsafe {
-            CFRelease(name as *const c_void);
+            CFRelease(uid as *const c_void);
         }
     }
+}
+
+#[test]
+#[should_panic]
+fn test_get_device_uid_by_unknwon_device() {
+    // Unknown device.
+    assert!(get_device_uid(kAudioObjectUnknown).is_err());
 }
 
 // AggregateDevice::set_sub_devices

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1081,6 +1081,168 @@ fn test_get_device_uid_by_unknwon_device() {
     assert!(get_device_uid(kAudioObjectUnknown, DeviceType::INPUT).is_err());
 }
 
+// get_device_source
+// ------------------------------------
+#[test]
+fn test_get_device_source() {
+    if let Some(device) = test_get_default_device(Scope::Input) {
+        if let Ok(source) = get_device_source(device, DeviceType::INPUT) {
+            println!("{}, {:?}", source, convert_uint32_into_string(source));
+        } else {
+            println!("No data source.");
+        }
+    } else {
+        println!("No input device.");
+    }
+
+    if let Some(device) = test_get_default_device(Scope::Output) {
+        if let Ok(source) = get_device_source(device, DeviceType::OUTPUT) {
+            println!("{}, {:?}", source, convert_uint32_into_string(source));
+        } else {
+            println!("No data source.");
+        }
+    } else {
+        println!("No output device.");
+    }
+}
+
+#[test]
+#[should_panic]
+fn test_get_device_source_by_unknown_device() {
+    assert!(get_device_source(kAudioObjectUnknown, DeviceType::INPUT).is_err());
+}
+
+// get_device_source_name
+// ------------------------------------
+#[test]
+fn test_get_device_source_name() {
+    if let Some(device) = test_get_default_device(Scope::Input) {
+        if let Ok(name) = get_device_source_name(device, DeviceType::INPUT) {
+            println!("{}", name.into_string());
+        } else {
+            println!("No data source name.");
+        }
+    } else {
+        println!("No input device.");
+    }
+
+    if let Some(device) = test_get_default_device(Scope::Output) {
+        if let Ok(name) = get_device_source_name(device, DeviceType::OUTPUT) {
+            println!("{}", name.into_string());
+        } else {
+            println!("No data source name.");
+        }
+    } else {
+        println!("No output device.");
+    }
+}
+
+#[test]
+#[should_panic]
+fn test_get_device_source_name_by_unknown_device() {
+    assert!(get_device_source_name(kAudioObjectUnknown, DeviceType::INPUT).is_err());
+}
+
+// get_device_name
+// ------------------------------------
+#[test]
+fn test_get_device_name() {
+    if let Some(device) = test_get_default_device(Scope::Input) {
+        let name = get_device_name(device, DeviceType::INPUT).unwrap();
+        println!("input device name: {}", name.into_string());
+    } else {
+        println!("No input device.");
+    }
+
+    if let Some(device) = test_get_default_device(Scope::Output) {
+        let name = get_device_name(device, DeviceType::OUTPUT).unwrap();
+        println!("output device name: {}", name.into_string());
+    } else {
+        println!("No output device.");
+    }
+}
+
+#[test]
+#[should_panic]
+fn test_get_device_name_by_unknown_device() {
+    assert!(get_device_name(kAudioObjectUnknown, DeviceType::INPUT).is_err());
+}
+
+// get_device_label
+// ------------------------------------
+#[test]
+fn test_get_device_label() {
+    if let Some(device) = test_get_default_device(Scope::Input) {
+        let name = get_device_label(device, DeviceType::INPUT).unwrap();
+        println!("input device label: {}", name.into_string());
+    } else {
+        println!("No input device.");
+    }
+
+    if let Some(device) = test_get_default_device(Scope::Output) {
+        let name = get_device_label(device, DeviceType::OUTPUT).unwrap();
+        println!("output device label: {}", name.into_string());
+    } else {
+        println!("No output device.");
+    }
+}
+
+#[test]
+#[should_panic]
+fn test_get_device_label_by_unknown_device() {
+    assert!(get_device_label(kAudioObjectUnknown, DeviceType::INPUT).is_err());
+}
+
+// get_device_manufacturer
+// ------------------------------------
+#[test]
+fn test_get_device_manufacturer() {
+    if let Some(device) = test_get_default_device(Scope::Input) {
+        let name = get_device_manufacturer(device, DeviceType::INPUT).unwrap();
+        println!("input device vendor: {}", name.into_string());
+    } else {
+        println!("No input device.");
+    }
+
+    if let Some(device) = test_get_default_device(Scope::Output) {
+        let name = get_device_manufacturer(device, DeviceType::OUTPUT).unwrap();
+        println!("output device vendor: {}", name.into_string());
+    } else {
+        println!("No output device.");
+    }
+}
+
+#[test]
+#[should_panic]
+fn test_get_device_manufacturer_by_unknown_device() {
+    assert!(get_device_manufacturer(kAudioObjectUnknown, DeviceType::INPUT).is_err());
+}
+
+// get_device_buffer_frame_size_range
+// ------------------------------------
+#[test]
+fn test_get_device_buffer_frame_size_range() {
+    if let Some(device) = test_get_default_device(Scope::Input) {
+        let (min, max) = get_device_buffer_frame_size_range(device, DeviceType::INPUT).unwrap();
+        println!("range of input buffer frame size: {}-{}", min, max);
+    } else {
+        println!("No input device.");
+    }
+
+    if let Some(device) = test_get_default_device(Scope::Output) {
+        let (min, max) = get_device_buffer_frame_size_range(device, DeviceType::OUTPUT).unwrap();
+        println!("range of output buffer frame size: {}-{}", min, max);
+    } else {
+        println!("No output device.");
+    }
+}
+
+#[test]
+#[should_panic]
+fn test_get_device_buffer_frame_size_range_by_unknown_device() {
+    assert!(get_device_buffer_frame_size_range(kAudioObjectUnknown, DeviceType::INPUT).is_err());
+}
+
 // AggregateDevice::set_sub_devices
 // ------------------------------------
 #[test]

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1198,15 +1198,23 @@ fn test_get_device_label_by_unknown_device() {
 #[test]
 fn test_get_device_manufacturer() {
     if let Some(device) = test_get_default_device(Scope::Input) {
-        let name = get_device_manufacturer(device, DeviceType::INPUT).unwrap();
-        println!("input device vendor: {}", name.into_string());
+        // Some devices like AirPods cannot get the vendor info so we print the error directly.
+        // TODO: Replace `map` and `unwrap_or_else` by `map_or_else`
+        let name = get_device_manufacturer(device, DeviceType::INPUT)
+            .map(|name| name.into_string())
+            .unwrap_or_else(|e| format!("Error: {}", e));
+        println!("input device vendor: {}", name);
     } else {
         println!("No input device.");
     }
 
     if let Some(device) = test_get_default_device(Scope::Output) {
-        let name = get_device_manufacturer(device, DeviceType::OUTPUT).unwrap();
-        println!("output device vendor: {}", name.into_string());
+        // Some devices like AirPods cannot get the vendor info so we print the error directly.
+        // TODO: Replace `map` and `unwrap_or_else` by `map_or_else`
+        let name = get_device_manufacturer(device, DeviceType::OUTPUT)
+            .map(|name| name.into_string())
+            .unwrap_or_else(|e| format!("Error: {}", e));
+        println!("output device vendor: {}", name);
     } else {
         println!("No output device.");
     }

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1036,17 +1036,15 @@ fn test_get_device_global_uid() {
     // Input device.
     if let Some(input) = test_get_default_device(Scope::Input) {
         let uid = get_device_global_uid(input).unwrap();
-        unsafe {
-            CFRelease(uid as *const c_void);
-        }
+        let uid = uid.into_string();
+        assert!(!uid.is_empty());
     }
 
     // Output device.
     if let Some(output) = test_get_default_device(Scope::Output) {
         let uid = get_device_global_uid(output).unwrap();
-        unsafe {
-            CFRelease(uid as *const c_void);
-        }
+        let uid = uid.into_string();
+        assert!(!uid.is_empty());
     }
 }
 
@@ -1064,17 +1062,15 @@ fn test_get_device_uid() {
     // Input device.
     if let Some(input) = test_get_default_device(Scope::Input) {
         let uid = get_device_uid(input, DeviceType::INPUT).unwrap();
-        unsafe {
-            CFRelease(uid as *const c_void);
-        }
+        let uid = uid.into_string();
+        assert!(!uid.is_empty());
     }
 
     // Output device.
     if let Some(output) = test_get_default_device(Scope::Output) {
         let uid = get_device_uid(output, DeviceType::OUTPUT).unwrap();
-        unsafe {
-            CFRelease(uid as *const c_void);
-        }
+        let uid = uid.into_string();
+        assert!(!uid.is_empty());
     }
 }
 

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1029,13 +1029,13 @@ fn test_set_channel_layout_with_null_unit() {
     .is_err());
 }
 
-// get_device_uid
+// get_device_global_uid
 // ------------------------------------
 #[test]
-fn test_get_device_uid() {
+fn test_get_device_global_uid() {
     // Input device.
     if let Some(input) = test_get_default_device(Scope::Input) {
-        let uid = get_device_uid(input).unwrap();
+        let uid = get_device_global_uid(input).unwrap();
         unsafe {
             CFRelease(uid as *const c_void);
         }
@@ -1043,7 +1043,35 @@ fn test_get_device_uid() {
 
     // Output device.
     if let Some(output) = test_get_default_device(Scope::Output) {
-        let uid = get_device_uid(output).unwrap();
+        let uid = get_device_global_uid(output).unwrap();
+        unsafe {
+            CFRelease(uid as *const c_void);
+        }
+    }
+}
+
+#[test]
+#[should_panic]
+fn test_get_device_global_uid_by_unknwon_device() {
+    // Unknown device.
+    assert!(get_device_global_uid(kAudioObjectUnknown).is_err());
+}
+
+// get_device_uid
+// ------------------------------------
+#[test]
+fn test_get_device_uid() {
+    // Input device.
+    if let Some(input) = test_get_default_device(Scope::Input) {
+        let uid = get_device_uid(input, DeviceType::INPUT).unwrap();
+        unsafe {
+            CFRelease(uid as *const c_void);
+        }
+    }
+
+    // Output device.
+    if let Some(output) = test_get_default_device(Scope::Output) {
+        let uid = get_device_uid(output, DeviceType::OUTPUT).unwrap();
         unsafe {
             CFRelease(uid as *const c_void);
         }
@@ -1054,7 +1082,7 @@ fn test_get_device_uid() {
 #[should_panic]
 fn test_get_device_uid_by_unknwon_device() {
     // Unknown device.
-    assert!(get_device_uid(kAudioObjectUnknown).is_err());
+    assert!(get_device_uid(kAudioObjectUnknown, DeviceType::INPUT).is_err());
 }
 
 // AggregateDevice::set_sub_devices

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1728,9 +1728,9 @@ fn test_get_device_presentation_latency() {
 
     fn test_get_device_presentation_latencies_of_device(id: AudioObjectID) -> Vec<u32> {
         let scopes = [
-            kAudioObjectPropertyScopeGlobal,
-            kAudioDevicePropertyScopeInput,
-            kAudioDevicePropertyScopeOutput,
+            DeviceType::INPUT,
+            DeviceType::OUTPUT,
+            DeviceType::INPUT | DeviceType::OUTPUT,
         ];
         let mut latencies = Vec::new();
         for scope in scopes.iter() {

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1666,9 +1666,9 @@ fn test_get_available_samplerate() {
 
     fn test_get_available_samplerate_of_device(id: AudioObjectID) -> Vec<(u32, u32, u32)> {
         let scopes = [
-            kAudioObjectPropertyScopeGlobal,
-            kAudioDevicePropertyScopeInput,
-            kAudioDevicePropertyScopeOutput,
+            DeviceType::INPUT,
+            DeviceType::OUTPUT,
+            DeviceType::INPUT | DeviceType::OUTPUT,
         ];
         let mut samplerates = Vec::new();
         for scope in scopes.iter() {
@@ -1679,12 +1679,12 @@ fn test_get_available_samplerate() {
 
     fn test_get_available_samplerate_of_device_in_scope(
         id: AudioObjectID,
-        scope: AudioObjectPropertyScope,
+        devtype: DeviceType,
     ) -> (u32, u32, u32) {
         let mut default = 0;
         let mut min = 0;
         let mut max = 0;
-        audiounit_get_available_samplerate(id, scope, &mut min, &mut max, &mut default);
+        audiounit_get_available_samplerate(id, devtype, &mut min, &mut max, &mut default);
         (min, max, default)
     }
 

--- a/src/backend/tests/utils.rs
+++ b/src/backend/tests/utils.rs
@@ -861,11 +861,10 @@ impl TestDevicePlugger {
             CFDictionaryAddValue(
                 sub_device_dict,
                 cfstringref_from_static_string(SUB_DEVICE_UID_KEY) as *const c_void,
-                uid as *const c_void,
+                uid.get_raw() as *const c_void,
             );
             CFArrayAppendValue(list, sub_device_dict as *const c_void);
             CFRelease(sub_device_dict as *const c_void);
-            CFRelease(uid as *const c_void);
             Some(list)
         }
     }

--- a/src/backend/tests/utils.rs
+++ b/src/backend/tests/utils.rs
@@ -845,7 +845,7 @@ impl TestDevicePlugger {
             return None;
         }
         let device = device.unwrap();
-        let uid = get_device_uid(device);
+        let uid = get_device_global_uid(device);
         if uid.is_err() {
             return None;
         }

--- a/src/backend/tests/utils.rs
+++ b/src/backend/tests/utils.rs
@@ -845,10 +845,11 @@ impl TestDevicePlugger {
             return None;
         }
         let device = device.unwrap();
-        let uid = get_device_name(device);
-        if uid.is_null() {
+        let uid = get_device_uid(device);
+        if uid.is_err() {
             return None;
         }
+        let uid = uid.unwrap();
         unsafe {
             let list = CFArrayCreateMutable(ptr::null(), 0, &kCFTypeArrayCallBacks);
             let sub_device_dict = CFDictionaryCreateMutable(

--- a/todo.md
+++ b/todo.md
@@ -7,7 +7,6 @@
 - Use `ErrorChain`
 - Centralize the error log in one place
 - Check scope for `audiounit_get_available_samplerate`
-- Return `Result` from `audiounit_get_channel_count`
 - Refacotr the whole `audiounit_create_device_from_hwdev`
     - Return `cubeb_device_info` in `Result` from `audiounit_create_device_from_hwdev`
     - Decouple the settings of `devid` and `device_id`

--- a/todo.md
+++ b/todo.md
@@ -8,7 +8,6 @@
 - Centralize the error log in one place
 - Check scope for `audiounit_get_available_samplerate`
 - Refacotr the whole `audiounit_create_device_from_hwdev`
-    - Return `cubeb_device_info` in `Result` from `audiounit_create_device_from_hwdev`
     - Decouple the settings of `devid` and `device_id`
     - Split the data retrieve into different functions
 - Support `enumerate_devices` with in-out type?

--- a/todo.md
+++ b/todo.md
@@ -7,9 +7,12 @@
 - Use `ErrorChain`
 - Centralize the error log in one place
 - Check scope for `audiounit_get_available_samplerate`
-- Refacotr the whole `audiounit_create_device_from_hwdev`
-    - Decouple the settings of `devid` and `device_id`
-    - Split the data retrieve into different functions
+- Create utils in device_property to replace:
+  - `audiounit_get_available_samplerate`
+  - `audiounit_get_device_presentation_latency`
+  - `audiounit_get_acceptable_latency_range`
+  - `audiounit_get_default_datasource`
+- Merge _property_address.rs_ and _device_property.rs_
 - Support `enumerate_devices` with in-out type?
 - Monitor `kAudioDevicePropertyDeviceIsAlive` for output device.
 


### PR DESCRIPTION
Create several functions to get the device info separately instead of getting all the info in one huge function. As a result, we don't need to call this huge function when we only need one specific device value and it's easier to test the device info query separately.