### PR TITLE
Replace`*.get_mut()` by `*.store()` on all the `Atomic*`

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -794,7 +794,7 @@ extern "C" fn audiounit_property_listener_callback(
         );
         return NO_ERR;
     }
-    *stm.switching_device.get_mut() = true;
+    stm.switching_device.store(true, Ordering::SeqCst);
 
     cubeb_log!(
         "({:p}) Audio device changed, {} events.",
@@ -832,7 +832,7 @@ extern "C" fn audiounit_property_listener_callback(
                     .contains(device_flags::DEV_SYSTEM_DEFAULT)
                 {
                     cubeb_log!("It's the default input device, ignore the event");
-                    *stm.switching_device.get_mut() = false;
+                    stm.switching_device.store(false, Ordering::SeqCst);
                     return NO_ERR;
                 }
             }
@@ -849,7 +849,7 @@ extern "C" fn audiounit_property_listener_callback(
                     i,
                     addr.mSelector
                 );
-                *stm.switching_device.get_mut() = false;
+                stm.switching_device.store(false, Ordering::SeqCst);
                 return NO_ERR;
             }
         }
@@ -3263,7 +3263,7 @@ impl<'ctx> AudioUnitStream<'ctx> {
                     stm_ptr
                 );
             }
-            *stm_guard.switching_device.get_mut() = false;
+            stm_guard.switching_device.store(false, Ordering::SeqCst);
             *stm_guard.reinit_pending.get_mut() = false;
         });
     }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3276,7 +3276,7 @@ impl<'ctx> AudioUnitStream<'ctx> {
     }
 
     fn destroy(&mut self) {
-        *self.destroy_pending.get_mut() = true;
+        self.destroy_pending.store(true, Ordering::SeqCst);
 
         let queue = self.context.serial_queue;
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3264,7 +3264,7 @@ impl<'ctx> AudioUnitStream<'ctx> {
                 );
             }
             stm_guard.switching_device.store(false, Ordering::SeqCst);
-            *stm_guard.reinit_pending.get_mut() = false;
+            stm_guard.reinit_pending.store(false, Ordering::SeqCst);
         });
     }
 


### PR DESCRIPTION
`Atomic*::get_mut()` uses `UnsafeCell` to mutate the value directly, so `Atomic*::get_mut()` is only safe if it's called from a single thread. If `Atomic*::get_mut()` is called from multiple threads, or `Atomic*` is accessible as mutable references in different threads, it will cause the data race. 
Thus, for all the `Atomic*` in the current code, the `*.get_mut()` should be replaced by `*.store()` to avoid the data race. This change will solve the data race found by ThreadSanitizer(#34).