### PR TITLE
Add manual tests

### DIFF
--- a/coreaudio-sys-utils/src/dispatch.rs
+++ b/coreaudio-sys-utils/src/dispatch.rs
@@ -54,13 +54,13 @@ where
         F: FnOnce(),
     {
         // Retake the leaked closure.
-        let closure: Box<F> = unsafe { Box::from_raw(unboxed_closure as *mut F) };
+        let closure = unsafe { Box::from_raw(unboxed_closure as *mut F) };
         // Execute the closure.
         (*closure)();
         // closure is released after finishiing this function call.
     }
 
-    let closure: Box<F> = Box::new(closure); // Allocate closure on heap.
+    let closure = Box::new(closure); // Allocate closure on heap.
     let executor: dispatch_function_t = Some(closure_executer::<F>);
 
     (

--- a/coreaudio-sys-utils/src/dispatch.rs
+++ b/coreaudio-sys-utils/src/dispatch.rs
@@ -57,7 +57,7 @@ where
         let closure = unsafe { Box::from_raw(unboxed_closure as *mut F) };
         // Execute the closure.
         (*closure)();
-        // closure is released after finishiing this function call.
+        // closure is released after finishing this function call.
     }
 
     let closure = Box::new(closure); // Allocate closure on heap.

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -45,6 +45,4 @@ cargo test test_reinit_duplex_stream_by_unplugging_a_default_output_device -- --
 # cargo test test_switch_output_device -- --ignored --nocapture
 # cargo test test_add_then_remove_listeners -- --ignored --nocapture
 # cargo test test_device_collection_change -- --ignored --nocapture
-# cargo test test_loop_in_a_output_stream -- --ignored --nocapture
-# cargo test test_loop_in_a_input_stream -- --ignored --nocapture
-# cargo test test_loop_in_a_duplex_stream -- --ignored --nocapture
+# cargo test test_stream_tester -- --ignored --nocapture

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,3 +1,6 @@
+# display backtrace for debugging
+export RUST_BACKTRACE=1
+
 # Regular Tests
 cargo test --verbose
 cargo test test_configure_output -- --ignored

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -42,3 +42,6 @@ cargo test test_reinit_duplex_stream_by_unplugging_a_default_output_device -- --
 # cargo test test_switch_output_device -- --ignored --nocapture
 # cargo test test_add_then_remove_listeners -- --ignored --nocapture
 # cargo test test_device_collection_change -- --ignored --nocapture
+# cargo test test_loop_in_a_output_stream -- --ignored --nocapture
+# cargo test test_loop_in_a_input_stream -- --ignored --nocapture
+# cargo test test_loop_in_a_duplex_stream -- --ignored --nocapture

--- a/src/backend/tests/device_change.rs
+++ b/src/backend/tests/device_change.rs
@@ -716,10 +716,10 @@ fn test_ops_default_callbacks_stream_operation<F>(
     }
 }
 
-// The stream format for input and output must be same.
-const STREAM_FORMAT: u32 = ffi::CUBEB_SAMPLE_FLOAT32NE;
-
 fn get_dummy_stream_params(scope: Scope) -> ffi::cubeb_stream_params {
+    // The stream format for input and output must be same.
+    const STREAM_FORMAT: u32 = ffi::CUBEB_SAMPLE_FLOAT32NE;
+
     // Make sure the parameters meet the requirements of AudioUnitContext::stream_init
     // (in the comments).
     let mut stream_params = ffi::cubeb_stream_params::default();

--- a/src/backend/tests/device_change.rs
+++ b/src/backend/tests/device_change.rs
@@ -16,9 +16,9 @@
 
 use super::utils::{
     test_create_device_change_listener, test_device_in_scope, test_get_default_device,
-    test_get_devices_in_scope, test_ops_stream_operation,
-    test_ops_stream_operation_with_default_callbacks, test_set_default_device, Scope,
-    TestDevicePlugger, TestDeviceSwitcher,
+    test_get_devices_in_scope, test_get_stream_with_default_callbacks_by_type,
+    test_ops_stream_operation, test_set_default_device, Scope, StreamType, TestDevicePlugger,
+    TestDeviceSwitcher,
 };
 use super::*;
 use std::fmt::Debug;
@@ -601,14 +601,6 @@ impl<T: Clone + PartialEq> Watcher<T> {
     }
 }
 
