### PR TITLE
Remove the test_set_channel_layout_input

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1001,6 +1001,8 @@ fn audiounit_get_preferred_channel_layout(output_unit: AudioUnit) -> ChannelLayo
     audiounit_convert_channel_layout(layout.as_ref())
 }
 
+// This is for output AudioUnit only. Calling this by input-only AudioUnit is prone
+// to crash intermittently.
 fn audiounit_get_current_channel_layout(output_unit: AudioUnit) -> ChannelLayout {
     let mut rv = NO_ERR;
     let mut size: usize = 0;

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -981,23 +981,6 @@ fn test_set_channel_layout_output_undefind() {
 }
 
 #[test]
-fn test_set_channel_layout_input() {
-    if let Some(unit) = test_get_default_audiounit(Scope::Input) {
-        // Get original layout.
-        let original_layout = audiounit_get_current_channel_layout(unit.get_inner());
-        // Leave layout as it is.
-        assert!(audiounit_set_channel_layout(unit.get_inner(), ChannelLayout::UNDEFINED).is_ok());
-        // Check the layout is same as the original one.
-        assert_eq!(
-            audiounit_get_current_channel_layout(unit.get_inner()),
-            original_layout
-        );
-    } else {
-        println!("No input audiounit.");
-    }
-}
-
-#[test]
 #[should_panic]
 fn test_set_channel_layout_with_null_unit() {
     assert!(audiounit_set_channel_layout(ptr::null_mut(), ChannelLayout::UNDEFINED).is_err());


### PR DESCRIPTION
Calling audiounit_get_current_channel_layout by _input-only_
(_microphone-only_) `AudioUnit` is prone to cause crash intermittently.

The `test_set_channel_layout_input` is likely to cause intermittent crash
since it calls `audiounit_get_current_channel_layout` by an _input-only_
`AudioUnit`. Removing this test can avoid the random crashes when running
`cargo test` (#31).

The cubeb implementation has no need to get the channel-layout on input
side, so the `test_set_channel_layout_input` is unnecessary anyway.