### PR TITLE
Replace some `assert` by `debug_assert`

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -392,7 +392,7 @@ extern "C" fn audiounit_input_callback(
             stm.core_stream_data.input_desc.mChannelsPerFrame;
         input_buffer_list.mNumberBuffers = 1;
 
-        assert!(!stm.core_stream_data.input_unit.is_null());
+        debug_assert!(!stm.core_stream_data.input_unit.is_null());
         let status = audio_unit_render(
             stm.core_stream_data.input_unit,
             flags,
@@ -524,7 +524,7 @@ extern "C" fn audiounit_input_callback(
     // If the input (input-only stream) or the output is drained (duplex stream),
     // cancel this callback.
     if stm.draining.load(Ordering::SeqCst) {
-        assert!(stop_audiounit(stm.core_stream_data.input_unit).is_ok());
+        debug_assert!(stop_audiounit(stm.core_stream_data.input_unit).is_ok());
         // Only fire state-changed callback for input-only stream.
         // The state-changed callback for the duplex stream is fired in the output callback.
         if stm.core_stream_data.output_unit.is_null() {
@@ -611,7 +611,7 @@ extern "C" fn audiounit_output_callback(
     if stm.draining.load(Ordering::SeqCst) {
         // Cancel the output callback only. For duplex stream,
         // the input callback will be cancelled in its own callback.
-        assert!(stop_audiounit(stm.core_stream_data.output_unit).is_ok());
+        debug_assert!(stop_audiounit(stm.core_stream_data.output_unit).is_ok());
         stm.notify_state_changed(State::Drained);
         audiounit_make_silent(&mut buffers[0]);
         return NO_ERR;
@@ -932,7 +932,7 @@ fn audiounit_get_preferred_channel_layout(output_unit: AudioUnit) -> Vec<mixer::
         );
         return Vec::new();
     }
-    assert!(size > 0);
+    debug_assert!(size > 0);
 
     let mut layout = make_sized_audio_channel_layout(size);
     rv = audio_unit_get_property(
@@ -975,7 +975,7 @@ fn audiounit_get_current_channel_layout(output_unit: AudioUnit) -> Vec<mixer::Ch
         // This property isn't known before macOS 10.12, attempt another method.
         return audiounit_get_preferred_channel_layout(output_unit);
     }
-    assert!(size > 0);
+    debug_assert!(size > 0);
 
     let mut layout = make_sized_audio_channel_layout(size);
     rv = audio_unit_get_property(
@@ -2343,7 +2343,7 @@ impl<'ctx> CoreStreamData<'ctx> {
     fn start_audiounits(&self) -> Result<()> {
         // Only allowed to be called after the stream is initialized
         // and before the stream is destroyed.
-        assert!(!self.input_unit.is_null() || !self.output_unit.is_null());
+        debug_assert!(!self.input_unit.is_null() || !self.output_unit.is_null());
 
         if !self.input_unit.is_null() {
             start_audiounit(self.input_unit)?;
@@ -2356,10 +2356,10 @@ impl<'ctx> CoreStreamData<'ctx> {
 
     fn stop_audiounits(&self) {
         if !self.input_unit.is_null() {
-            assert!(stop_audiounit(self.input_unit).is_ok());
+            debug_assert!(stop_audiounit(self.input_unit).is_ok());
         }
         if !self.output_unit.is_null() {
-            assert!(stop_audiounit(self.output_unit).is_ok());
+            debug_assert!(stop_audiounit(self.output_unit).is_ok());
         }
     }
 
@@ -3136,7 +3136,7 @@ impl<'ctx> AudioUnitStream<'ctx> {
             self.core_stream_data.stop_audiounits();
         }
 
-        assert!(
+        debug_assert!(
             !self.core_stream_data.input_unit.is_null()
                 || !self.core_stream_data.output_unit.is_null()
         );


### PR DESCRIPTION
Some `assert` might not lead to fatal error can be replaced by
`debug_assert`. This adds a bit error-tolerance for the release build.