### PR TITLE
Make utf8_from_cfstringref work with empty CFStringRef

### DIFF
--- a/coreaudio-sys-utils/src/string.rs
+++ b/coreaudio-sys-utils/src/string.rs
@@ -81,7 +81,9 @@ fn utf8_from_cfstringref(string_ref: CFStringRef) -> Vec<u8> {
     assert!(!string_ref.is_null());
 
     let length: CFIndex = unsafe { CFStringGetLength(string_ref) };
-    assert!(length > 0);
+    if length == 0 {
+        return Vec::new();
+    }
 
     // Get the buffer size of the string.
     let range: CFRange = CFRange {
@@ -127,6 +129,7 @@ mod test {
     use super::*;
 
     const STATIC_STRING: &str = "static string for testing";
+    const STATIC_EMPTY_STRING: &str = "";
 
     #[test]
     fn test_create_static_cfstring_ref() {
@@ -141,8 +144,29 @@ mod test {
     }
 
     #[test]
+    fn test_create_static_empty_cfstring_ref() {
+        let stringref =
+            StringRef::new(cfstringref_from_static_string(STATIC_EMPTY_STRING) as CFStringRef);
+        assert_eq!(STATIC_EMPTY_STRING, stringref.to_string());
+        assert_eq!(
+            CString::new(STATIC_EMPTY_STRING).unwrap(),
+            stringref.into_cstring()
+        );
+        // TODO: Find a way to check the string's inner pointer is same.
+    }
+
+    #[test]
     fn test_create_cfstring_ref() {
         let expected = "Rustaceans 🦀";
+        let stringref = StringRef::new(cfstringref_from_string(expected) as CFStringRef);
+        assert_eq!(expected, stringref.to_string());
+        assert_eq!(CString::new(expected).unwrap(), stringref.into_cstring());
+        // TODO: Find a way to check the string's inner pointer is different.
+    }
+
+    #[test]
+    fn test_create_empty_cfstring_ref() {
+        let expected = "";
         let stringref = StringRef::new(cfstringref_from_string(expected) as CFStringRef);
         assert_eq!(expected, stringref.to_string());
         assert_eq!(CString::new(expected).unwrap(), stringref.into_cstring());

--- a/coreaudio-sys-utils/src/string.rs
+++ b/coreaudio-sys-utils/src/string.rs
@@ -128,11 +128,9 @@ fn utf8_from_cfstringref(string_ref: CFStringRef) -> Vec<u8> {
 mod test {
     use super::*;
 
-    const STATIC_STRING: &str = "static string for testing";
-    const STATIC_EMPTY_STRING: &str = "";
-
     #[test]
     fn test_create_static_cfstring_ref() {
+        const STATIC_STRING: &str = "static string for testing";
         let stringref =
             StringRef::new(cfstringref_from_static_string(STATIC_STRING) as CFStringRef);
         assert_eq!(STATIC_STRING, stringref.to_string());
@@ -145,6 +143,7 @@ mod test {
 
     #[test]
     fn test_create_static_empty_cfstring_ref() {
+        const STATIC_EMPTY_STRING: &str = "";
         let stringref =
             StringRef::new(cfstringref_from_static_string(STATIC_EMPTY_STRING) as CFStringRef);
         assert_eq!(STATIC_EMPTY_STRING, stringref.to_string());


### PR DESCRIPTION
Passing a `CFStringRef `whose internal string is `""` (empty) to
`StringRef::utf8_from_cfstringref` will hit an assertion that asserts the passed
`CFStringRef` cannot be empty. Instead of using the assertion, an empty `u8`
`Vec` should be returned directly when the passed `CFStringRef` is empty,
which will yield an empty `String` or `CString` in `StringRef::to_string` or `StringRef::to_cstring`.