### PR TITLE
Improve device switch tests

### DIFF
--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -31,14 +31,6 @@ fn test_make_sized_audio_channel_layout_with_wrong_size() {
     let _ = make_sized_audio_channel_layout(wrong_size);
 }
 
-// has_input
-// ------------------------------------
-// TODO
-
-// has_output
-// ------------------------------------
-// TODO
-
 // channel_label_to_cubeb_channel
 // ------------------------------------
 // Convert a CAChannelLabel into a ChannelLayout
@@ -264,14 +256,6 @@ fn test_make_silent() {
     }
 }
 
-// render_input
-// ------------------------------------
-// TODO
-
-// input_callback
-// ------------------------------------
-// TODO
-
 // minimum_resampling_input_frames
 // ------------------------------------
 #[test]
@@ -309,10 +293,6 @@ fn test_minimum_resampling_input_frames_equal_input_output_rate() {
         frames
     );
 }
-
-// output_callback
-// ------------------------------------
-// TODO
 
 // create_device_info
 // ------------------------------------
@@ -377,22 +357,6 @@ fn test_set_device_info_to_nonexistent_output_device() {
     let nonexistent_id = std::u32::MAX;
     let _device = create_device_info(nonexistent_id, DeviceType::OUTPUT);
 }
-
-// reinit_stream
-// ------------------------------------
-// TODO
-
-// reinit_stream_async
-// ------------------------------------
-// TODO
-
-// event_addr_to_string
-// ------------------------------------
-// TODO
-
-// property_listener_callback
-// ------------------------------------
-// TODO
 
 // add_listener (for default output device)
 // ------------------------------------
@@ -504,14 +468,6 @@ fn test_remove_listener_unknown_device() {
         );
     });
 }
-
-// install_system_changed_callback
-// ------------------------------------
-// TODO
-
-// uninstall_system_changed_callback
-// ------------------------------------
-// TODO
 
 // get_default_device_id
 // ------------------------------------
@@ -834,11 +790,6 @@ fn test_get_preferred_channel_layout_output() {
     }
 }
 
-// TODO: Should it be banned ? It only works with output audiounit for now.
-// #[test]
-// fn test_get_preferred_channel_layout_input() {
-// }
-
 // get_current_channel_layout
 // ------------------------------------
 #[test]
@@ -872,11 +823,6 @@ fn test_get_current_channel_layout_output() {
         println!("Device {} is not in the whitelist.", source);
     }
 }
-
-// TODO: Should it be banned ? It only works with output audiounit for now.
-// #[test]
-// fn test_get_current_channel_layout_input() {
-// }
 
 // create_stream_description
 // ------------------------------------
@@ -1290,30 +1236,6 @@ fn test_set_buffer_size_sync_by_scope_with_null_unit(scope: Scope) {
     assert!(set_buffer_size_sync(unit, scope.into(), 2048).is_err());
 }
 
-// setup_stream
-// ------------------------------------
-// TODO
-
-// stream_destroy_internal
-// ------------------------------------
-// TODO
-
-// stream_destroy
-// ------------------------------------
-// TODO
-
-// stream_start_internal
-// ------------------------------------
-// TODO
-
-// stream_start
-// ------------------------------------
-// TODO
-
-// stream_stop_internal
-// ------------------------------------
-// TODO
-
 // get_volume, set_volume
 // ------------------------------------
 #[test]
@@ -1358,10 +1280,6 @@ fn test_get_default_device_name() {
         }
     }
 }
-
-// strref_to_cstr_utf8
-// ------------------------------------
-// TODO
 
 // is_device_a_type_of
 // ------------------------------------

--- a/src/backend/tests/device_change.rs
+++ b/src/backend/tests/device_change.rs
@@ -44,7 +44,7 @@ fn test_switch_device_in_scope(scope: Scope) {
         scope
     );
 
