### PR TITLE
Make audiounit_get_devices_of_type infallible

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1758,10 +1758,19 @@ fn audiounit_get_devices_of_type(devtype: DeviceType) -> Vec<AudioObjectID> {
 
     let mut devices_in_scope = Vec::new();
     for device in devices {
+        let label = match get_device_label(device, DeviceType::OUTPUT | DeviceType::INPUT) {
+            Ok(label) => label.into_string(),
+            Err(e) => format!("Unknown(error: {})", e),
+        };
+        let info = format!("{} ({})", device, label);
+
         if let Ok(channels) = get_channel_count(device, devtype) {
+            cubeb_log!("device {} has {} {:?}-channels", info, channels, devtype);
             if channels > 0 {
                 devices_in_scope.push(device);
             }
+        } else {
+            cubeb_log!("Cannot get the channel count for device {}. Ignored.", info);
         }
     }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1758,8 +1758,10 @@ fn audiounit_get_devices_of_type(devtype: DeviceType) -> Vec<AudioObjectID> {
 
     let mut devices_in_scope = Vec::new();
     for device in devices {
-        if get_channel_count(device, devtype).unwrap() > 0 {
-            devices_in_scope.push(device);
+        if let Ok(channels) = get_channel_count(device, devtype) {
+            if channels > 0 {
+                devices_in_scope.push(device);
+            }
         }
     }
 


### PR DESCRIPTION
Unwrapping a failed result from `get_channel_count` will lead to a panic in `audiounit_get_devices_of_type`. This might be the cause of [BMO 1590151][b1590151].

[b1590151]: https://bugzilla.mozilla.org/show_bug.cgi?id=1590151