### PR TITLE
Replace io_side by DeviceType

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1327,7 +1327,8 @@ fn set_buffer_size_sync(unit: AudioUnit, devtype: DeviceType, frames: u32) -> Re
     })?;
     if frames == current_frames {
         cubeb_log!(
-            "The size of {:?} buffer frames is already {}",
+            "The buffer frame size of AudioUnit {:?} for {:?} is already {}",
+            unit,
             devtype,
             frames
         );
@@ -1377,7 +1378,8 @@ fn set_buffer_size_sync(unit: AudioUnit, devtype: DeviceType, frames: u32) -> Re
         let (chg, timeout_res) = cvar.wait_timeout(changed, waiting_time).unwrap();
         if timeout_res.timed_out() {
             cubeb_log!(
-                "Time out for waiting the {:?} buffer size setting!",
+                "Time out for waiting the buffer frame size setting of AudioUnit {:?} for {:?}",
+                unit,
                 devtype
             );
         }
@@ -1396,7 +1398,8 @@ fn set_buffer_size_sync(unit: AudioUnit, devtype: DeviceType, frames: u32) -> Re
         Error::error()
     })?;
     cubeb_log!(
-        "The new size of {:?} buffer frames is {}",
+        "The new buffer frames size of AudioUnit {:?} for {:?} is {}",
+        unit,
         devtype,
         new_frames
     );

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1361,11 +1361,12 @@ fn set_buffer_size_sync(unit: AudioUnit, devtype: DeviceType, frames: u32) -> Re
         );
     });
 
