### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,4 @@ before_script:
   - cargo --version
 script:
   - cargo build --verbose
-  - cargo test --verbose
   - sh run_tests.sh

--- a/coreaudio-sys-utils/Cargo.toml
+++ b/coreaudio-sys-utils/Cargo.toml
@@ -10,5 +10,4 @@ core-foundation-sys = { version = "0.6" }
 [dependencies.coreaudio-sys]
 default-features = false
 features = ["audio_unit", "core_audio"]
-git = "https://github.com/ChunMinChang/coreaudio-sys"
-branch = "gecko-build"
+version = "0.2"


### PR DESCRIPTION
Use official [coreaudio-sys](https://github.com/RustAudio/coreaudio-sys) instead of the custom version for gecko.