### PR TITLE
Correct the removal of the aggregate device in the device list 

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1645,7 +1645,7 @@ fn audiounit_get_devices_of_type(devtype: DeviceType) -> Vec<AudioObjectID> {
     devices.retain(|&device| {
         if let Ok(uid) = get_device_global_uid(device) {
             let uid = uid.into_string();
-            uid != PRIVATE_AGGREGATE_DEVICE_NAME
+            !uid.contains(PRIVATE_AGGREGATE_DEVICE_NAME)
         } else {
             // Fail to get device uid.
             true


### PR DESCRIPTION
The `PRIVATE_AGGREGATE_DEVICE_NAME` is just a part of the `uid` of the
created aggregate device, so we should check if the `uid` contains that
string instead of comparing them. A new test is added to verify the problem is solved when the default input and the default output device are different.