-    let device_switcher = TestDeviceSwitcher::new(scope.clone());
+    let mut device_switcher = TestDeviceSwitcher::new(scope.clone());
 
     let count = Arc::new(Mutex::new(0));
     let also_count = Arc::clone(&count);
@@ -59,7 +59,7 @@ fn test_switch_device_in_scope(scope: Scope) {
     test_get_started_stream_in_scope(scope.clone(), move |_stream| loop {
         thread::sleep(Duration::from_millis(500));
         changed_watcher.prepare();
-        assert!(device_switcher.next().unwrap());
+        device_switcher.next();
         changed_watcher.wait_for_change();
         if changed_watcher.current_result() >= devices.len() {
             break;
@@ -354,8 +354,8 @@ fn test_register_device_changed_callback_to_check_default_device_changed(stm_typ
         0
     };
 
-    let input_device_switcher = TestDeviceSwitcher::new(Scope::Input);
-    let output_device_switcher = TestDeviceSwitcher::new(Scope::Output);
+    let mut input_device_switcher = TestDeviceSwitcher::new(Scope::Input);
+    let mut output_device_switcher = TestDeviceSwitcher::new(Scope::Output);
 
     test_get_stream_with_device_changed_callback(
         "stream: test callback for default device changed",
@@ -378,7 +378,7 @@ fn test_register_device_changed_callback_to_check_default_device_changed(stm_typ
                 // switching for the default device again will be ignored.
                 while stream.switching_device.load(atomic::Ordering::SeqCst) {}
                 changed_watcher.prepare();
-                assert!(input_device_switcher.next().unwrap());
+                input_device_switcher.next();
                 changed_watcher.wait_for_change();
             }
 
@@ -387,7 +387,7 @@ fn test_register_device_changed_callback_to_check_default_device_changed(stm_typ
                 // switching for the default device again will be ignored.
                 while stream.switching_device.load(atomic::Ordering::SeqCst) {}
                 changed_watcher.prepare();
-                assert!(output_device_switcher.next().unwrap());
+                output_device_switcher.next();
                 changed_watcher.wait_for_change();
             }
         },

--- a/src/backend/tests/device_change.rs
+++ b/src/backend/tests/device_change.rs
@@ -17,8 +17,8 @@
 use super::utils::{
     test_create_device_change_listener, test_device_in_scope, test_get_default_device,
     test_get_devices_in_scope, test_get_stream_with_default_callbacks_by_type,
-    test_ops_stream_operation, test_set_default_device, Scope, StreamType, TestDevicePlugger,
-    TestDeviceSwitcher,
+    test_ops_stream_operation, test_print_devices_in_scope, test_set_default_device, Scope,
+    StreamType, TestDevicePlugger, TestDeviceSwitcher,
 };
 use super::*;
 use std::fmt::Debug;
@@ -32,6 +32,8 @@ fn test_switch_device() {
 }
 
 fn test_switch_device_in_scope(scope: Scope) {
+    test_print_devices_in_scope(scope.clone());
+
     // Do nothing if there is no 2 available devices at least.
     let devices = test_get_devices_in_scope(scope.clone());
     if devices.len() < 2 {

--- a/src/backend/tests/device_change.rs
+++ b/src/backend/tests/device_change.rs
@@ -17,8 +17,8 @@
 use super::utils::{
     test_create_device_change_listener, test_device_in_scope, test_get_default_device,
     test_get_devices_in_scope, test_get_stream_with_default_callbacks_by_type,
-    test_ops_stream_operation, test_print_devices_in_scope, test_set_default_device, Scope,
-    StreamType, TestDevicePlugger, TestDeviceSwitcher,
+    test_ops_stream_operation, test_set_default_device, Scope, StreamType, TestDevicePlugger,
+    TestDeviceSwitcher,
 };
 use super::*;
 use std::fmt::Debug;
@@ -32,8 +32,6 @@ fn test_switch_device() {
 }
 
 fn test_switch_device_in_scope(scope: Scope) {
-    test_print_devices_in_scope(scope.clone());
-
     // Do nothing if there is no 2 available devices at least.
     let devices = test_get_devices_in_scope(scope.clone());
     if devices.len() < 2 {

--- a/src/backend/tests/manual.rs
+++ b/src/backend/tests/manual.rs
@@ -19,7 +19,7 @@ fn test_switch_output_device() {
         return;
     }
 
-    let output_device_switcher = TestDeviceSwitcher::new(Scope::Output);
+    let mut output_device_switcher = TestDeviceSwitcher::new(Scope::Output);
 
     // Make sure the parameters meet the requirements of AudioUnitContext::stream_init
     // (in the comments).
@@ -52,7 +52,7 @@ fn test_switch_output_device() {
                 assert_eq!(input.pop().unwrap(), '\n');
                 match input.as_str() {
                     "s" => {
-                        assert!(output_device_switcher.next().unwrap());
+                        output_device_switcher.next();
                     }
                     "q" => {
                         println!("Quit.");

--- a/src/backend/tests/utils.rs
+++ b/src/backend/tests/utils.rs
@@ -293,6 +293,50 @@ pub fn test_get_devices_in_scope(scope: Scope) -> Vec<AudioObjectID> {
     devices
 }
 
+pub fn test_print_devices_in_scope(scope: Scope) {
+    #[derive(Debug)]
+    struct Info {
+        id: AudioObjectID,
+        label: String,
+        uid: String,
+    }
+    impl Info {
+        fn new(id: AudioObjectID, label: String, uid: String) -> Self {
+            Self { id, label, uid }
+        }
+    }
+
+    let mut infos = Vec::new();
+    let devices = test_get_devices_in_scope(scope.clone());
+    for device in devices {
+        let label = match get_device_label(device, scope.clone().into()) {
+            Ok(label) => label.into_string(),
+            Err(status) => format!("Unknown: Error: {}", status).to_string(),
+        };
+
+        let uid = match get_device_uid(device, scope.clone().into()) {
+            Ok(uid) => uid.into_string(),
+            Err(status) => format!("Unknow: Error: {}", status).to_string(),
+        };
+
+        infos.push(Info::new(device, label, uid));
+    }
+
+    println!(
+        "\n{:?} devices\n\
+         --------------------",
+        scope
+    );
+    for info in infos {
+        print_info(&info);
+    }
+    println!("");
+
+    fn print_info(info: &Info) {
+        println!("{:>4}: {}\n\tuid: {}", info.id, info.label, info.uid);
+    }
+}
+
 pub fn test_device_channels_in_scope(
     id: AudioObjectID,
     scope: Scope,

--- a/src/backend/tests/utils.rs
+++ b/src/backend/tests/utils.rs
@@ -552,9 +552,11 @@ pub struct TestDeviceSwitcher {
 
 impl TestDeviceSwitcher {
     pub fn new(scope: Scope) -> Self {
+        let devices = test_get_devices_in_scope(scope.clone());
+        println!("{:?} devices: {:?}", scope, devices);
         Self {
-            scope: scope.clone(),
-            devices: test_get_devices_in_scope(scope),
+            scope: scope,
+            devices: devices,
         }
     }
 


### PR DESCRIPTION
1. The current device's index of the cached devices will be calculated every time when the DeviceSwitcher.next is called. We should calculate it once the DeviceSwitcher is created and cache it. However, it will also add a limit that devices are not allowed to be changed during the device-changing test since they are cached and assumed to be valid during the whole test.
2. Show the available device list before rotating/switching them is extremely useful for debugging. When the aggregate device is created accidentally in the stream reinitialization when I was working in https://github.com/ChunMinChang/cubeb-coreaudio-rs/pull/13, the `test_switch_device` fails. The reason is that the created aggregate device will be cached as one of the available candidates of the default device. However, it will be destroyed already when it's set to the default device. Showing all the cached devices is useful to know whether we cache some invalid devices that would be assigned to default devices.