-    set_buffer_size(unit, devtype, frames).map_err(|r| {
+    set_buffer_size(unit, devtype, frames).map_err(|e| {
         cubeb_log!(
-            "AudioUnitSetProperty/{:?}/kAudioDevicePropertyBufferFrameSize rv={}",
+            "Fail to set buffer size for AudioUnit {:?} for {:?}. Error: {}",
+            unit,
             devtype,
-            r
+            e
         );
         Error::error()
     })?;

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1316,11 +1316,12 @@ fn set_buffer_size(
 }
 
 fn set_buffer_size_sync(unit: AudioUnit, devtype: DeviceType, frames: u32) -> Result<()> {
-    let current_frames = get_buffer_size(unit, devtype).map_err(|r| {
+    let current_frames = get_buffer_size(unit, devtype).map_err(|e| {
         cubeb_log!(
-            "AudioUnitGetProperty/{:?}/kAudioDevicePropertyBufferFrameSize rv={}",
+            "Cannot get buffer size of AudioUnit {:?} for {:?}. Error: {}",
+            unit,
             devtype,
-            r
+            e
         );
         Error::error()
     })?;
@@ -1384,8 +1385,13 @@ fn set_buffer_size_sync(unit: AudioUnit, devtype: DeviceType, frames: u32) -> Re
         }
     }
 
-    let new_frames = get_buffer_size(unit, devtype).map_err(|r| {
-        cubeb_log!("Cannot get new {:?} buffer size. Error: {}", devtype, r);
+    let new_frames = get_buffer_size(unit, devtype).map_err(|e| {
+        cubeb_log!(
+            "Cannot get new buffer size of AudioUnit {:?} for {:?}. Error: {}",
+            unit,
+            devtype,
+            e
+        );
         Error::error()
     })?;
     cubeb_log!(

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -31,16 +31,6 @@ fn test_make_sized_audio_channel_layout_with_wrong_size() {
     let _ = make_sized_audio_channel_layout(wrong_size);
 }
 
-// to_string
-// ------------------------------------
-#[test]
-fn test_to_string() {
-    let input = io_side::INPUT;
-    assert_eq!(input.to_string(), "input");
-    let output = io_side::OUTPUT;
-    assert_eq!(output.to_string(), "output");
-}
-
 // has_input
 // ------------------------------------
 // TODO
@@ -951,7 +941,7 @@ fn test_set_channel_layout_output() {
     let source = source.unwrap();
     let unit = unit.unwrap();
     if let Some(layout) = devices_layouts.get(source.as_str()) {
-        assert!(audiounit_set_channel_layout(unit.get_inner(), io_side::OUTPUT, *layout).is_ok());
+        assert!(audiounit_set_channel_layout(unit.get_inner(), *layout).is_ok());
         assert_eq!(
             audiounit_get_current_channel_layout(unit.get_inner()),
             *layout
@@ -967,12 +957,7 @@ fn test_set_channel_layout_output_undefind() {
         // Get original layout.
         let original_layout = audiounit_get_current_channel_layout(unit.get_inner());
         // Leave layout as it is.
-        assert!(audiounit_set_channel_layout(
-            unit.get_inner(),
-            io_side::OUTPUT,
-            ChannelLayout::UNDEFINED
-        )
-        .is_ok());
+        assert!(audiounit_set_channel_layout(unit.get_inner(), ChannelLayout::UNDEFINED).is_ok());
         // Check the layout is same as the original one.
         assert_eq!(
             audiounit_get_current_channel_layout(unit.get_inner()),
@@ -986,14 +971,14 @@ fn test_set_channel_layout_output_undefind() {
 #[test]
 fn test_set_channel_layout_input() {
     if let Some(unit) = test_get_default_audiounit(Scope::Input) {
+        // Get original layout.
+        let original_layout = audiounit_get_current_channel_layout(unit.get_inner());
+        // Leave layout as it is.
+        assert!(audiounit_set_channel_layout(unit.get_inner(), ChannelLayout::UNDEFINED).is_ok());
+        // Check the layout is same as the original one.
         assert_eq!(
-            audiounit_set_channel_layout(
-                unit.get_inner(),
-                io_side::INPUT,
-                ChannelLayout::UNDEFINED
-            )
-            .unwrap_err(),
-            Error::error()
+            audiounit_get_current_channel_layout(unit.get_inner()),
+            original_layout
         );
     } else {
         println!("No input audiounit.");
@@ -1003,12 +988,7 @@ fn test_set_channel_layout_input() {
 #[test]
 #[should_panic]
 fn test_set_channel_layout_with_null_unit() {
-    assert!(audiounit_set_channel_layout(
-        ptr::null_mut(),
-        io_side::OUTPUT,
-        ChannelLayout::UNDEFINED
-    )
-    .is_err());
+    assert!(audiounit_set_channel_layout(ptr::null_mut(), ChannelLayout::UNDEFINED).is_err());
 }
 
 // create_default_audiounit
@@ -1044,10 +1024,10 @@ fn test_enable_audiounit_scope() {
     // for the unit whose subtype is kAudioUnitSubType_HALOutput
     // even when there is no available input or output devices.
     if let Some(unit) = test_create_audiounit(ComponentSubType::HALOutput) {
-        assert!(enable_audiounit_scope(unit.get_inner(), io_side::OUTPUT, true).is_ok());
-        assert!(enable_audiounit_scope(unit.get_inner(), io_side::OUTPUT, false).is_ok());
-        assert!(enable_audiounit_scope(unit.get_inner(), io_side::INPUT, true).is_ok());
-        assert!(enable_audiounit_scope(unit.get_inner(), io_side::INPUT, false).is_ok());
+        assert!(enable_audiounit_scope(unit.get_inner(), DeviceType::OUTPUT, true).is_ok());
+        assert!(enable_audiounit_scope(unit.get_inner(), DeviceType::OUTPUT, false).is_ok());
+        assert!(enable_audiounit_scope(unit.get_inner(), DeviceType::INPUT, true).is_ok());
+        assert!(enable_audiounit_scope(unit.get_inner(), DeviceType::INPUT, false).is_ok());
     } else {
         println!("No audiounit to perform test.");
     }
@@ -1057,19 +1037,19 @@ fn test_enable_audiounit_scope() {
 fn test_enable_audiounit_scope_for_default_output_unit() {
     if let Some(unit) = test_create_audiounit(ComponentSubType::DefaultOutput) {
         assert_eq!(
-            enable_audiounit_scope(unit.get_inner(), io_side::OUTPUT, true).unwrap_err(),
+            enable_audiounit_scope(unit.get_inner(), DeviceType::OUTPUT, true).unwrap_err(),
             kAudioUnitErr_InvalidProperty
         );
         assert_eq!(
-            enable_audiounit_scope(unit.get_inner(), io_side::OUTPUT, false).unwrap_err(),
+            enable_audiounit_scope(unit.get_inner(), DeviceType::OUTPUT, false).unwrap_err(),
             kAudioUnitErr_InvalidProperty
         );
         assert_eq!(
-            enable_audiounit_scope(unit.get_inner(), io_side::INPUT, true).unwrap_err(),
+            enable_audiounit_scope(unit.get_inner(), DeviceType::INPUT, true).unwrap_err(),
             kAudioUnitErr_InvalidProperty
         );
         assert_eq!(
-            enable_audiounit_scope(unit.get_inner(), io_side::INPUT, false).unwrap_err(),
+            enable_audiounit_scope(unit.get_inner(), DeviceType::INPUT, false).unwrap_err(),
             kAudioUnitErr_InvalidProperty
         );
     }
@@ -1079,7 +1059,7 @@ fn test_enable_audiounit_scope_for_default_output_unit() {
 #[should_panic]
 fn test_enable_audiounit_scope_with_null_unit() {
     let unit: AudioUnit = ptr::null_mut();
-    assert!(enable_audiounit_scope(unit, io_side::INPUT, false).is_err());
+    assert!(enable_audiounit_scope(unit, DeviceType::INPUT, false).is_err());
 }
 
 // create_audiounit

--- a/src/backend/tests/utils.rs
+++ b/src/backend/tests/utils.rs
@@ -8,15 +8,6 @@ pub enum Scope {
     Output,
 }
 
-impl From<Scope> for io_side {
-    fn from(scope: Scope) -> Self {
-        match scope {
-            Scope::Input => io_side::INPUT,
-            Scope::Output => io_side::OUTPUT,
-        }
-    }
-}
-
 impl From<Scope> for DeviceType {
     fn from(scope: Scope) -> Self {
         match scope {

--- a/todo.md
+++ b/todo.md
@@ -4,8 +4,6 @@
 - Some of bugs are found when adding tests. Search *FIXIT* to find them.
 - Remove `#[allow(non_camel_case_types)]`, `#![allow(unused_assignments)]`, `#![allow(unused_must_use)]`
 - Rephrase the error messages for those APIs use `io_side` previously
-    - `get_buffer_size`
-        - Revise the error message when `get_buffer_size` is failed in `set_buffer_size_sync`
     - `set_buffer_size`
         - Revise the error message when `set_buffer_size` is failed in `set_buffer_size_sync`
     - `set_buffer_size_sync`

--- a/todo.md
+++ b/todo.md
@@ -3,7 +3,16 @@
 ## General
 - Some of bugs are found when adding tests. Search *FIXIT* to find them.
 - Remove `#[allow(non_camel_case_types)]`, `#![allow(unused_assignments)]`, `#![allow(unused_must_use)]`
-- Merge `io_side` and `DeviceType`
+- Rephrase the error messages for those APIs use `io_side` previously
+    - `audiounit_set_channel_layout`
+        - return `OSStatus` for error
+        - Log error in `setup` instead
+    - `get_buffer_size`
+        - Revise the error message when `get_buffer_size` is failed in `set_buffer_size_sync`
+    - `set_buffer_size`
+        - Revise the error message when `set_buffer_size` is failed in `set_buffer_size_sync`
+    - `set_buffer_size_sync`
+        - Check if the error messages using `DeviceType` should be revised
 - Use `ErrorChain`
 - Centralize the error log in one place
 - Merge _property_address.rs_ and _device_property.rs_

--- a/todo.md
+++ b/todo.md
@@ -4,9 +4,6 @@
 - Some of bugs are found when adding tests. Search *FIXIT* to find them.
 - Remove `#[allow(non_camel_case_types)]`, `#![allow(unused_assignments)]`, `#![allow(unused_must_use)]`
 - Rephrase the error messages for those APIs use `io_side` previously
-    - `audiounit_set_channel_layout`
-        - return `OSStatus` for error
-        - Log error in `setup` instead
     - `get_buffer_size`
         - Revise the error message when `get_buffer_size` is failed in `set_buffer_size_sync`
     - `set_buffer_size`

--- a/todo.md
+++ b/todo.md
@@ -4,8 +4,6 @@
 - Some of bugs are found when adding tests. Search *FIXIT* to find them.
 - Remove `#[allow(non_camel_case_types)]`, `#![allow(unused_assignments)]`, `#![allow(unused_must_use)]`
 - Rephrase the error messages for those APIs use `io_side` previously
-    - `set_buffer_size`
-        - Revise the error message when `set_buffer_size` is failed in `set_buffer_size_sync`
     - `set_buffer_size_sync`
         - Check if the error messages using `DeviceType` should be revised
 - Use `ErrorChain`

--- a/todo.md
+++ b/todo.md
@@ -3,9 +3,6 @@
 ## General
 - Some of bugs are found when adding tests. Search *FIXIT* to find them.
 - Remove `#[allow(non_camel_case_types)]`, `#![allow(unused_assignments)]`, `#![allow(unused_must_use)]`
-- Rephrase the error messages for those APIs use `io_side` previously
-    - `set_buffer_size_sync`
-        - Check if the error messages using `DeviceType` should be revised
 - Use `ErrorChain`
 - Centralize the error log in one place
 - Merge _property_address.rs_ and _device_property.rs_


### PR DESCRIPTION
The usage of `io_side` is similar to `DeviceType`. Both of them are used to declare what the scope of the `AudioUnit` or the audio device is. The only difference is that `io_side` has no in-out type. In those functions that have `io_side` parameters, we could replace `io_side` by `DeviceType` with checking the scope are either `DeviceType::INPUT` or `DeviceType::OUTPUT`. As a result, we don't need to maintain two similar struct for the same usage. 