-bitflags! {
-    struct StreamType: u8 {
-        const INPUT = 0b01;
-        const OUTPUT = 0b10;
-        const DUPLEX = Self::INPUT.bits | Self::OUTPUT.bits;
-    }
-}
-
 fn test_get_stream_with_device_changed_callback<F>(
     name: &'static str,
     stm_type: StreamType,
@@ -620,61 +612,18 @@ fn test_get_stream_with_device_changed_callback<F>(
 ) where
     F: FnOnce(&mut AudioUnitStream),
 {
-    let mut input_params = get_dummy_stream_params(Scope::Input);
-    let mut output_params = get_dummy_stream_params(Scope::Output);
-
-    let in_params = if stm_type.contains(StreamType::INPUT) {
-        &mut input_params as *mut ffi::cubeb_stream_params
-    } else {
-        ptr::null_mut()
-    };
-    let out_params = if stm_type.contains(StreamType::OUTPUT) {
-        &mut output_params as *mut ffi::cubeb_stream_params
-    } else {
-        ptr::null_mut()
-    };
-    let in_device = if let Some(id) = input_device {
-        id as ffi::cubeb_devid
-    } else {
-        ptr::null_mut()
-    };
-    let out_device = if let Some(id) = output_device {
-        id as ffi::cubeb_devid
-    } else {
-        ptr::null_mut()
-    };
-
-    test_ops_stream_operation_with_default_callbacks(
+    test_get_stream_with_default_callbacks_by_type(
         name,
-        in_device,
-        in_params,
-        out_device,
-        out_params,
+        stm_type,
+        input_device,
+        output_device,
         data,
         |stream| {
-            let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
-            assert!(stm.register_device_changed_callback(Some(callback)).is_ok());
-            operation(stm);
-            assert!(stm.register_device_changed_callback(None).is_ok());
+            assert!(stream
+                .register_device_changed_callback(Some(callback))
+                .is_ok());
+            operation(stream);
+            assert!(stream.register_device_changed_callback(None).is_ok());
         },
     );
-}
-
-fn get_dummy_stream_params(scope: Scope) -> ffi::cubeb_stream_params {
-    // The stream format for input and output must be same.
-    const STREAM_FORMAT: u32 = ffi::CUBEB_SAMPLE_FLOAT32NE;
-
-    // Make sure the parameters meet the requirements of AudioUnitContext::stream_init
-    // (in the comments).
-    let mut stream_params = ffi::cubeb_stream_params::default();
-    stream_params.prefs = ffi::CUBEB_STREAM_PREF_NONE;
-    let (format, rate, channels, layout) = match scope {
-        Scope::Input => (STREAM_FORMAT, 48000, 1, ffi::CUBEB_LAYOUT_MONO),
-        Scope::Output => (STREAM_FORMAT, 44100, 2, ffi::CUBEB_LAYOUT_STEREO),
-    };
-    stream_params.format = format;
-    stream_params.rate = rate;
-    stream_params.channels = channels;
-    stream_params.layout = layout;
-    stream_params
 }

--- a/src/backend/tests/manual.rs
+++ b/src/backend/tests/manual.rs
@@ -1,7 +1,6 @@
 use super::utils::{
     test_get_default_device, test_get_default_raw_stream, test_get_devices_in_scope,
-    test_get_stream_with_default_callbacks_by_type, test_ops_stream_operation, Scope, StreamType,
-    TestDeviceSwitcher,
+    test_ops_context_operation, test_ops_stream_operation, Scope, StreamType, TestDeviceSwitcher,
 };
 use super::*;
 use std::io;
@@ -256,70 +255,186 @@ fn test_device_collection_change() {
 #[ignore]
 #[test]
 fn test_stream_tester() {
-    let mut stream_type = StreamType::empty();
-    while stream_type.is_empty() {
-        println!("Select stream type:\n1) Input 2) Output 3) In-Out Duplex 4) Quit");
-        let mut input = String::new();
-        let _ = io::stdin().read_line(&mut input);
-        assert_eq!(input.pop().unwrap(), '\n');
-        stream_type = match input.as_str() {
-            "1" => StreamType::INPUT,
-            "2" => StreamType::OUTPUT,
-            "3" => StreamType::DUPLEX,
-            "4" => {
-                println!("Quit.\n");
-                return;
-            }
-            _ => {
-                println!("Invalid type. Select again.\n");
-                StreamType::empty()
+    test_ops_context_operation("context: stream tester", |context_ptr| {
+        let mut stream_ptr: *mut ffi::cubeb_stream = ptr::null_mut();
+        loop {
+            println!(
+                "commands:\n\
+                 \t'q': quit\n\
+                 \t'c': create a stream\n\
+                 \t'd': destroy a stream\n\
+                 \t's': start the created stream\n\
+                 \t't': stop the created stream"
+            );
+
+            let mut command = String::new();
+            let _ = io::stdin().read_line(&mut command);
+            assert_eq!(command.pop().unwrap(), '\n');
+
+            match command.as_str() {
+                "q" => {
+                    println!("Quit.");
+                    destroy_stream(&mut stream_ptr);
+                    break;
+                }
+                "c" => create_stream(&mut stream_ptr, context_ptr),
+                "d" => destroy_stream(&mut stream_ptr),
+                "s" => start_stream(stream_ptr),
+                "t" => stop_stream(stream_ptr),
+                x => println!("Unknown command: {}", x),
             }
         }
-    }
-    stream_tester_by_type(
-        "loop within a stream",
-        stream_type,
-        None, // Use default input device.
-        None, // Use default output device.
-    );
-}
+    });
 
-fn stream_tester_by_type(
-    name: &'static str,
-    stm_type: StreamType,
-    input_device: Option<AudioObjectID>,
-    output_device: Option<AudioObjectID>,
-) {
-    test_get_stream_with_default_callbacks_by_type(
-        name,
-        stm_type,
-        input_device,
-        output_device,
-        ptr::null_mut(), // Use null since no any callback would be registered.
-        |stream| {
-            println!("Commands:\n\t's' to start stream\n\t't' to stop stream\n\t'q' to to quit.");
-            loop {
-                let mut input = String::new();
-                let _ = io::stdin().read_line(&mut input);
-                assert_eq!(input.pop().unwrap(), '\n');
-                match input.as_str() {
-                    "s" => {
-                        println!("Start stream.");
-                        assert!(stream.start().is_ok());
-                    }
-                    "t" => {
-                        println!("Stop stream.");
-                        assert!(stream.stop().is_ok());
-                    }
-                    "q" => {
-                        println!("Quit.");
-                        break;
-                    }
-                    x => {
-                        println!("Unknown command: {}", x);
-                    }
+    fn start_stream(stream_ptr: *mut ffi::cubeb_stream) {
+        if stream_ptr.is_null() {
+            println!("No stream can start.");
+            return;
+        }
+        assert_eq!(
+            unsafe { OPS.stream_start.unwrap()(stream_ptr) },
+            ffi::CUBEB_OK
+        );
+        println!("Stream started.");
+    }
+
+    fn stop_stream(stream_ptr: *mut ffi::cubeb_stream) {
+        if stream_ptr.is_null() {
+            println!("No stream can stop.");
+            return;
+        }
+        assert_eq!(
+            unsafe { OPS.stream_stop.unwrap()(stream_ptr) },
+            ffi::CUBEB_OK
+        );
+        println!("Stream stopped.");
+    }
+
+    fn destroy_stream(stream_ptr: &mut *mut ffi::cubeb_stream) {
+        if stream_ptr.is_null() {
+            println!("No need to destroy stream.");
+            return;
+        }
+        unsafe {
+            OPS.stream_destroy.unwrap()(*stream_ptr);
+        }
+        *stream_ptr = ptr::null_mut();
+        println!("Stream destroyed.");
+    }
+
+    fn create_stream(stream_ptr: &mut *mut ffi::cubeb_stream, context_ptr: *mut ffi::cubeb) {
+        if !stream_ptr.is_null() {
+            println!("Stream has been created.");
+            return;
+        }
+
+        let mut stream_type = StreamType::empty();
+        while stream_type.is_empty() {
+            println!("Select stream type:\n1) Input 2) Output 3) In-Out Duplex 4) Quit");
+            let mut input = String::new();
+            let _ = io::stdin().read_line(&mut input);
+            assert_eq!(input.pop().unwrap(), '\n');
+            stream_type = match input.as_str() {
+                "1" => StreamType::INPUT,
+                "2" => StreamType::OUTPUT,
+                "3" => StreamType::DUPLEX,
+                "4" => {
+                    println!("Do nothing.");
+                    return;
+                }
+                _ => {
+                    println!("Invalid type. Select again.\n");
+                    StreamType::empty()
                 }
             }
-        },
-    );
+        }
+
+        let mut input_params = get_dummy_stream_params(Scope::Input);
+        let mut output_params = get_dummy_stream_params(Scope::Output);
+
+        let input_stream_params = if stream_type.contains(StreamType::INPUT) {
+            &mut input_params as *mut ffi::cubeb_stream_params
+        } else {
+            ptr::null_mut()
+        };
+        let output_stream_params = if stream_type.contains(StreamType::OUTPUT) {
+            &mut output_params as *mut ffi::cubeb_stream_params
+        } else {
+            ptr::null_mut()
+        };
+
+        let stream_name = CString::new("stream tester").unwrap();
+
+        assert_eq!(
+            unsafe {
+                OPS.stream_init.unwrap()(
+                    context_ptr,
+                    stream_ptr,
+                    stream_name.as_ptr(),
+                    ptr::null_mut(), // default input device
+                    input_stream_params,
+                    ptr::null_mut(), // default output device
+                    output_stream_params,
+                    4096, // latency
+                    Some(data_callback),
+                    Some(state_callback),
+                    ptr::null_mut(), // user pointer
+                )
+            },
+            ffi::CUBEB_OK
+        );
+        assert!(!stream_ptr.is_null());
+
+        extern "C" fn state_callback(
+            stream: *mut ffi::cubeb_stream,
+            _user_ptr: *mut c_void,
+            state: ffi::cubeb_state,
+        ) {
+            assert!(!stream.is_null());
+            assert_ne!(state, ffi::CUBEB_STATE_ERROR);
+        }
+
+        extern "C" fn data_callback(
+            stream: *mut ffi::cubeb_stream,
+            _user_ptr: *mut c_void,
+            _input_buffer: *const c_void,
+            output_buffer: *mut c_void,
+            nframes: i64,
+        ) -> i64 {
+            assert!(!stream.is_null());
+
+            // Feed silence data to output buffer
+            if !output_buffer.is_null() {
+                let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+                let channels = stm.core_stream_data.output_stream_params.channels();
+                let samples = nframes as usize * channels as usize;
+                let sample_size =
+                    cubeb_sample_size(stm.core_stream_data.output_stream_params.format());
+                unsafe {
+                    ptr::write_bytes(output_buffer, 0, samples * sample_size);
+                }
+            }
+
+            nframes
+        }
+
+        fn get_dummy_stream_params(scope: Scope) -> ffi::cubeb_stream_params {
+            // The stream format for input and output must be same.
+            const STREAM_FORMAT: u32 = ffi::CUBEB_SAMPLE_FLOAT32NE;
+
+            // Make sure the parameters meet the requirements of AudioUnitContext::stream_init
+            // (in the comments).
+            let mut stream_params = ffi::cubeb_stream_params::default();
+            stream_params.prefs = ffi::CUBEB_STREAM_PREF_NONE;
+            let (format, rate, channels, layout) = match scope {
+                Scope::Input => (STREAM_FORMAT, 48000, 1, ffi::CUBEB_LAYOUT_MONO),
+                Scope::Output => (STREAM_FORMAT, 44100, 2, ffi::CUBEB_LAYOUT_STEREO),
+            };
+            stream_params.format = format;
+            stream_params.rate = rate;
+            stream_params.channels = channels;
+            stream_params.layout = layout;
+            stream_params
+        }
+    }
 }

--- a/src/backend/tests/manual.rs
+++ b/src/backend/tests/manual.rs
@@ -295,7 +295,7 @@ fn test_stream_tester() {
             unsafe { OPS.stream_start.unwrap()(stream_ptr) },
             ffi::CUBEB_OK
         );
-        println!("Stream started.");
+        println!("Stream {:p} started.", stream_ptr);
     }
 
     fn stop_stream(stream_ptr: *mut ffi::cubeb_stream) {
@@ -307,7 +307,7 @@ fn test_stream_tester() {
             unsafe { OPS.stream_stop.unwrap()(stream_ptr) },
             ffi::CUBEB_OK
         );
-        println!("Stream stopped.");
+        println!("Stream {:p} stopped.", stream_ptr);
     }
 
     fn destroy_stream(stream_ptr: &mut *mut ffi::cubeb_stream) {
@@ -318,8 +318,8 @@ fn test_stream_tester() {
         unsafe {
             OPS.stream_destroy.unwrap()(*stream_ptr);
         }
+        println!("Stream {:p} destroyed.", *stream_ptr);
         *stream_ptr = ptr::null_mut();
-        println!("Stream destroyed.");
     }
 
     fn create_stream(stream_ptr: &mut *mut ffi::cubeb_stream, context_ptr: *mut ffi::cubeb) {
@@ -330,7 +330,7 @@ fn test_stream_tester() {
 
         let mut stream_type = StreamType::empty();
         while stream_type.is_empty() {
-            println!("Select stream type:\n1) Input 2) Output 3) In-Out Duplex 4) Quit");
+            println!("Select stream type:\n1) Input 2) Output 3) In-Out Duplex 4) Back");
             let mut input = String::new();
             let _ = io::stdin().read_line(&mut input);
             assert_eq!(input.pop().unwrap(), '\n');
@@ -384,6 +384,7 @@ fn test_stream_tester() {
             ffi::CUBEB_OK
         );
         assert!(!stream_ptr.is_null());
+        println!("Stream {:p} created.", *stream_ptr);
 
         extern "C" fn state_callback(
             stream: *mut ffi::cubeb_stream,

--- a/src/backend/tests/manual.rs
+++ b/src/backend/tests/manual.rs
@@ -4,12 +4,12 @@ use super::utils::{
     TestDeviceSwitcher,
 };
 use super::*;
+use std::io;
 
 #[ignore]
 #[test]
 fn test_switch_output_device() {
     use std::f32::consts::PI;
-    use std::io;
 
     const SAMPLE_FREQUENCY: u32 = 48_000;
 
@@ -263,8 +263,21 @@ fn test_loop_in_a_output_stream() {
         None,            // Use default output device.
         ptr::null_mut(), // Use null since no any callback would be registered.
         |_stream| {
-            println!("Test anything here. Unplug/Plug devices or change default devices.");
-            loop {}
+            println!("Test anything here. Unplug/Plug devices or change default devices. Press 'q' to to quit.");
+            loop {
+                let mut input = String::new();
+                let _ = io::stdin().read_line(&mut input);
+                assert_eq!(input.pop().unwrap(), '\n');
+                match input.as_str() {
+                    "q" => {
+                        println!("Quit.");
+                        break;
+                    }
+                    x => {
+                        println!("Unknown command: {}", x);
+                    }
+                }
+            }
         },
     );
 }
@@ -279,8 +292,21 @@ fn test_loop_in_a_input_stream() {
         None,            // Use default output device.
         ptr::null_mut(), // Use null since no any callback would be registered.
         |_stream| {
-            println!("Test anything here. Unplug/Plug devices or change default devices.");
-            loop {}
+            println!("Test anything here. Unplug/Plug devices or change default devices. Press 'q' to to quit.");
+            loop {
+                let mut input = String::new();
+                let _ = io::stdin().read_line(&mut input);
+                assert_eq!(input.pop().unwrap(), '\n');
+                match input.as_str() {
+                    "q" => {
+                        println!("Quit.");
+                        break;
+                    }
+                    x => {
+                        println!("Unknown command: {}", x);
+                    }
+                }
+            }
         },
     );
 }
@@ -295,8 +321,21 @@ fn test_loop_in_a_duplex_stream() {
         None,            // Use default output device.
         ptr::null_mut(), // Use null since no any callback would be registered.
         |_stream| {
-            println!("Test anything here. Unplug/Plug devices or change default devices.");
-            loop {}
+            println!("Test anything here. Unplug/Plug devices or change default devices. Press 'q' to to quit.");
+            loop {
+                let mut input = String::new();
+                let _ = io::stdin().read_line(&mut input);
+                assert_eq!(input.pop().unwrap(), '\n');
+                match input.as_str() {
+                    "q" => {
+                        println!("Quit.");
+                        break;
+                    }
+                    x => {
+                        println!("Unknown command: {}", x);
+                    }
+                }
+            }
         },
     );
 }

--- a/src/backend/tests/manual.rs
+++ b/src/backend/tests/manual.rs
@@ -258,7 +258,7 @@ fn test_device_collection_change() {
 fn test_stream_tester() {
     let mut stream_type = StreamType::empty();
     while stream_type.is_empty() {
-        println!("Select stream type:\n1) Input 2) Output 3) In-Out Duplex");
+        println!("Select stream type:\n1) Input 2) Output 3) In-Out Duplex 4) Quit");
         let mut input = String::new();
         let _ = io::stdin().read_line(&mut input);
         assert_eq!(input.pop().unwrap(), '\n');
@@ -266,6 +266,10 @@ fn test_stream_tester() {
             "1" => StreamType::INPUT,
             "2" => StreamType::OUTPUT,
             "3" => StreamType::DUPLEX,
+            "4" => {
+                println!("Quit.\n");
+                return;
+            }
             _ => {
                 println!("Invalid type. Select again.\n");
                 StreamType::empty()

--- a/src/backend/tests/manual.rs
+++ b/src/backend/tests/manual.rs
@@ -255,78 +255,58 @@ fn test_device_collection_change() {
 
 #[ignore]
 #[test]
-fn test_loop_in_a_output_stream() {
-    test_get_stream_with_default_callbacks_by_type(
-        "loop in a output stream",
-        StreamType::OUTPUT,
-        None,            // Use default input device.
-        None,            // Use default output device.
-        ptr::null_mut(), // Use null since no any callback would be registered.
-        |_stream| {
-            println!("Test anything here. Unplug/Plug devices or change default devices. Press 'q' to to quit.");
-            loop {
-                let mut input = String::new();
-                let _ = io::stdin().read_line(&mut input);
-                assert_eq!(input.pop().unwrap(), '\n');
-                match input.as_str() {
-                    "q" => {
-                        println!("Quit.");
-                        break;
-                    }
-                    x => {
-                        println!("Unknown command: {}", x);
-                    }
-                }
+fn test_stream_tester() {
+    let mut stream_type = StreamType::empty();
+    while stream_type.is_empty() {
+        println!("Select stream type:\n1) Input 2) Output 3) In-Out Duplex");
+        let mut input = String::new();
+        let _ = io::stdin().read_line(&mut input);
+        assert_eq!(input.pop().unwrap(), '\n');
+        stream_type = match input.as_str() {
+            "1" => StreamType::INPUT,
+            "2" => StreamType::OUTPUT,
+            "3" => StreamType::DUPLEX,
+            _ => {
+                println!("Invalid type. Select again.\n");
+                StreamType::empty()
             }
-        },
+        }
+    }
+    stream_tester_by_type(
+        "loop within a stream",
+        stream_type,
+        None, // Use default input device.
+        None, // Use default output device.
     );
 }
 
-#[ignore]
-#[test]
-fn test_loop_in_a_input_stream() {
+fn stream_tester_by_type(
+    name: &'static str,
+    stm_type: StreamType,
+    input_device: Option<AudioObjectID>,
+    output_device: Option<AudioObjectID>,
+) {
     test_get_stream_with_default_callbacks_by_type(
-        "loop in a input stream",
-        StreamType::INPUT,
-        None,            // Use default input device.
-        None,            // Use default output device.
+        name,
+        stm_type,
+        input_device,
+        output_device,
         ptr::null_mut(), // Use null since no any callback would be registered.
-        |_stream| {
-            println!("Test anything here. Unplug/Plug devices or change default devices. Press 'q' to to quit.");
+        |stream| {
+            println!("Commands:\n\t's' to start stream\n\t't' to stop stream\n\t'q' to to quit.");
             loop {
                 let mut input = String::new();
                 let _ = io::stdin().read_line(&mut input);
                 assert_eq!(input.pop().unwrap(), '\n');
                 match input.as_str() {
-                    "q" => {
-                        println!("Quit.");
-                        break;
+                    "s" => {
+                        println!("Start stream.");
+                        assert!(stream.start().is_ok());
                     }
-                    x => {
-                        println!("Unknown command: {}", x);
+                    "t" => {
+                        println!("Stop stream.");
+                        assert!(stream.stop().is_ok());
                     }
-                }
-            }
-        },
-    );
-}
-
-#[ignore]
-#[test]
-fn test_loop_in_a_duplex_stream() {
-    test_get_stream_with_default_callbacks_by_type(
-        "loop in a in-out stream",
-        StreamType::DUPLEX,
-        None,            // Use default input device.
-        None,            // Use default output device.
-        ptr::null_mut(), // Use null since no any callback would be registered.
-        |_stream| {
-            println!("Test anything here. Unplug/Plug devices or change default devices. Press 'q' to to quit.");
-            loop {
-                let mut input = String::new();
-                let _ = io::stdin().read_line(&mut input);
-                assert_eq!(input.pop().unwrap(), '\n');
-                match input.as_str() {
                     "q" => {
                         println!("Quit.");
                         break;

--- a/src/backend/tests/manual.rs
+++ b/src/backend/tests/manual.rs
@@ -1,6 +1,7 @@
 use super::utils::{
     test_get_default_device, test_get_default_raw_stream, test_get_devices_in_scope,
-    test_ops_stream_operation, Scope, TestDeviceSwitcher,
+    test_ops_stream_operation, test_ops_stream_operation_with_default_callbacks, Scope,
+    TestDeviceSwitcher,
 };
 use super::*;
 
@@ -250,4 +251,127 @@ fn test_device_collection_change() {
     println!("Unplug/Plug device to see the event log.\nEnter anything to finish.");
     let mut input = String::new();
     let _ = std::io::stdin().read_line(&mut input);
+}
+
+#[ignore]
+#[test]
+fn test_loop_in_a_output_stream() {
+    test_get_stream_with_default_callbacks_by_type(
+        "loop in a output stream",
+        StreamType::OUTPUT,
+        None,            // Use default input device.
+        None,            // Use default output device.
+        ptr::null_mut(), // Use null since no any callback would be registered.
+        |stream| {
+            println!("Test anything here. Unplug/Plug devices or change default devices.");
+            loop {}
+        },
+    );
+}
+
+#[ignore]
+#[test]
+fn test_loop_in_a_input_stream() {
+    test_get_stream_with_default_callbacks_by_type(
+        "loop in a input stream",
+        StreamType::INPUT,
+        None,            // Use default input device.
+        None,            // Use default output device.
+        ptr::null_mut(), // Use null since no any callback would be registered.
+        |stream| {
+            println!("Test anything here. Unplug/Plug devices or change default devices.");
+            loop {}
+        },
+    );
+}
+
+#[ignore]
+#[test]
+fn test_loop_in_a_duplex_stream() {
+    test_get_stream_with_default_callbacks_by_type(
+        "loop in a in-out stream",
+        StreamType::DUPLEX,
+        None,            // Use default input device.
+        None,            // Use default output device.
+        ptr::null_mut(), // Use null since no any callback would be registered.
+        |stream| {
+            println!("Test anything here. Unplug/Plug devices or change default devices.");
+            loop {}
+        },
+    );
+}
+
+bitflags! {
+    struct StreamType: u8 {
+        const INPUT = 0b01;
+        const OUTPUT = 0b10;
+        const DUPLEX = Self::INPUT.bits | Self::OUTPUT.bits;
+    }
+}
+
+fn test_get_stream_with_default_callbacks_by_type<F>(
+    name: &'static str,
+    stm_type: StreamType,
+    input_device: Option<AudioObjectID>,
+    output_device: Option<AudioObjectID>,
+    data: *mut c_void,
+    operation: F,
+) where
+    F: FnOnce(&mut AudioUnitStream),
+{
+    let mut input_params = get_dummy_stream_params(Scope::Input);
+    let mut output_params = get_dummy_stream_params(Scope::Output);
+
+    let in_params = if stm_type.contains(StreamType::INPUT) {
+        &mut input_params as *mut ffi::cubeb_stream_params
+    } else {
+        ptr::null_mut()
+    };
+    let out_params = if stm_type.contains(StreamType::OUTPUT) {
+        &mut output_params as *mut ffi::cubeb_stream_params
+    } else {
+        ptr::null_mut()
+    };
+    let in_device = if let Some(id) = input_device {
+        id as ffi::cubeb_devid
+    } else {
+        ptr::null_mut()
+    };
+    let out_device = if let Some(id) = output_device {
+        id as ffi::cubeb_devid
+    } else {
+        ptr::null_mut()
+    };
+
+    test_ops_stream_operation_with_default_callbacks(
+        name,
+        in_device,
+        in_params,
+        out_device,
+        out_params,
+        data,
+        |stream| {
+            let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+            operation(stm);
+        },
+    );
+}
+
+fn get_dummy_stream_params(scope: Scope) -> ffi::cubeb_stream_params {
+    // The stream format for input and output must be same.
+    const STREAM_FORMAT: u32 = ffi::CUBEB_SAMPLE_FLOAT32NE;
+
+    // Make sure the parameters meet the requirements of AudioUnitContext::stream_init
+    // (in the comments).
+    let mut stream_params = ffi::cubeb_stream_params::default();
+    stream_params.prefs = ffi::CUBEB_STREAM_PREF_NONE;
+    let (format, rate, channels, layout) = match scope {
+        Scope::Input => (STREAM_FORMAT, 48000, 1, ffi::CUBEB_LAYOUT_MONO),
+        Scope::Output => (STREAM_FORMAT, 44100, 2, ffi::CUBEB_LAYOUT_STEREO),
+    };
+    stream_params.format = format;
+    stream_params.rate = rate;
+    stream_params.channels = channels;
+    stream_params.layout = layout;
+    stream_params
 }

--- a/src/backend/tests/utils.rs
+++ b/src/backend/tests/utils.rs
@@ -980,63 +980,6 @@ where
     unsafe { OPS.destroy.unwrap()(context) }
 }
 
-pub fn test_ops_stream_operation_with_default_callbacks<F>(
-    name: &'static str,
-    input_device: ffi::cubeb_devid,
-    input_stream_params: *mut ffi::cubeb_stream_params,
-    output_device: ffi::cubeb_devid,
-    output_stream_params: *mut ffi::cubeb_stream_params,
-    data: *mut c_void,
-    operation: F,
-) where
-    F: FnOnce(*mut ffi::cubeb_stream),
-{
-    test_ops_stream_operation(
-        name,
-        input_device,
-        input_stream_params,
-        output_device,
-        output_stream_params,
-        4096, // TODO: Get latency by get_min_latency instead ?
-        Some(data_callback),
-        Some(state_callback),
-        data,
-        operation,
-    );
-
-    extern "C" fn state_callback(
-        stream: *mut ffi::cubeb_stream,
-        _user_ptr: *mut c_void,
-        state: ffi::cubeb_state,
-    ) {
-        assert!(!stream.is_null());
-        assert_ne!(state, ffi::CUBEB_STATE_ERROR);
-    }
-
-    extern "C" fn data_callback(
-        stream: *mut ffi::cubeb_stream,
-        _user_ptr: *mut c_void,
-        _input_buffer: *const c_void,
-        output_buffer: *mut c_void,
-        nframes: i64,
-    ) -> i64 {
-        assert!(!stream.is_null());
-
-        // Feed silence data to output buffer
-        if !output_buffer.is_null() {
-            let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
-            let channels = stm.core_stream_data.output_stream_params.channels();
-            let samples = nframes as usize * channels as usize;
-            let sample_size = cubeb_sample_size(stm.core_stream_data.output_stream_params.format());
-            unsafe {
-                ptr::write_bytes(output_buffer, 0, samples * sample_size);
-            }
-        }
-
-        nframes
-    }
-}
-
 // The in-out stream initializeed with different device will create an aggregate_device and
 // result in firing device-collection-changed callbacks. Run in-out streams with tests
 // capturing device-collection-changed callbacks may cause troubles.
@@ -1134,4 +1077,136 @@ fn test_get_raw_stream<F>(
     stream.core_stream_data = CoreStreamData::new(&stream, None, None);
 
     operation(&mut stream);
+}
+
+pub fn test_get_stream_with_default_callbacks_by_type<F>(
+    name: &'static str,
+    stm_type: StreamType,
+    input_device: Option<AudioObjectID>,
+    output_device: Option<AudioObjectID>,
+    data: *mut c_void,
+    operation: F,
+) where
+    F: FnOnce(&mut AudioUnitStream),
+{
+    let mut input_params = get_dummy_stream_params(Scope::Input);
+    let mut output_params = get_dummy_stream_params(Scope::Output);
+
+    let in_params = if stm_type.contains(StreamType::INPUT) {
+        &mut input_params as *mut ffi::cubeb_stream_params
+    } else {
+        ptr::null_mut()
+    };
+    let out_params = if stm_type.contains(StreamType::OUTPUT) {
+        &mut output_params as *mut ffi::cubeb_stream_params
+    } else {
+        ptr::null_mut()
+    };
+    let in_device = if let Some(id) = input_device {
+        id as ffi::cubeb_devid
+    } else {
+        ptr::null_mut()
+    };
+    let out_device = if let Some(id) = output_device {
+        id as ffi::cubeb_devid
+    } else {
+        ptr::null_mut()
+    };
+
+    test_ops_stream_operation_with_default_callbacks(
+        name,
+        in_device,
+        in_params,
+        out_device,
+        out_params,
+        data,
+        |stream| {
+            let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+            operation(stm);
+        },
+    );
+}
+
+bitflags! {
+    pub struct StreamType: u8 {
+        const INPUT = 0b01;
+        const OUTPUT = 0b10;
+        const DUPLEX = Self::INPUT.bits | Self::OUTPUT.bits;
+    }
+}
+
+fn get_dummy_stream_params(scope: Scope) -> ffi::cubeb_stream_params {
+    // The stream format for input and output must be same.
+    const STREAM_FORMAT: u32 = ffi::CUBEB_SAMPLE_FLOAT32NE;
+
+    // Make sure the parameters meet the requirements of AudioUnitContext::stream_init
+    // (in the comments).
+    let mut stream_params = ffi::cubeb_stream_params::default();
+    stream_params.prefs = ffi::CUBEB_STREAM_PREF_NONE;
+    let (format, rate, channels, layout) = match scope {
+        Scope::Input => (STREAM_FORMAT, 48000, 1, ffi::CUBEB_LAYOUT_MONO),
+        Scope::Output => (STREAM_FORMAT, 44100, 2, ffi::CUBEB_LAYOUT_STEREO),
+    };
+    stream_params.format = format;
+    stream_params.rate = rate;
+    stream_params.channels = channels;
+    stream_params.layout = layout;
+    stream_params
+}
+
+fn test_ops_stream_operation_with_default_callbacks<F>(
+    name: &'static str,
+    input_device: ffi::cubeb_devid,
+    input_stream_params: *mut ffi::cubeb_stream_params,
+    output_device: ffi::cubeb_devid,
+    output_stream_params: *mut ffi::cubeb_stream_params,
+    data: *mut c_void,
+    operation: F,
+) where
+    F: FnOnce(*mut ffi::cubeb_stream),
+{
+    test_ops_stream_operation(
+        name,
+        input_device,
+        input_stream_params,
+        output_device,
+        output_stream_params,
+        4096, // TODO: Get latency by get_min_latency instead ?
+        Some(data_callback),
+        Some(state_callback),
+        data,
+        operation,
+    );
+
+    extern "C" fn state_callback(
+        stream: *mut ffi::cubeb_stream,
+        _user_ptr: *mut c_void,
+        state: ffi::cubeb_state,
+    ) {
+        assert!(!stream.is_null());
+        assert_ne!(state, ffi::CUBEB_STATE_ERROR);
+    }
+
+    extern "C" fn data_callback(
+        stream: *mut ffi::cubeb_stream,
+        _user_ptr: *mut c_void,
+        _input_buffer: *const c_void,
+        output_buffer: *mut c_void,
+        nframes: i64,
+    ) -> i64 {
+        assert!(!stream.is_null());
+
+        // Feed silence data to output buffer
+        if !output_buffer.is_null() {
+            let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+            let channels = stm.core_stream_data.output_stream_params.channels();
+            let samples = nframes as usize * channels as usize;
+            let sample_size = cubeb_sample_size(stm.core_stream_data.output_stream_params.format());
+            unsafe {
+                ptr::write_bytes(output_buffer, 0, samples * sample_size);
+            }
+        }
+
+        nframes
+    }
 }

--- a/src/backend/tests/utils.rs
+++ b/src/backend/tests/utils.rs
@@ -980,6 +980,63 @@ where
     unsafe { OPS.destroy.unwrap()(context) }
 }
 
+pub fn test_ops_stream_operation_with_default_callbacks<F>(
+    name: &'static str,
+    input_device: ffi::cubeb_devid,
+    input_stream_params: *mut ffi::cubeb_stream_params,
+    output_device: ffi::cubeb_devid,
+    output_stream_params: *mut ffi::cubeb_stream_params,
+    data: *mut c_void,
+    operation: F,
+) where
+    F: FnOnce(*mut ffi::cubeb_stream),
+{
+    test_ops_stream_operation(
+        name,
+        input_device,
+        input_stream_params,
+        output_device,
+        output_stream_params,
+        4096, // TODO: Get latency by get_min_latency instead ?
+        Some(data_callback),
+        Some(state_callback),
+        data,
+        operation,
+    );
+
+    extern "C" fn state_callback(
+        stream: *mut ffi::cubeb_stream,
+        _user_ptr: *mut c_void,
+        state: ffi::cubeb_state,
+    ) {
+        assert!(!stream.is_null());
+        assert_ne!(state, ffi::CUBEB_STATE_ERROR);
+    }
+
+    extern "C" fn data_callback(
+        stream: *mut ffi::cubeb_stream,
+        _user_ptr: *mut c_void,
+        _input_buffer: *const c_void,
+        output_buffer: *mut c_void,
+        nframes: i64,
+    ) -> i64 {
+        assert!(!stream.is_null());
+
+        // Feed silence data to output buffer
+        if !output_buffer.is_null() {
+            let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+            let channels = stm.core_stream_data.output_stream_params.channels();
+            let samples = nframes as usize * channels as usize;
+            let sample_size = cubeb_sample_size(stm.core_stream_data.output_stream_params.format());
+            unsafe {
+                ptr::write_bytes(output_buffer, 0, samples * sample_size);
+            }
+        }
+
+        nframes
+    }
+}
+
 // Note: The in-out stream initializeed with different device will create an aggregate_device and
 //       result in firing device-collection-changed callbacks. Run in-out streams with tests
 //       capturing device-collection-changed callbacks may cause troubles. See more details in the

--- a/src/backend/tests/utils.rs
+++ b/src/backend/tests/utils.rs
@@ -1037,10 +1037,9 @@ pub fn test_ops_stream_operation_with_default_callbacks<F>(
     }
 }
 
-// Note: The in-out stream initializeed with different device will create an aggregate_device and
-//       result in firing device-collection-changed callbacks. Run in-out streams with tests
-//       capturing device-collection-changed callbacks may cause troubles. See more details in the
-//       comments for test_create_blank_aggregate_device.
+// The in-out stream initializeed with different device will create an aggregate_device and
+// result in firing device-collection-changed callbacks. Run in-out streams with tests
+// capturing device-collection-changed callbacks may cause troubles.
 pub fn test_ops_stream_operation<F>(
     name: &'static str,
     input_device: ffi::cubeb_devid,


### PR DESCRIPTION
There are some crash reports in Bugzilla that relate to stream reinitialization. There are no tests we could test that manually. This change adds some manual tests that loop in the input or output or in-out streams. While the test runs, users could manually unplug or change the current default devices to check if stream reinitialization works. Some cleanup are contained in this change as well.