### PR TITLE
Simplify the APIs for querying device information

### DIFF
--- a/src/backend/device_property.rs
+++ b/src/backend/device_property.rs
@@ -177,11 +177,29 @@ pub fn get_stream_latency(
     }
 }
 
+pub fn get_device_sample_rate(
+    id: AudioDeviceID,
+    devtype: DeviceType,
+) -> std::result::Result<f64, OSStatus> {
+    assert_ne!(id, kAudioObjectUnknown);
+
+    let address = get_property_address(Property::DeviceSampleRate, devtype);
+    let mut size = mem::size_of::<f64>();
+    let mut rate: f64 = 0.0;
+    let err = audio_object_get_property_data(id, &address, &mut size, &mut rate);
+    if err == NO_ERR {
+        Ok(rate)
+    } else {
+        Err(err)
+    }
+}
+
 enum Property {
     DeviceBufferFrameSizeRange,
     DeviceLatency,
     DeviceManufacturer,
     DeviceName,
+    DeviceSampleRate,
     DeviceSource,
     DeviceSourceName,
     DeviceStreams,
@@ -196,6 +214,7 @@ impl From<Property> for AudioObjectPropertySelector {
             Property::DeviceLatency => kAudioDevicePropertyLatency,
             Property::DeviceManufacturer => kAudioObjectPropertyManufacturer,
             Property::DeviceName => kAudioObjectPropertyName,
+            Property::DeviceSampleRate => kAudioDevicePropertyNominalSampleRate,
             Property::DeviceSource => kAudioDevicePropertyDataSource,
             Property::DeviceSourceName => kAudioDevicePropertyDataSourceNameForIDCFString,
             Property::DeviceStreams => kAudioDevicePropertyStreams,

--- a/src/backend/device_property.rs
+++ b/src/backend/device_property.rs
@@ -106,7 +106,7 @@ pub fn get_device_manufacturer(
 pub fn get_device_buffer_frame_size_range(
     id: AudioDeviceID,
     devtype: DeviceType,
-) -> std::result::Result<(f64, f64), OSStatus> {
+) -> std::result::Result<AudioValueRange, OSStatus> {
     assert_ne!(id, kAudioObjectUnknown);
 
     let address = get_property_address(Property::DeviceBufferFrameSizeRange, devtype);
@@ -114,7 +114,7 @@ pub fn get_device_buffer_frame_size_range(
     let mut range = AudioValueRange::default();
     let err = audio_object_get_property_data(id, &address, &mut size, &mut range);
     if err == NO_ERR {
-        Ok((range.mMinimum, range.mMaximum))
+        Ok(range)
     } else {
         Err(err)
     }

--- a/src/backend/device_property.rs
+++ b/src/backend/device_property.rs
@@ -120,8 +120,26 @@ pub fn get_device_buffer_frame_size_range(
     }
 }
 
+pub fn get_device_latency(
+    id: AudioDeviceID,
+    devtype: DeviceType,
+) -> std::result::Result<u32, OSStatus> {
+    assert_ne!(id, kAudioObjectUnknown);
+
+    let address = get_property_address(Property::DeviceLatency, devtype);
+    let mut size = mem::size_of::<u32>();
+    let mut latency: u32 = 0;
+    let err = audio_object_get_property_data(id, &address, &mut size, &mut latency);
+    if err == NO_ERR {
+        Ok(latency)
+    } else {
+        Err(err)
+    }
+}
+
 enum Property {
     DeviceBufferFrameSizeRange,
+    DeviceLatency,
     DeviceManufacturer,
     DeviceName,
     DeviceSource,
@@ -133,6 +151,7 @@ impl From<Property> for AudioObjectPropertySelector {
     fn from(p: Property) -> Self {
         match p {
             Property::DeviceBufferFrameSizeRange => kAudioDevicePropertyBufferFrameSizeRange,
+            Property::DeviceLatency => kAudioDevicePropertyLatency,
             Property::DeviceManufacturer => kAudioObjectPropertyManufacturer,
             Property::DeviceName => kAudioObjectPropertyName,
             Property::DeviceSource => kAudioDevicePropertyDataSource,

--- a/src/backend/device_property.rs
+++ b/src/backend/device_property.rs
@@ -137,6 +137,29 @@ pub fn get_device_latency(
     }
 }
 
+pub fn get_device_streams(
+    id: AudioDeviceID,
+    devtype: DeviceType,
+) -> std::result::Result<Vec<AudioStreamID>, OSStatus> {
+    assert_ne!(id, kAudioObjectUnknown);
+
+    let address = get_property_address(Property::DeviceStreams, devtype);
+
+    let mut size: usize = 0;
+    let err = audio_object_get_property_data_size(id, &address, &mut size);
+    if err != NO_ERR {
+        return Err(err);
+    }
+
+    let mut streams: Vec<AudioObjectID> = allocate_array_by_size(size);
+    let err = audio_object_get_property_data(id, &address, &mut size, streams.as_mut_ptr());
+    if err == NO_ERR {
+        Ok(streams)
+    } else {
+        Err(err)
+    }
+}
+
 enum Property {
     DeviceBufferFrameSizeRange,
     DeviceLatency,
@@ -144,6 +167,7 @@ enum Property {
     DeviceName,
     DeviceSource,
     DeviceSourceName,
+    DeviceStreams,
     DeviceUID,
 }
 
@@ -156,6 +180,7 @@ impl From<Property> for AudioObjectPropertySelector {
             Property::DeviceName => kAudioObjectPropertyName,
             Property::DeviceSource => kAudioDevicePropertyDataSource,
             Property::DeviceSourceName => kAudioDevicePropertyDataSourceNameForIDCFString,
+            Property::DeviceStreams => kAudioDevicePropertyStreams,
             Property::DeviceUID => kAudioDevicePropertyDeviceUID,
         }
     }

--- a/src/backend/device_property.rs
+++ b/src/backend/device_property.rs
@@ -160,23 +160,6 @@ pub fn get_device_streams(
     }
 }
 
-pub fn get_stream_latency(
-    id: AudioStreamID,
-    devtype: DeviceType,
-) -> std::result::Result<u32, OSStatus> {
-    assert_ne!(id, kAudioObjectUnknown);
-
-    let address = get_property_address(Property::StreamLatency, devtype);
-    let mut size = mem::size_of::<u32>();
-    let mut latency: u32 = 0;
-    let err = audio_object_get_property_data(id, &address, &mut size, &mut latency);
-    if err == NO_ERR {
-        Ok(latency)
-    } else {
-        Err(err)
-    }
-}
-
 pub fn get_device_sample_rate(
     id: AudioDeviceID,
     devtype: DeviceType,
@@ -212,6 +195,23 @@ pub fn get_ranges_of_device_sample_rate(
     let err = audio_object_get_property_data(id, &address, &mut size, ranges.as_mut_ptr());
     if err == NO_ERR {
         Ok(ranges)
+    } else {
+        Err(err)
+    }
+}
+
+pub fn get_stream_latency(
+    id: AudioStreamID,
+    devtype: DeviceType,
+) -> std::result::Result<u32, OSStatus> {
+    assert_ne!(id, kAudioObjectUnknown);
+
+    let address = get_property_address(Property::StreamLatency, devtype);
+    let mut size = mem::size_of::<u32>();
+    let mut latency: u32 = 0;
+    let err = audio_object_get_property_data(id, &address, &mut size, &mut latency);
+    if err == NO_ERR {
+        Ok(latency)
     } else {
         Err(err)
     }

--- a/src/backend/device_property.rs
+++ b/src/backend/device_property.rs
@@ -200,6 +200,23 @@ pub fn get_ranges_of_device_sample_rate(
     }
 }
 
+pub fn get_device_stream_format(
+    id: AudioDeviceID,
+    devtype: DeviceType,
+) -> std::result::Result<AudioStreamBasicDescription, OSStatus> {
+    assert_ne!(id, kAudioObjectUnknown);
+
+    let address = get_property_address(Property::DeviceStreamFormat, devtype);
+    let mut size = mem::size_of::<AudioStreamBasicDescription>();
+    let mut format = AudioStreamBasicDescription::default();
+    let err = audio_object_get_property_data(id, &address, &mut size, &mut format);
+    if err == NO_ERR {
+        Ok(format)
+    } else {
+        Err(err)
+    }
+}
+
 pub fn get_stream_latency(
     id: AudioStreamID,
     devtype: DeviceType,
@@ -226,6 +243,7 @@ enum Property {
     DeviceSampleRates,
     DeviceSource,
     DeviceSourceName,
+    DeviceStreamFormat,
     DeviceStreams,
     DeviceUID,
     StreamLatency,
@@ -242,6 +260,7 @@ impl From<Property> for AudioObjectPropertySelector {
             Property::DeviceSampleRates => kAudioDevicePropertyAvailableNominalSampleRates,
             Property::DeviceSource => kAudioDevicePropertyDataSource,
             Property::DeviceSourceName => kAudioDevicePropertyDataSourceNameForIDCFString,
+            Property::DeviceStreamFormat => kAudioDevicePropertyStreamFormat,
             Property::DeviceStreams => kAudioDevicePropertyStreams,
             Property::DeviceUID => kAudioDevicePropertyDeviceUID,
             Property::StreamLatency => kAudioStreamPropertyLatency,

--- a/src/backend/device_property.rs
+++ b/src/backend/device_property.rs
@@ -160,6 +160,23 @@ pub fn get_device_streams(
     }
 }
 
+pub fn get_stream_latency(
+    id: AudioStreamID,
+    devtype: DeviceType,
+) -> std::result::Result<u32, OSStatus> {
+    assert_ne!(id, kAudioObjectUnknown);
+
+    let address = get_property_address(Property::StreamLatency, devtype);
+    let mut size = mem::size_of::<u32>();
+    let mut latency: u32 = 0;
+    let err = audio_object_get_property_data(id, &address, &mut size, &mut latency);
+    if err == NO_ERR {
+        Ok(latency)
+    } else {
+        Err(err)
+    }
+}
+
 enum Property {
     DeviceBufferFrameSizeRange,
     DeviceLatency,
@@ -169,6 +186,7 @@ enum Property {
     DeviceSourceName,
     DeviceStreams,
     DeviceUID,
+    StreamLatency,
 }
 
 impl From<Property> for AudioObjectPropertySelector {
@@ -182,6 +200,7 @@ impl From<Property> for AudioObjectPropertySelector {
             Property::DeviceSourceName => kAudioDevicePropertyDataSourceNameForIDCFString,
             Property::DeviceStreams => kAudioDevicePropertyStreams,
             Property::DeviceUID => kAudioDevicePropertyDeviceUID,
+            Property::StreamLatency => kAudioStreamPropertyLatency,
         }
     }
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1600,15 +1600,11 @@ fn audiounit_get_device_presentation_latency(devid: AudioObjectID, devtype: Devi
     let dev = get_device_latency(devid, devtype).unwrap_or(0);
 
     let mut stream: u32 = 0;
-    let mut sid: [AudioStreamID; 1] = [kAudioObjectUnknown];
-
-    adr.mSelector = kAudioDevicePropertyStreams;
-    size = mem::size_of_val(&sid);
-    assert_eq!(size, mem::size_of::<AudioStreamID>());
-    if audio_object_get_property_data(devid, &adr, &mut size, sid.as_mut_ptr()) == NO_ERR {
-        adr.mSelector = kAudioStreamPropertyLatency;
+    if let Ok(streams) = get_device_streams(devid, devtype) {
+        assert!(!streams.is_empty());
         size = mem::size_of::<u32>();
-        audio_object_get_property_data(sid[0], &adr, &mut size, &mut stream);
+        adr.mSelector = kAudioStreamPropertyLatency;
+        audio_object_get_property_data(streams[0], &adr, &mut size, &mut stream);
     }
 
     dev + stream

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3541,10 +3541,12 @@ impl<'ctx> StreamOps for AudioUnitStream<'ctx> {
     #[cfg(not(target_os = "ios"))]
     fn current_device(&mut self) -> Result<&DeviceRef> {
         let mut device: Box<ffi::cubeb_device> = Box::new(ffi::cubeb_device::default());
-        let input_source = audiounit_get_default_datasource_string(DeviceType::INPUT)?;
-        device.input_name = input_source.into_raw();
-        let output_source = audiounit_get_default_datasource_string(DeviceType::OUTPUT)?;
-        device.output_name = output_source.into_raw();
+        if let Ok(source) = audiounit_get_default_datasource_string(DeviceType::INPUT) {
+            device.input_name = source.into_raw();
+        }
+        if let Ok(source) = audiounit_get_default_datasource_string(DeviceType::OUTPUT) {
+            device.output_name = source.into_raw();
+        }
         Ok(unsafe { DeviceRef::from_ptr(Box::into_raw(device)) })
     }
     #[cfg(target_os = "ios")]

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1597,15 +1597,10 @@ fn audiounit_get_device_presentation_latency(devid: AudioObjectID, devtype: Devi
         mElement: kAudioObjectPropertyElementMaster,
     };
     let mut size: usize = 0;
-    let mut dev: u32 = 0;
+    let dev = get_device_latency(devid, devtype).unwrap_or(0);
+
     let mut stream: u32 = 0;
     let mut sid: [AudioStreamID; 1] = [kAudioObjectUnknown];
-
-    adr.mSelector = kAudioDevicePropertyLatency;
-    size = mem::size_of::<u32>();
-    if audio_object_get_property_data(devid, &adr, &mut size, &mut dev) != NO_ERR {
-        dev = 0;
-    }
 
     adr.mSelector = kAudioDevicePropertyStreams;
     size = mem::size_of_val(&sid);

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2113,14 +2113,14 @@ impl ContextOps for AudioUnitContext {
     }
     #[cfg(not(target_os = "ios"))]
     fn min_latency(&mut self, _params: StreamParams) -> Result<u32> {
-        let output_device_id = audiounit_get_default_device_id(DeviceType::OUTPUT);
-        if output_device_id == kAudioObjectUnknown {
+        let device = audiounit_get_default_device_id(DeviceType::OUTPUT);
+        if device == kAudioObjectUnknown {
             cubeb_log!("Could not get default output device id.");
             return Err(Error::error());
         }
 
-        let range = get_device_buffer_frame_size_range(output_device_id, DeviceType::OUTPUT)
-            .map_err(|e| {
+        let range =
+            get_device_buffer_frame_size_range(device, DeviceType::OUTPUT).map_err(|e| {
                 cubeb_log!("Could not get acceptable latency range. Error: {}", e);
                 Error::error()
             })?;

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -2,8 +2,8 @@ use super::utils::{
     test_audiounit_get_buffer_frame_size, test_audiounit_scope_is_enabled, test_create_audiounit,
     test_device_channels_in_scope, test_device_in_scope, test_get_all_devices,
     test_get_default_audiounit, test_get_default_device, test_get_default_raw_stream,
-    test_get_default_source_data, test_get_default_source_name, test_get_devices_in_scope,
-    test_get_raw_context, ComponentSubType, PropertyScope, Scope,
+    test_get_default_source_name, test_get_devices_in_scope, test_get_raw_context,
+    ComponentSubType, PropertyScope, Scope,
 };
 use super::*;
 use std::any::Any;
@@ -1363,25 +1363,6 @@ fn test_convert_uint32_into_string() {
     let data: u32 = ('R' as u32) << 24 | ('U' as u32) << 16 | ('S' as u32) << 8 | 'T' as u32;
     let data_string = convert_uint32_into_string(data);
     assert_eq!(data_string, CString::new("RUST").unwrap());
-}
-
-// get_default_datasource
-// ------------------------------------
-#[test]
-fn test_get_default_device_datasource() {
-    test_get_default_datasource_in_scope(Scope::Input);
-    test_get_default_datasource_in_scope(Scope::Output);
-
-    fn test_get_default_datasource_in_scope(scope: Scope) {
-        if let Some(source) = test_get_default_source_data(scope.clone()) {
-            assert_eq!(
-                audiounit_get_default_datasource(scope.into()).unwrap(),
-                source
-            );
-        } else {
-            println!("No source data for {:?}.", scope);
-        }
-    }
 }
 
 // get_default_datasource_string

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -511,24 +511,6 @@ fn test_remove_listener_unknown_device() {
 // ------------------------------------
 // TODO
 
-// get_acceptable_latency_range
-// ------------------------------------
-#[test]
-fn test_get_acceptable_latency_range() {
-    let default_output = test_get_default_device(Scope::Output);
-    let range = audiounit_get_acceptable_latency_range();
-    if default_output.is_none() {
-        println!("No output device.");
-        assert_eq!(range.unwrap_err(), Error::error());
-        return;
-    }
-
-    let range = range.unwrap();
-    assert!(range.mMinimum > 0.0);
-    assert!(range.mMaximum > 0.0);
-    assert!(range.mMaximum > range.mMinimum);
-}
-
 // get_default_device_id
 // ------------------------------------
 #[test]

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1537,23 +1537,10 @@ fn test_get_device_presentation_latency() {
     fn test_get_device_presentation_latencies_in_scope(scope: Scope) {
         if let Some(device) = test_get_default_device(scope.clone()) {
             // TODO: The latencies very from devices to devices. Check nothing here.
-            let _latencies = test_get_device_presentation_latencies_of_device(device);
+            let _latency = audiounit_get_device_presentation_latency(device, scope.into());
         } else {
             println!("No device for {:?}.", scope);
         }
-    }
-
-    fn test_get_device_presentation_latencies_of_device(id: AudioObjectID) -> Vec<u32> {
-        let scopes = [
-            DeviceType::INPUT,
-            DeviceType::OUTPUT,
-            DeviceType::INPUT | DeviceType::OUTPUT,
-        ];
-        let mut latencies = Vec::new();
-        for scope in scopes.iter() {
-            latencies.push(audiounit_get_device_presentation_latency(id, *scope));
-        }
-        latencies
     }
 }
 

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1428,7 +1428,6 @@ fn test_get_channel_count_of_unknown_device() {
 }
 
 #[test]
-#[should_panic]
 fn test_get_channel_count_of_inout_type() {
     test_channel_count(Scope::Input);
     test_channel_count(Scope::Output);
@@ -1436,11 +1435,12 @@ fn test_get_channel_count_of_inout_type() {
     fn test_channel_count(scope: Scope) {
         if let Some(device) = test_get_default_device(scope.clone()) {
             assert_eq!(
+                // Get a kAudioHardwareUnknownPropertyError in get_channel_count actually.
                 get_channel_count(device, DeviceType::INPUT | DeviceType::OUTPUT).unwrap_err(),
                 Error::error()
             );
         } else {
-            panic!("Panic by default: No device for {:?}.", scope);
+            println!("No device for {:?}.", scope);
         }
     }
 }
@@ -1637,18 +1637,18 @@ fn test_create_device_info_with_unknown_type() {
 }
 
 #[test]
-#[should_panic]
 fn test_create_device_from_hwdev_with_inout_type() {
     test_create_device_from_hwdev_with_inout_type_by_scope(Scope::Input);
     test_create_device_from_hwdev_with_inout_type_by_scope(Scope::Output);
 
     fn test_create_device_from_hwdev_with_inout_type_by_scope(scope: Scope) {
         if let Some(device) = test_get_default_device(scope.clone()) {
+            // Get a kAudioHardwareUnknownPropertyError in get_channel_count actually.
             assert!(
                 create_cubeb_device_info(device, DeviceType::INPUT | DeviceType::OUTPUT).is_err()
             );
         } else {
-            panic!("Panic by default: No device for {:?}.", scope);
+            println!("No device for {:?}.", scope);
         }
     }
 }

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1502,7 +1502,7 @@ fn test_get_range_of_sample_rates() {
     }
 }
 
-// get_device_presentation_latency
+// get_presentation_latency
 // ------------------------------------
 #[test]
 fn test_get_device_presentation_latency() {
@@ -1512,7 +1512,11 @@ fn test_get_device_presentation_latency() {
     fn test_get_device_presentation_latencies_in_scope(scope: Scope) {
         if let Some(device) = test_get_default_device(scope.clone()) {
             // TODO: The latencies very from devices to devices. Check nothing here.
-            let _latency = audiounit_get_device_presentation_latency(device, scope.into());
+            let latency = get_presentation_latency(device, scope.clone().into());
+            println!(
+                "present latency on the device {} in scope {:?}: {}",
+                device, scope, latency
+            );
         } else {
             println!("No device for {:?}.", scope);
         }

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1487,7 +1487,7 @@ fn test_get_available_samplerate() {
         }
     }
 
-    fn test_get_available_samplerate_of_device(id: AudioObjectID) -> Vec<(u32, u32, u32)> {
+    fn test_get_available_samplerate_of_device(id: AudioObjectID) -> Vec<(u32, u32)> {
         let scopes = [
             DeviceType::INPUT,
             DeviceType::OUTPUT,
@@ -1503,27 +1503,22 @@ fn test_get_available_samplerate() {
     fn test_get_available_samplerate_of_device_in_scope(
         id: AudioObjectID,
         devtype: DeviceType,
-    ) -> (u32, u32, u32) {
-        let mut default = 0;
+    ) -> (u32, u32) {
         let mut min = 0;
         let mut max = 0;
-        audiounit_get_available_samplerate(id, devtype, &mut min, &mut max, &mut default);
-        (min, max, default)
+        audiounit_get_available_samplerate(id, devtype, &mut min, &mut max);
+        (min, max)
     }
 
-    fn check_samplerates((min, max, default): (u32, u32, u32)) {
-        assert!(default > 0);
+    fn check_samplerates((min, max): (u32, u32)) {
         assert!(min > 0);
         assert!(max > 0);
         assert!(min <= max);
-        assert!(min <= default);
-        assert!(default <= max);
     }
 
-    fn check_samplerates_are_zeros((min, max, default): (u32, u32, u32)) {
+    fn check_samplerates_are_zeros((min, max): (u32, u32)) {
         assert_eq!(min, 0);
         assert_eq!(max, 0);
-        assert_eq!(default, 0);
     }
 }
 

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1463,62 +1463,42 @@ fn test_get_channel_count_of_unknwon_type() {
     }
 }
 
-// get_available_samplerate
+// get_range_of_sample_rates
 // ------------------------------------
 #[test]
-fn test_get_available_samplerate() {
-    let samplerates = test_get_available_samplerate_of_device(kAudioObjectUnknown);
-    for rates in samplerates {
-        check_samplerates_are_zeros(rates);
-    }
+fn test_get_range_of_sample_rates() {
+    test_get_range_of_sample_rates_in_scope(Scope::Input);
+    test_get_range_of_sample_rates_in_scope(Scope::Output);
 
-    test_get_available_samplerate_in_scope(Scope::Input);
-    test_get_available_samplerate_in_scope(Scope::Output);
-
-    fn test_get_available_samplerate_in_scope(scope: Scope) {
+    fn test_get_range_of_sample_rates_in_scope(scope: Scope) {
         if let Some(device) = test_get_default_device(scope.clone()) {
-            let samplerates = test_get_available_samplerate_of_device(device);
-            for rates in samplerates {
-                // Surprisingly, we can get the input/output samplerates from a non-input/non-output device.
-                check_samplerates(rates);
+            let ranges = test_get_available_samplerate_of_device(device);
+            for range in ranges {
+                // Surprisingly, we can get the input/output sample rates from a non-input/non-output device.
+                check_samplerates(range);
             }
         } else {
             println!("No device for {:?}.", scope);
         }
     }
 
-    fn test_get_available_samplerate_of_device(id: AudioObjectID) -> Vec<(u32, u32)> {
+    fn test_get_available_samplerate_of_device(id: AudioObjectID) -> Vec<(f64, f64)> {
         let scopes = [
             DeviceType::INPUT,
             DeviceType::OUTPUT,
             DeviceType::INPUT | DeviceType::OUTPUT,
         ];
-        let mut samplerates = Vec::new();
+        let mut ranges = Vec::new();
         for scope in scopes.iter() {
-            samplerates.push(test_get_available_samplerate_of_device_in_scope(id, *scope));
+            ranges.push(get_range_of_sample_rates(id, *scope).unwrap());
         }
-        samplerates
+        ranges
     }
 
-    fn test_get_available_samplerate_of_device_in_scope(
-        id: AudioObjectID,
-        devtype: DeviceType,
-    ) -> (u32, u32) {
-        let mut min = 0;
-        let mut max = 0;
-        audiounit_get_available_samplerate(id, devtype, &mut min, &mut max);
-        (min, max)
-    }
-
-    fn check_samplerates((min, max): (u32, u32)) {
-        assert!(min > 0);
-        assert!(max > 0);
+    fn check_samplerates((min, max): (f64, f64)) {
+        assert!(min > 0.0);
+        assert!(max > 0.0);
         assert!(min <= max);
-    }
-
-    fn check_samplerates_are_zeros((min, max): (u32, u32)) {
-        assert_eq!(min, 0);
-        assert_eq!(max, 0);
     }
 }
 

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1531,12 +1531,6 @@ fn test_get_available_samplerate() {
 // ------------------------------------
 #[test]
 fn test_get_device_presentation_latency() {
-    let latencies = test_get_device_presentation_latencies_of_device(kAudioObjectUnknown);
-    for latency in latencies {
-        // Hit the kAudioHardwareBadObjectError actually.
-        assert_eq!(latency, 0);
-    }
-
     test_get_device_presentation_latencies_in_scope(Scope::Input);
     test_get_device_presentation_latencies_in_scope(Scope::Output);
 

--- a/src/backend/tests/device_property.rs
+++ b/src/backend/tests/device_property.rs
@@ -338,6 +338,31 @@ fn test_get_ranges_of_device_sample_rate_by_unknown_device() {
     assert!(get_ranges_of_device_sample_rate(kAudioObjectUnknown, DeviceType::INPUT).is_err());
 }
 
+// get_device_stream_format
+// ------------------------------------
+#[test]
+fn test_get_device_stream_format() {
+    if let Some(device) = test_get_default_device(Scope::Input) {
+        let format = get_device_stream_format(device, DeviceType::INPUT).unwrap();
+        println!("input stream format: {:?}", format);
+    } else {
+        println!("No input device.");
+    }
+
+    if let Some(device) = test_get_default_device(Scope::Output) {
+        let format = get_device_stream_format(device, DeviceType::OUTPUT).unwrap();
+        println!("output stream format: {:?}", format);
+    } else {
+        println!("No output device.");
+    }
+}
+
+#[test]
+#[should_panic]
+fn test_get_device_stream_format_by_unknown_device() {
+    assert!(get_device_stream_format(kAudioObjectUnknown, DeviceType::INPUT).is_err());
+}
+
 // get_stream_latency
 // ------------------------------------
 #[test]

--- a/src/backend/tests/device_property.rs
+++ b/src/backend/tests/device_property.rs
@@ -262,3 +262,28 @@ fn test_get_device_latency() {
 fn test_get_device_latency_by_unknown_device() {
     assert!(get_device_latency(kAudioObjectUnknown, DeviceType::INPUT).is_err());
 }
+
+// get_device_streams
+// ------------------------------------
+#[test]
+fn test_get_device_streams() {
+    if let Some(device) = test_get_default_device(Scope::Input) {
+        let streams = get_device_streams(device, DeviceType::INPUT).unwrap();
+        println!("streams on the input device: {:?}", streams);
+    } else {
+        println!("No input device.");
+    }
+
+    if let Some(device) = test_get_default_device(Scope::Output) {
+        let streams = get_device_streams(device, DeviceType::OUTPUT).unwrap();
+        println!("streams on the output device: {:?}", streams);
+    } else {
+        println!("No output device.");
+    }
+}
+
+#[test]
+#[should_panic]
+fn test_get_device_streams_by_unknown_device() {
+    assert!(get_device_streams(kAudioObjectUnknown, DeviceType::INPUT).is_err());
+}

--- a/src/backend/tests/device_property.rs
+++ b/src/backend/tests/device_property.rs
@@ -287,3 +287,34 @@ fn test_get_device_streams() {
 fn test_get_device_streams_by_unknown_device() {
     assert!(get_device_streams(kAudioObjectUnknown, DeviceType::INPUT).is_err());
 }
+
+// get_stream_latency
+// ------------------------------------
+#[test]
+fn test_get_stream_latency() {
+    if let Some(device) = test_get_default_device(Scope::Input) {
+        let streams = get_device_streams(device, DeviceType::INPUT).unwrap();
+        for stream in streams {
+            let latency = get_stream_latency(stream, DeviceType::INPUT).unwrap();
+            println!("latency of the input stream {} is {}", stream, latency);
+        }
+    } else {
+        println!("No input device.");
+    }
+
+    if let Some(device) = test_get_default_device(Scope::Output) {
+        let streams = get_device_streams(device, DeviceType::OUTPUT).unwrap();
+        for stream in streams {
+            let latency = get_stream_latency(stream, DeviceType::OUTPUT).unwrap();
+            println!("latency of the output stream {} is {}", stream, latency);
+        }
+    } else {
+        println!("No output device.");
+    }
+}
+
+#[test]
+#[should_panic]
+fn test_get_stream_latency_by_unknown_device() {
+    assert!(get_stream_latency(kAudioObjectUnknown, DeviceType::INPUT).is_err());
+}

--- a/src/backend/tests/device_property.rs
+++ b/src/backend/tests/device_property.rs
@@ -343,3 +343,28 @@ fn test_get_device_sample_rate() {
 fn test_get_device_sample_rate_by_unknown_device() {
     assert!(get_device_sample_rate(kAudioObjectUnknown, DeviceType::INPUT).is_err());
 }
+
+// get_ranges_of_device_sample_rate
+// ------------------------------------
+#[test]
+fn test_get_ranges_of_device_sample_rate() {
+    if let Some(device) = test_get_default_device(Scope::Input) {
+        let ranges = get_ranges_of_device_sample_rate(device, DeviceType::INPUT).unwrap();
+        println!("ranges of input sample rate: {:?}", ranges);
+    } else {
+        println!("No input device.");
+    }
+
+    if let Some(device) = test_get_default_device(Scope::Output) {
+        let ranges = get_ranges_of_device_sample_rate(device, DeviceType::OUTPUT).unwrap();
+        println!("ranges of output sample rate: {:?}", ranges);
+    } else {
+        println!("No output device.");
+    }
+}
+
+#[test]
+#[should_panic]
+fn test_get_ranges_of_device_sample_rate_by_unknown_device() {
+    assert!(get_ranges_of_device_sample_rate(kAudioObjectUnknown, DeviceType::INPUT).is_err());
+}

--- a/src/backend/tests/device_property.rs
+++ b/src/backend/tests/device_property.rs
@@ -288,37 +288,6 @@ fn test_get_device_streams_by_unknown_device() {
     assert!(get_device_streams(kAudioObjectUnknown, DeviceType::INPUT).is_err());
 }
 
-// get_stream_latency
-// ------------------------------------
-#[test]
-fn test_get_stream_latency() {
-    if let Some(device) = test_get_default_device(Scope::Input) {
-        let streams = get_device_streams(device, DeviceType::INPUT).unwrap();
-        for stream in streams {
-            let latency = get_stream_latency(stream, DeviceType::INPUT).unwrap();
-            println!("latency of the input stream {} is {}", stream, latency);
-        }
-    } else {
-        println!("No input device.");
-    }
-
-    if let Some(device) = test_get_default_device(Scope::Output) {
-        let streams = get_device_streams(device, DeviceType::OUTPUT).unwrap();
-        for stream in streams {
-            let latency = get_stream_latency(stream, DeviceType::OUTPUT).unwrap();
-            println!("latency of the output stream {} is {}", stream, latency);
-        }
-    } else {
-        println!("No output device.");
-    }
-}
-
-#[test]
-#[should_panic]
-fn test_get_stream_latency_by_unknown_device() {
-    assert!(get_stream_latency(kAudioObjectUnknown, DeviceType::INPUT).is_err());
-}
-
 // get_device_sample_rate
 // ------------------------------------
 #[test]
@@ -367,4 +336,35 @@ fn test_get_ranges_of_device_sample_rate() {
 #[should_panic]
 fn test_get_ranges_of_device_sample_rate_by_unknown_device() {
     assert!(get_ranges_of_device_sample_rate(kAudioObjectUnknown, DeviceType::INPUT).is_err());
+}
+
+// get_stream_latency
+// ------------------------------------
+#[test]
+fn test_get_stream_latency() {
+    if let Some(device) = test_get_default_device(Scope::Input) {
+        let streams = get_device_streams(device, DeviceType::INPUT).unwrap();
+        for stream in streams {
+            let latency = get_stream_latency(stream, DeviceType::INPUT).unwrap();
+            println!("latency of the input stream {} is {}", stream, latency);
+        }
+    } else {
+        println!("No input device.");
+    }
+
+    if let Some(device) = test_get_default_device(Scope::Output) {
+        let streams = get_device_streams(device, DeviceType::OUTPUT).unwrap();
+        for stream in streams {
+            let latency = get_stream_latency(stream, DeviceType::OUTPUT).unwrap();
+            println!("latency of the output stream {} is {}", stream, latency);
+        }
+    } else {
+        println!("No output device.");
+    }
+}
+
+#[test]
+#[should_panic]
+fn test_get_stream_latency_by_unknown_device() {
+    assert!(get_stream_latency(kAudioObjectUnknown, DeviceType::INPUT).is_err());
 }

--- a/src/backend/tests/device_property.rs
+++ b/src/backend/tests/device_property.rs
@@ -237,3 +237,28 @@ fn test_get_device_buffer_frame_size_range() {
 fn test_get_device_buffer_frame_size_range_by_unknown_device() {
     assert!(get_device_buffer_frame_size_range(kAudioObjectUnknown, DeviceType::INPUT).is_err());
 }
+
+// get_device_latency
+// ------------------------------------
+#[test]
+fn test_get_device_latency() {
+    if let Some(device) = test_get_default_device(Scope::Input) {
+        let latency = get_device_latency(device, DeviceType::INPUT).unwrap();
+        println!("latency of input device: {}", latency);
+    } else {
+        println!("No input device.");
+    }
+
+    if let Some(device) = test_get_default_device(Scope::Output) {
+        let latency = get_device_latency(device, DeviceType::OUTPUT).unwrap();
+        println!("latency of output device: {}", latency);
+    } else {
+        println!("No output device.");
+    }
+}
+
+#[test]
+#[should_panic]
+fn test_get_device_latency_by_unknown_device() {
+    assert!(get_device_latency(kAudioObjectUnknown, DeviceType::INPUT).is_err());
+}

--- a/src/backend/tests/device_property.rs
+++ b/src/backend/tests/device_property.rs
@@ -363,6 +363,33 @@ fn test_get_device_stream_format_by_unknown_device() {
     assert!(get_device_stream_format(kAudioObjectUnknown, DeviceType::INPUT).is_err());
 }
 
+// get_device_stream_configuration
+// ------------------------------------
+#[test]
+fn test_get_device_stream_configuration() {
+    if let Some(device) = test_get_default_device(Scope::Input) {
+        let buffers = get_device_stream_configuration(device, DeviceType::INPUT).unwrap();
+        println!("input stream config: {:?}", buffers);
+        dbg!(buffers);
+    } else {
+        println!("No input device.");
+    }
+
+    if let Some(device) = test_get_default_device(Scope::Output) {
+        let buffers = get_device_stream_configuration(device, DeviceType::OUTPUT).unwrap();
+        println!("output stream config: {:?}", buffers);
+        dbg!(buffers);
+    } else {
+        println!("No output device.");
+    }
+}
+
+#[test]
+#[should_panic]
+fn test_get_device_stream_configuration_by_unknown_device() {
+    assert!(get_device_stream_configuration(kAudioObjectUnknown, DeviceType::INPUT).is_err());
+}
+
 // get_stream_latency
 // ------------------------------------
 #[test]

--- a/src/backend/tests/device_property.rs
+++ b/src/backend/tests/device_property.rs
@@ -212,15 +212,21 @@ fn test_get_device_manufacturer_by_unknown_device() {
 #[test]
 fn test_get_device_buffer_frame_size_range() {
     if let Some(device) = test_get_default_device(Scope::Input) {
-        let (min, max) = get_device_buffer_frame_size_range(device, DeviceType::INPUT).unwrap();
-        println!("range of input buffer frame size: {}-{}", min, max);
+        let range = get_device_buffer_frame_size_range(device, DeviceType::INPUT).unwrap();
+        println!(
+            "range of input buffer frame size: {}-{}",
+            range.mMinimum, range.mMaximum
+        );
     } else {
         println!("No input device.");
     }
 
     if let Some(device) = test_get_default_device(Scope::Output) {
-        let (min, max) = get_device_buffer_frame_size_range(device, DeviceType::OUTPUT).unwrap();
-        println!("range of output buffer frame size: {}-{}", min, max);
+        let range = get_device_buffer_frame_size_range(device, DeviceType::OUTPUT).unwrap();
+        println!(
+            "range of output buffer frame size: {}-{}",
+            range.mMinimum, range.mMaximum
+        );
     } else {
         println!("No output device.");
     }

--- a/src/backend/tests/device_property.rs
+++ b/src/backend/tests/device_property.rs
@@ -318,3 +318,28 @@ fn test_get_stream_latency() {
 fn test_get_stream_latency_by_unknown_device() {
     assert!(get_stream_latency(kAudioObjectUnknown, DeviceType::INPUT).is_err());
 }
+
+// get_device_sample_rate
+// ------------------------------------
+#[test]
+fn test_get_device_sample_rate() {
+    if let Some(device) = test_get_default_device(Scope::Input) {
+        let rate = get_device_sample_rate(device, DeviceType::INPUT).unwrap();
+        println!("input sample rate: {}", rate);
+    } else {
+        println!("No input device.");
+    }
+
+    if let Some(device) = test_get_default_device(Scope::Output) {
+        let rate = get_device_sample_rate(device, DeviceType::OUTPUT).unwrap();
+        println!("output sample rate: {}", rate);
+    } else {
+        println!("No output device.");
+    }
+}
+
+#[test]
+#[should_panic]
+fn test_get_device_sample_rate_by_unknown_device() {
+    assert!(get_device_sample_rate(kAudioObjectUnknown, DeviceType::INPUT).is_err());
+}

--- a/todo.md
+++ b/todo.md
@@ -11,7 +11,6 @@
   - `audiounit_get_available_samplerate`
   - `audiounit_get_device_presentation_latency`
   - `audiounit_get_acceptable_latency_range`
-  - `audiounit_get_default_datasource`
 - Merge _property_address.rs_ and _device_property.rs_
 - Support `enumerate_devices` with in-out type?
 - Monitor `kAudioDevicePropertyDeviceIsAlive` for output device.

--- a/todo.md
+++ b/todo.md
@@ -10,7 +10,6 @@
 - Create utils in device_property to replace:
   - `audiounit_get_available_samplerate`
   - `audiounit_get_device_presentation_latency`
-  - `audiounit_get_acceptable_latency_range`
 - Merge _property_address.rs_ and _device_property.rs_
 - Support `enumerate_devices` with in-out type?
 - Monitor `kAudioDevicePropertyDeviceIsAlive` for output device.

--- a/todo.md
+++ b/todo.md
@@ -6,8 +6,6 @@
 - Merge `io_side` and `DeviceType`
 - Use `ErrorChain`
 - Centralize the error log in one place
-- Create utils in device_property to replace:
-  - `audiounit_get_device_presentation_latency`
 - Merge _property_address.rs_ and _device_property.rs_
 - Support `enumerate_devices` with in-out type?
 - Monitor `kAudioDevicePropertyDeviceIsAlive` for output device.

--- a/todo.md
+++ b/todo.md
@@ -6,9 +6,7 @@
 - Merge `io_side` and `DeviceType`
 - Use `ErrorChain`
 - Centralize the error log in one place
-- Check scope for `audiounit_get_available_samplerate`
 - Create utils in device_property to replace:
-  - `audiounit_get_available_samplerate`
   - `audiounit_get_device_presentation_latency`
 - Merge _property_address.rs_ and _device_property.rs_
 - Support `enumerate_devices` with in-out type?


### PR DESCRIPTION
Move most of the APIs that queries the device information to a device-API module so the logic for the main cubeb code (_mod.rs_) will be simpler, without knowing the detail of how the API works. In addition, those APIs are simpified by using other low-level API wrappers.

r? @kinetiknz