### PR TITLE
Always return null-terminated strings from current_device

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3471,12 +3471,12 @@ impl<'ctx> StreamOps for AudioUnitStream<'ctx> {
     #[cfg(not(target_os = "ios"))]
     fn current_device(&mut self) -> Result<&DeviceRef> {
         let mut device: Box<ffi::cubeb_device> = Box::new(ffi::cubeb_device::default());
-        if let Ok(source) = audiounit_get_default_datasource_string(DeviceType::INPUT) {
-            device.input_name = source.into_raw();
-        }
-        if let Ok(source) = audiounit_get_default_datasource_string(DeviceType::OUTPUT) {
-            device.output_name = source.into_raw();
-        }
+        let input_name = audiounit_get_default_datasource_string(DeviceType::INPUT)
+            .unwrap_or(CString::default());
+        device.input_name = input_name.into_raw();
+        let output_name = audiounit_get_default_datasource_string(DeviceType::OUTPUT)
+            .unwrap_or(CString::default());
+        device.output_name = output_name.into_raw();
         Ok(unsafe { DeviceRef::from_ptr(Box::into_raw(device)) })
     }
     #[cfg(target_os = "ios")]

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3470,13 +3470,20 @@ impl<'ctx> StreamOps for AudioUnitStream<'ctx> {
     }
     #[cfg(not(target_os = "ios"))]
     fn current_device(&mut self) -> Result<&DeviceRef> {
+        let input_name = audiounit_get_default_datasource_string(DeviceType::INPUT);
+        let output_name = audiounit_get_default_datasource_string(DeviceType::OUTPUT);
+        if input_name.is_err() && output_name.is_err() {
+            return Err(Error::error());
+        }
+
         let mut device: Box<ffi::cubeb_device> = Box::new(ffi::cubeb_device::default());
-        let input_name = audiounit_get_default_datasource_string(DeviceType::INPUT)
-            .unwrap_or(CString::default());
+
+        let input_name = input_name.unwrap_or(CString::default());
         device.input_name = input_name.into_raw();
-        let output_name = audiounit_get_default_datasource_string(DeviceType::OUTPUT)
-            .unwrap_or(CString::default());
+
+        let output_name = output_name.unwrap_or(CString::default());
         device.output_name = output_name.into_raw();
+
         Ok(unsafe { DeviceRef::from_ptr(Box::into_raw(device)) })
     }
     #[cfg(target_os = "ios")]


### PR DESCRIPTION
Always return null-terminated(`\0`) strings when querying the current input and output devices successfully, which will solve [BMO 1589931][b1589931].

[b1589931]: https://bugzilla.mozilla.org/show_bug.cgi?id=1589931