### PR TITLE
Return error when get_ranges_of_device_sample_rate gives an empty vector

### DIFF
--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1498,7 +1498,7 @@ fn test_get_range_of_sample_rates() {
         ];
         let mut ranges = Vec::new();
         for scope in scopes.iter() {
-            ranges.push(get_range_of_sample_rates(id, *scope).unwrap());
+            ranges.push(get_range_of_sample_rates(id, *scope).unwrap().unwrap());
         }
         ranges
     }

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1498,7 +1498,7 @@ fn test_get_range_of_sample_rates() {
         ];
         let mut ranges = Vec::new();
         for scope in scopes.iter() {
-            ranges.push(get_range_of_sample_rates(id, *scope).unwrap().unwrap());
+            ranges.push(get_range_of_sample_rates(id, *scope).unwrap());
         }
         ranges
     }


### PR DESCRIPTION
 There is an assertion to check the returned vector from `get_ranges_of_device_sample_rate`  is not empty, 
https://github.com/ChunMinChang/cubeb-coreaudio-rs/blob/b1ad8b94fd5103c0fe6965162894f56db7a0957f/src/backend/mod.rs#L1495-L1496
but actually it's possible to get an empty vector from `get_ranges_of_device_sample_rate`.

That assertion leads to a crash in [BMO 1603761][bmo1603761]. It's ok to remove that assertion since it's only used to log the device info.


[bmo1603761]: https://bugzilla.mozilla.org/show_bug.cgi?id=1603761