### PR TITLE
Fix draining

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -756,18 +756,19 @@ extern "C" fn audiounit_output_callback(
         // Post process output samples.
         if stm.draining.load(Ordering::SeqCst) {
             // Clear missing frames (silence)
-            let count_bytes = |frames: usize| -> usize {
+            let frames_to_bytes = |frames: usize| -> usize {
                 let sample_size =
                     cubeb_sample_size(stm.core_stream_data.output_stream_params.format());
-                frames * sample_size / mem::size_of::<u8>()
+                let channel_count = stm.core_stream_data.output_desc.mChannelsPerFrame as usize;
+                frames * sample_size * channel_count
             };
             let out_bytes = unsafe {
                 slice::from_raw_parts_mut(
                     output_buffer as *mut u8,
-                    count_bytes(output_frames as usize),
+                    frames_to_bytes(output_frames as usize),
                 )
             };
-            let start = count_bytes(outframes as usize);
+            let start = frames_to_bytes(outframes as usize);
             for i in start..out_bytes.len() {
                 out_bytes[i] = 0;
             }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -759,7 +759,7 @@ extern "C" fn audiounit_output_callback(
             let frames_to_bytes = |frames: usize| -> usize {
                 let sample_size =
                     cubeb_sample_size(stm.core_stream_data.output_stream_params.format());
-                let channel_count = stm.core_stream_data.output_desc.mChannelsPerFrame as usize;
+                let channel_count = stm.core_stream_data.output_stream_params.channels() as usize;
                 frames * sample_size * channel_count
             };
             let out_bytes = unsafe {


### PR DESCRIPTION
Same fix as https://github.com/kinetiknz/cubeb/pull/546. This only seem to matter in practice when remoting is enabled, because the buffers are not zeroed out.