### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ crate-type = ["staticlib", "rlib"]
 [dependencies]
 atomic = "0.4"
 bitflags = "1.0"
-core-foundation-sys = { version = "0.6" }
 coreaudio-sys-utils = { path = "coreaudio-sys-utils" }
 cubeb-backend = "0.6"
 libc = "0.2"

--- a/coreaudio-sys-utils/Cargo.toml
+++ b/coreaudio-sys-utils/Cargo.toml
@@ -10,4 +10,4 @@ core-foundation-sys = { version = "0.6" }
 [dependencies.coreaudio-sys]
 default-features = false
 features = ["audio_unit", "core_audio"]
-version = "0.2.3"
+version = "0.2"

--- a/coreaudio-sys-utils/Cargo.toml
+++ b/coreaudio-sys-utils/Cargo.toml
@@ -10,4 +10,4 @@ core-foundation-sys = { version = "0.6" }
 [dependencies.coreaudio-sys]
 default-features = false
 features = ["audio_unit", "core_audio"]
-version = "0.2"
+version = "0.2.3"


### PR DESCRIPTION
- Remove unused _core-foundation-sys_ dependency. The _core-foundation-sys_ is imported for `CFStringRef` previously, which is wrapped into a `StringRef` in _coreaudio-sys-utils_.
- Bump _coreaudio-sys_ to 0.2.3 that fixes the cross-compiling issue.