### PR TITLE
Change the policy of aggregate usage

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2433,11 +2433,7 @@ impl<'ctx> CoreStreamData<'ctx> {
         self.output_stream_params.rate() > 0
     }
 
-    fn should_use_aggregate_device(
-        &self,
-        input_device: &device_info,
-        output_device: &device_info,
-    ) -> bool {
+    fn should_use_aggregate_device(&self) -> bool {
         // Only using aggregate device when
         // 1. Stream is duplex
         // 2. Input device is valid
@@ -2455,13 +2451,13 @@ impl<'ctx> CoreStreamData<'ctx> {
         // input and output or not.
         self.has_input()
             && self.has_output()
-            && input_device.id != kAudioObjectUnknown
-            && input_device.flags.contains(device_flags::DEV_INPUT)
-            && output_device.id != kAudioObjectUnknown
-            && output_device.flags.contains(device_flags::DEV_OUTPUT)
-            && input_device.id != output_device.id
-            && !is_device_a_type_of(input_device.id, DeviceType::OUTPUT)
-            && !is_device_a_type_of(output_device.id, DeviceType::INPUT)
+            && self.input_device.id != kAudioObjectUnknown
+            && self.input_device.flags.contains(device_flags::DEV_INPUT)
+            && self.output_device.id != kAudioObjectUnknown
+            && self.output_device.flags.contains(device_flags::DEV_OUTPUT)
+            && self.input_device.id != self.output_device.id
+            && !is_device_a_type_of(self.input_device.id, DeviceType::OUTPUT)
+            && !is_device_a_type_of(self.output_device.id, DeviceType::INPUT)
     }
 
     fn setup(&mut self) -> Result<()> {
@@ -2481,7 +2477,7 @@ impl<'ctx> CoreStreamData<'ctx> {
         let mut in_dev_info = self.input_device.clone();
         let mut out_dev_info = self.output_device.clone();
 
-        if self.should_use_aggregate_device(&in_dev_info, &out_dev_info) {
+        if self.should_use_aggregate_device() {
             match AggregateDevice::new(in_dev_info.id, out_dev_info.id) {
                 Ok(device) => {
                     in_dev_info.id = device.get_device_id();

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2434,21 +2434,9 @@ impl<'ctx> CoreStreamData<'ctx> {
     }
 
     fn should_use_aggregate_device(&self) -> bool {
-        // Only using aggregate device when
-        // 1. Stream is duplex
-        // 2. Input device is valid
-        // 3. Output device is valid
-        // 4. Input device and output device are different (based on their device id)
-        //   Some headset with mic will show different device ids for its
-        //   input and output, e.g., AirPods. They will be treated as different devices.
-        // 5. Input device is a microphone only device
-        // 6. Output device is a speaker only device
-        //   headset with mic is not a mic only and not a speaker only device
-
-        // Note that the `output_device` will be set anyway when reinitializing the stream,
-        // so we cannot rely on the `input_device` and `output_device` only. We must check
-        // `self.has_input()` and `self.has_output()` so we can make sure if the stream has
-        // input and output or not.
+        // Only using aggregate device when the input is a mic-only device and the output is a
+        // speaker-only device. Otherwise, the mic on the output device may become the main
+        // microphone of the aggregate device for this duplex stream.
         self.has_input()
             && self.has_output()
             && self.input_device.id != kAudioObjectUnknown

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1455,6 +1455,11 @@ fn audiounit_get_default_datasource_string(devtype: DeviceType) -> Result<CStrin
     Ok(convert_uint32_into_string(data))
 }
 
+fn is_device_a_type_of(devid: AudioObjectID, devtype: DeviceType) -> bool {
+    assert_ne!(devid, kAudioObjectUnknown);
+    get_channel_count(devid, devtype).unwrap_or(0) > 0
+}
+
 fn get_channel_count(devid: AudioObjectID, devtype: DeviceType) -> Result<u32> {
     assert_ne!(devid, kAudioObjectUnknown);
 

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1351,6 +1351,22 @@ fn test_get_default_device_name() {
 // ------------------------------------
 // TODO
 
+// is_device_a_type_of
+// ------------------------------------
+#[test]
+fn test_is_device_a_type_of() {
+    test_is_device_in_scope(Scope::Input);
+    test_is_device_in_scope(Scope::Output);
+
+    fn test_is_device_in_scope(scope: Scope) {
+        if let Some(device) = test_get_default_device(scope.clone()) {
+            assert!(is_device_a_type_of(device, scope.into()));
+        } else {
+            println!("No device for {:?}.", scope);
+        }
+    }
+}
+
 // get_channel_count
 // ------------------------------------
 #[test]

--- a/todo.md
+++ b/todo.md
@@ -21,6 +21,7 @@
 
 ### Generics
 - Create a _generics_ for `input_linear_buffer`
+    - Consider replacing `AutoArrayWrapper` by [`ringbuf`](https://github.com/agerasev/ringbuf)
 
 ## Separate the stream implementation from the interface
 The goal is to separate the audio stream into two parts(modules).

--- a/todo.md
+++ b/todo.md
@@ -11,6 +11,13 @@
 - Create a wrapper for `CFArrayCreateMutable` like what we do for `CFMutableDictionaryRef`
 - Create a wrapper for property listener’s callback
 - Change to official _coreaudio-sys_ after [pull #28](https://github.com/RustAudio/coreaudio-sys/pull/28) is is merged
+- Use `Option<AggregateDevice>` rather than `AggregateDevice` for `aggregate_device` in `CoreStreamData`
+
+### Type of stream
+- Use `Option<device_info>` rather than `device_info` for `{input, output}_device` in `CoreStreamData`
+- Use `Option<StreamParams>` rather than `StreamParams` for `{input, output}_stream_params` in `CoreStreamData`
+- Same as `{input, output}_desc`, `{input, output}_hw_rate`, ...etc
+- It would much clearer if we have a `struct X` to wrap all the above stuff and use `input_x` and `output_x` in `CoreStreamData`
 
 ### Generics
 - Create a _generics_ for `input_linear_buffer`
@@ -41,6 +48,7 @@ and create a new one. It's easier than the current implementation.
 ## Aggregate device
 ### Usage policy
 - [BMO 1563475][bmo1563475]: Only use _aggregate device_ when the mic is a input-only and the speaker is output-only device.
+- Test if we should do drift compensation.
 
 [bmo1563475]: https://bugzilla.mozilla.org/show_bug.cgi?id=1563475#c4
 ### Get sub devices

--- a/todo.md
+++ b/todo.md
@@ -49,6 +49,14 @@ and create a new one. It's easier than the current implementation.
 ### Usage policy
 - [BMO 1563475][bmo1563475]: Only use _aggregate device_ when the mic is a input-only and the speaker is output-only device.
 - Test if we should do drift compensation.
+- Add a test for `should_use_aggregate_device`
+    - Create a dummy stream and check
+    - Check again after reinit
+        - Input only: expect false
+        - Output only: expect false
+        - Duplex
+            - Default input and output are different and they are mic-only and speaker-only: expect true
+            - Otherwise: expect false
 
 [bmo1563475]: https://bugzilla.mozilla.org/show_bug.cgi?id=1563475#c4
 ### Get sub devices


### PR DESCRIPTION
In some case, the cubeb stream will use an unexpected mic rather than the one we choose. The STR can be found in [BMO 1563475](https://bugzilla.mozilla.org/show_bug.cgi?id=1563475). That is because we use aggregate device. If the output device is a headset with mic, when we select another mic as the input device, we will create an aggregate device as the input and output devices in the cubeb stream. However, the main mic is likely to be set to the mic within the headset, which is an unexpected choice for users. We should change our policy to use aggregate device when

1. the input device and output device are different
2. the input device is a microphone-only device
3. the output device is a speaker-only device
