### PR TITLE
Avoid various racing issues 

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2439,6 +2439,10 @@ impl<'ctx> CoreStreamData<'ctx> {
     }
 
     fn start_audiounits(&self) -> Result<()> {
+        // Only allowed to be called after the stream is initialized
+        // and before the stream is destroyed.
+        assert!(!self.input_unit.is_null() || !self.output_unit.is_null());
+
         if !self.input_unit.is_null() {
             start_audiounit(self.input_unit)?;
         }

--- a/src/backend/tests/manual.rs
+++ b/src/backend/tests/manual.rs
@@ -393,6 +393,8 @@ fn test_stream_tester() {
         ) {
             assert!(!stream.is_null());
             assert_ne!(state, ffi::CUBEB_STATE_ERROR);
+            let s = State::from(state);
+            println!("state: {:?}", s);
         }
 
         extern "C" fn data_callback(


### PR DESCRIPTION
This change solves the racing issues mentioned in [BMO 1598413][b1598413]. Racing can happen when: 
1. stream start and stream destroy runs in parallel
    - The stream data callback may still run when the stream is being destroyed
2. stream start and stream reinit runs in parallel
    - The stream data callback may still run when the stream is being reinitialized
3. stream stop and stream destroy runs in parallel
    - The stream data callback is canceled twice but it's probably fine
4. stream stop and stream reinit runs in parallel
    - The stream-stop may fail silently since reinit may restart stream after stream-stop is called
5. stream destroy and stream reinit runs in parallel
    - The stream-stop may fail silently since reinit may restart stream after stream-stop is called

To avoid the above problems, the stream-start and stream-start should be run in the same task queue where the stream-destroy and stream-reinit tasks are so all these operations are on the same task queue. As a result, they will be executed one by one sequentially, without worrying about racing.

[b1598413]: https://bugzilla.mozilla.org/show_bug.cgi?id=1598413#c1