### PR TITLE
Run tests by sanitizers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,8 @@ before_script:
 script:
   - cargo build --verbose
   - sh run_tests.sh
+  - sh run_sanitizers.sh
+jobs:
+  allow_failures:
+    - rust: nightly
+  fast_finish: true

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ after finishing normal tests.
 Most of the tests are executed in `run_tests.sh`.
 Only those tests commented with *FIXIT* are left.
 
+### Run Sanitizers
+Run _AddressSanitizer (ASan), LeakSanitizer (LSan), MemorySanitizer (MSan), ThreadSanitizer (TSan)_
+by `sh run_sanitizers.sh`.
+
+The above command will run all the test suits in *run_tests.sh* by all the available _sanitizers_.
+However, it takes a long time for finshing the tests.
+
 ### Device Switching
 The system default device will be changed during our tests.
 All the available devices will take turns being the system default device.

--- a/run_sanitizers.sh
+++ b/run_sanitizers.sh
@@ -1,0 +1,27 @@
+# The option `Z` is only accepted on the nightly compiler
+# so changing to nightly toolchain by `rustup default nightly` is required.
+
+# See: https://github.com/rust-lang/rust/issues/39699 for more sanitizer support.
+
+toolchain=$(rustup default)
+echo "\nUse Rust toolchain: $toolchain"
+
+if [[ $toolchain == nightly-* ]]
+then
+   echo "Run sanitizers!"
+else
+   echo "The sanitizer is only available on Rust Nightly only. Skip."
+   exit
+fi
+
+echo "\n\nRun ASan\n-----------\n"
+RUSTFLAGS="-Z sanitizer=address" sh run_tests.sh
+
+echo "\n\nRun LSan\n-----------\n"
+RUSTFLAGS="-Z sanitizer=leak" sh run_tests.sh
+
+echo "\n\nRun MSan\n-----------\n"
+RUSTFLAGS="-Z sanitizer=memory" sh run_tests.sh
+
+echo "\n\nRun TSan\n-----------\n"
+RUSTFLAGS="-Z sanitizer=thread" sh run_tests.sh


### PR DESCRIPTION
- Add a script to run test suits by all the available sanitizers
- Add an instruction of running sanitizers in _README.md_
- Run the sanitizers on _Travis CI_ but the tests are allowed to fail
  - Since sanitizers are under development, they may false positives, or be unavailable for Nightly toolchain sometimes