### PR TITLE
Clean up clippy warnings and errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ env:
 before_script:
   - rustc --version
   - cargo --version
-  - rustup component add rustfmt
-  - rustup component add clippy
+  - sh install_rustfmt_clippy.sh
 script:
   - cargo fmt --all -- --check
   - cargo clippy -- -D warnings

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ rust:
   - nightly
 os:
   - osx
+env:
+  - RUST_BACKTRACE=1
 before_script:
   - rustc --version
   - cargo --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ env:
 before_script:
   - rustc --version
   - cargo --version
+  - rustup component add rustfmt
 script:
+  - cargo fmt --all -- --check
   - cargo build --verbose
   - sh run_tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,9 @@ before_script:
   - rustc --version
   - cargo --version
   - rustup component add rustfmt
+  - rustup component add clippy
 script:
   - cargo fmt --all -- --check
+  - cargo clippy -- -D warnings
   - cargo build --verbose
   - sh run_tests.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ atomic = "0.4"
 bitflags = "1.0"
 coreaudio-sys-utils = { path = "coreaudio-sys-utils" }
 cubeb-backend = "0.6"
+float-cmp = "0.6"
 libc = "0.2"
 lazy_static = "1.2"
 mach = "0.3"

--- a/coreaudio-sys-utils/src/audio_unit.rs
+++ b/coreaudio-sys-utils/src/audio_unit.rs
@@ -30,18 +30,19 @@ pub fn audio_unit_get_property<T>(
     property: AudioUnitPropertyID,
     scope: AudioUnitScope,
     element: AudioUnitElement,
-    data: *mut T,
-    size: *mut usize,
+    data: &mut T,
+    size: &mut usize,
 ) -> OSStatus {
     assert!(!unit.is_null());
+    assert!(UInt32::try_from(*size).is_ok()); // Check if `size` can be converted to a UInt32.
     unsafe {
         AudioUnitGetProperty(
             unit,
             property,
             scope,
             element,
-            data as *mut c_void,
-            size as *mut UInt32,
+            data as *mut T as *mut c_void,
+            size as *mut usize as *mut UInt32,
         )
     }
 }

--- a/coreaudio-sys-utils/src/audio_unit.rs
+++ b/coreaudio-sys-utils/src/audio_unit.rs
@@ -1,23 +1,26 @@
 use coreaudio_sys::*;
+use std::convert::TryFrom;
 use std::os::raw::c_void;
+use std::ptr;
 
 pub fn audio_unit_get_property_info(
     unit: AudioUnit,
     property: AudioUnitPropertyID,
     scope: AudioUnitScope,
     element: AudioUnitElement,
-    size: *mut usize,
-    writable: *mut Boolean,
+    size: &mut usize,
+    writable: Option<&mut bool>, // Use `Option` since `writable` is nullable.
 ) -> OSStatus {
     assert!(!unit.is_null());
+    assert!(UInt32::try_from(*size).is_ok()); // Check if `size` can be converted to a UInt32.
     unsafe {
         AudioUnitGetPropertyInfo(
             unit,
             property,
             scope,
             element,
-            size as *mut UInt32,
-            writable,
+            size as *mut usize as *mut UInt32,
+            writable.map_or(ptr::null_mut(), |v| v as *mut bool as *mut Boolean),
         )
     }
 }

--- a/coreaudio-sys-utils/src/audio_unit.rs
+++ b/coreaudio-sys-utils/src/audio_unit.rs
@@ -124,11 +124,11 @@ pub fn audio_output_unit_stop(unit: AudioUnit) -> OSStatus {
 
 pub fn audio_unit_render(
     in_unit: AudioUnit,
-    io_action_flags: *mut AudioUnitRenderActionFlags,
-    in_time_stamp: *const AudioTimeStamp,
+    io_action_flags: &mut AudioUnitRenderActionFlags,
+    in_time_stamp: &AudioTimeStamp,
     in_output_bus_number: u32,
     in_number_frames: u32,
-    io_data: *mut AudioBufferList,
+    io_data: &mut AudioBufferList,
 ) -> OSStatus {
     assert!(!in_unit.is_null());
     unsafe {

--- a/coreaudio-sys-utils/src/audio_unit.rs
+++ b/coreaudio-sys-utils/src/audio_unit.rs
@@ -52,7 +52,7 @@ pub fn audio_unit_set_property<T>(
     property: AudioUnitPropertyID,
     scope: AudioUnitScope,
     element: AudioUnitElement,
-    data: *const T,
+    data: &T,
     size: usize,
 ) -> OSStatus {
     assert!(!unit.is_null());
@@ -62,7 +62,7 @@ pub fn audio_unit_set_property<T>(
             property,
             scope,
             element,
-            data as *const c_void,
+            data as *const T as *const c_void,
             size as UInt32,
         )
     }

--- a/install_rustfmt_clippy.sh
+++ b/install_rustfmt_clippy.sh
@@ -1,0 +1,17 @@
+# https://github.com/rust-lang/rustup-components-history/blob/master/README.md
+# https://github.com/rust-lang/rust-clippy/blob/27acea0a1baac6cf3ac6debfdbce04f91e15d772/.travis.yml#L40-L46
+if ! rustup component add rustfmt; then
+    TARGET=$(rustc -Vv | awk '/host/{print $2}')
+    NIGHTLY=$(curl -s "https://rust-lang.github.io/rustup-components-history/${TARGET}/rustfmt")
+    curl -sSL "https://static.rust-lang.org/dist/${NIGHTLY}/rustfmt-nightly-${TARGET}.tar.xz" | \
+    tar -xJf - --strip-components=3 -C ~/.cargo/bin
+    rm -rf ~/.cargo/bin/doc
+fi
+
+if ! rustup component add clippy; then
+    TARGET=$(rustc -Vv | awk '/host/{print $2}')
+    NIGHTLY=$(curl -s "https://rust-lang.github.io/rustup-components-history/${TARGET}/clippy")
+    rustup default nightly-${NIGHTLY}
+    rustup component add rustfmt
+    rustup component add clippy
+fi

--- a/src/backend/aggregate_device.rs
+++ b/src/backend/aggregate_device.rs
@@ -242,15 +242,14 @@ impl AggregateDevice {
             CFRelease(device_stacked_key as *const c_void);
 
             // This call will fire `audiounit_collection_changed_callback` indirectly!
-            let status = audio_object_get_property_data_with_qualifier(
+            audio_object_get_property_data_with_qualifier(
                 plugin_id,
                 &address,
                 mem::size_of_val(&device_dict),
                 &device_dict,
                 &mut size,
                 &mut device_id,
-            );
-            status
+            )
         };
         if status == NO_ERR {
             assert_ne!(device_id, kAudioObjectUnknown);

--- a/src/backend/device_property.rs
+++ b/src/backend/device_property.rs
@@ -217,6 +217,7 @@ pub fn get_device_stream_format(
     }
 }
 
+#[allow(clippy::cast_ptr_alignment)] // Allow casting *mut u8 to *mut AudioBufferList
 pub fn get_device_stream_configuration(
     id: AudioDeviceID,
     devtype: DeviceType,

--- a/src/backend/device_property.rs
+++ b/src/backend/device_property.rs
@@ -83,7 +83,7 @@ pub fn get_device_label(
     id: AudioDeviceID,
     devtype: DeviceType,
 ) -> std::result::Result<StringRef, OSStatus> {
-    get_device_source_name(id, devtype).or(get_device_name(id, devtype))
+    get_device_source_name(id, devtype).or_else(|_| get_device_name(id, devtype))
 }
 
 pub fn get_device_manufacturer(

--- a/src/backend/mixer.rs
+++ b/src/backend/mixer.rs
@@ -202,7 +202,7 @@ impl Mixer {
         }
 
         let all_silence = vec![audio_mixer::Channel::Silence; out_channel_count];
-        if output_channels.len() == 0
+        if output_channels.is_empty()
             || out_channel_count != output_channels.len()
             || all_silence == output_channels
         {

--- a/src/backend/mixer.rs
+++ b/src/backend/mixer.rs
@@ -44,13 +44,17 @@ pub fn get_channel_order(channel_layout: ChannelLayout) -> Vec<audio_mixer::Chan
 fn get_default_channel_order(channel_count: usize) -> Vec<audio_mixer::Channel> {
     assert_ne!(channel_count, 0);
     let mut channels = Vec::with_capacity(channel_count);
-    for i in 0..channel_count {
-        channels.push(if i < CHANNEL_OERDER.len() {
-            CHANNEL_OERDER[i]
-        } else {
-            audio_mixer::Channel::Silence
-        });
+    for channel in CHANNEL_OERDER.iter().take(channel_count) {
+        channels.push(*channel);
     }
+
+    if channel_count > CHANNEL_OERDER.len() {
+        channels.extend(vec![
+            audio_mixer::Channel::Silence;
+            channel_count - CHANNEL_OERDER.len()
+        ]);
+    }
+
     channels
 }
 
@@ -429,4 +433,18 @@ fn test_get_channel_order() {
             Channel::SideRight
         ]
     );
+}
+
+#[test]
+fn test_get_default_channel_order() {
+    for len in 1..CHANNEL_OERDER.len() + 10 {
+        let channels = get_default_channel_order(len);
+        if len <= CHANNEL_OERDER.len() {
+            assert_eq!(channels, &CHANNEL_OERDER[..len]);
+        } else {
+            let silences = vec![audio_mixer::Channel::Silence; len - CHANNEL_OERDER.len()];
+            assert_eq!(channels[..CHANNEL_OERDER.len()], CHANNEL_OERDER);
+            assert_eq!(&channels[CHANNEL_OERDER.len()..], silences.as_slice());
+        }
+    }
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3217,8 +3217,8 @@ impl<'ctx> AudioUnitStream<'ctx> {
             }
         }
 
-        if vol_rv.is_ok() {
-            set_volume(self.core_stream_data.output_unit, vol_rv.unwrap());
+        if let Ok(volume) = vol_rv {
+            set_volume(self.core_stream_data.output_unit, volume);
         }
 
         // If the stream was running, start it again.

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3041,6 +3041,8 @@ impl<'ctx> Drop for CoreStreamData<'ctx> {
 // #[repr(C)] is used to prevent any padding from being added in the beginning of the AudioUnitStream.
 #[repr(C)]
 #[derive(Debug)]
+// Allow exposing this private struct in public interfaces when running tests.
+#[cfg_attr(test, allow(private_in_public))]
 struct AudioUnitStream<'ctx> {
     context: &'ctx mut AudioUnitContext,
     user_ptr: *mut c_void,

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1771,9 +1771,7 @@ impl DevicesData {
     }
 
     fn is_empty(&self) -> bool {
-        self.changed_callback == None
-            && self.callback_user_ptr == ptr::null_mut()
-            && self.devices.is_empty()
+        self.changed_callback == None && self.callback_user_ptr.is_null() && self.devices.is_empty()
     }
 }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1397,7 +1397,7 @@ fn get_range_of_sample_rates(
 ) -> std::result::Result<(f64, f64), String> {
     let result = get_ranges_of_device_sample_rate(devid, devtype);
     if let Err(e) = result {
-        return Err(format!("status {}", e).to_string());
+        return Err(format!("status {}", e));
     }
     let rates = result.unwrap();
     if rates.is_empty() {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -383,6 +383,12 @@ extern "C" fn audiounit_input_callback(
             user_ptr as *const AudioUnitStream
         );
 
+        // `flags` and `tstamp` must be non-null so they can be casted into the references.
+        assert!(!flags.is_null());
+        let flags = unsafe { &mut (*flags) };
+        assert!(!tstamp.is_null());
+        let tstamp = unsafe { &(*tstamp) };
+
         // Create the AudioBufferList to store input.
         let mut input_buffer_list = AudioBufferList::default();
         input_buffer_list.mBuffers[0].mDataByteSize =

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2394,6 +2394,7 @@ impl<'ctx> CoreStreamData<'ctx> {
             && !is_device_a_type_of(self.output_device.id, DeviceType::INPUT)
     }
 
+    #[allow(clippy::cognitive_complexity)] // TODO: Refactoring.
     fn setup(&mut self) -> Result<()> {
         if self
             .input_stream_params

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -539,14 +539,13 @@ extern "C" fn audiounit_input_callback(
         }
     }
 
-    let status = match handle {
+    match handle {
         ErrorHandle::Reinit => {
             stm.reinit_async();
             NO_ERR
         }
         ErrorHandle::Return(s) => s,
-    };
-    status
+    }
 }
 
 fn host_time_to_ns(host_time: u64) -> u64 {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2141,7 +2141,7 @@ impl ContextOps for AudioUnitContext {
                     cubeb_log!("Fail to create device info for input.");
                     e
                 })?;
-            let stm_params = StreamParams::from(unsafe { (*params.as_ptr()) });
+            let stm_params = StreamParams::from(unsafe { *params.as_ptr() });
             Some((stm_params, in_device))
         } else {
             None
@@ -2153,7 +2153,7 @@ impl ContextOps for AudioUnitContext {
                     cubeb_log!("Fail to create device info for output.");
                     e
                 })?;
-            let stm_params = StreamParams::from(unsafe { (*params.as_ptr()) });
+            let stm_params = StreamParams::from(unsafe { *params.as_ptr() });
             Some((stm_params, out_device))
         } else {
             None

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -925,7 +925,7 @@ fn audiounit_get_preferred_channel_layout(output_unit: AudioUnit) -> Vec<mixer::
         kAudioUnitScope_Output,
         AU_OUT_BUS,
         &mut size,
-        ptr::null_mut(),
+        None,
     );
     if rv != NO_ERR {
         cubeb_log!(
@@ -967,7 +967,7 @@ fn audiounit_get_current_channel_layout(output_unit: AudioUnit) -> Vec<mixer::Ch
         kAudioUnitScope_Output,
         AU_OUT_BUS,
         &mut size,
-        ptr::null_mut(),
+        None,
     );
     if rv != NO_ERR {
         cubeb_log!(

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2741,14 +2741,14 @@ impl<'ctx> CoreStreamData<'ctx> {
         };
 
         let resampler_input_params = if self.has_input() {
-            let mut params = unsafe { (*(self.input_stream_params.as_ptr())) };
+            let mut params = unsafe { *(self.input_stream_params.as_ptr()) };
             params.rate = self.input_hw_rate as u32;
             Some(params)
         } else {
             None
         };
         let resampler_output_params = if self.has_output() {
-            let params = unsafe { (*(self.output_stream_params.as_ptr())) };
+            let params = unsafe { *(self.output_stream_params.as_ptr()) };
             Some(params)
         } else {
             None

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3393,10 +3393,10 @@ impl<'ctx> StreamOps for AudioUnitStream<'ctx> {
 
         let mut device: Box<ffi::cubeb_device> = Box::new(ffi::cubeb_device::default());
 
-        let input_name = input_name.unwrap_or(CString::default());
+        let input_name = input_name.unwrap_or_default();
         device.input_name = input_name.into_raw();
 
-        let output_name = output_name.unwrap_or(CString::default());
+        let output_name = output_name.unwrap_or_default();
         device.output_name = output_name.into_raw();
 
         Ok(unsafe { DeviceRef::from_ptr(Box::into_raw(device)) })

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -328,9 +328,9 @@ fn get_volume(unit: AudioUnit) -> Result<f32> {
 }
 
 fn minimum_resampling_input_frames(input_rate: f64, output_rate: f64, output_frames: i64) -> i64 {
-    assert_ne!(input_rate, 0_f64);
-    assert_ne!(output_rate, 0_f64);
-    if input_rate == output_rate {
+    assert!(!approx_eq!(f64, input_rate, 0_f64));
+    assert!(!approx_eq!(f64, output_rate, 0_f64));
+    if approx_eq!(f64, input_rate, output_rate) {
         return output_frames;
     }
     (input_rate * output_frames as f64 / output_rate).ceil() as i64

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1230,6 +1230,7 @@ fn set_buffer_size(
     }
 }
 
+#[allow(clippy::mutex_atomic)] // The mutex needs to be fed into Condvar::wait_timeout.
 fn set_buffer_size_sync(unit: AudioUnit, devtype: DeviceType, frames: u32) -> Result<()> {
     let current_frames = get_buffer_size(unit, devtype).map_err(|e| {
         cubeb_log!(

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -552,7 +552,7 @@ fn host_time_to_ns(host_time: u64) -> u64 {
     let mut rv: f64 = host_time as f64;
     rv *= HOST_TIME_TO_NS_RATIO.0 as f64;
     rv /= HOST_TIME_TO_NS_RATIO.1 as f64;
-    return rv as u64;
+    rv as u64
 }
 
 fn compute_output_latency(stm: &AudioUnitStream, host_time: u64) -> u32 {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -752,8 +752,8 @@ extern "C" fn audiounit_output_callback(
                 )
             };
             let start = frames_to_bytes(outframes as usize);
-            for i in start..out_bytes.len() {
-                out_bytes[i] = 0;
+            for byte in out_bytes.iter_mut().skip(start) {
+                *byte = 0;
             }
         }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -194,7 +194,7 @@ fn create_device_info(id: AudioDeviceID, devtype: DeviceType) -> Result<device_i
     assert_ne!(id, kAudioObjectSystemObject);
 
     let mut info = device_info {
-        id: id,
+        id,
         flags: match devtype {
             DeviceType::INPUT => device_flags::DEV_INPUT,
             DeviceType::OUTPUT => device_flags::DEV_OUTPUT,

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -730,7 +730,7 @@ fn test_get_preferred_channel_layout_output() {
         ("ispk", STEREO.to_vec()),
         ("FApd", STEREO.to_vec()),
     ]
-    .into_iter()
+    .iter()
     .cloned()
     .collect();
 
@@ -766,7 +766,7 @@ fn test_get_current_channel_layout_output() {
         ("ispk", STEREO.to_vec()),
         ("FApd", STEREO.to_vec()),
     ]
-    .into_iter()
+    .iter()
     .cloned()
     .collect();
 

--- a/src/backend/tests/device_change.rs
+++ b/src/backend/tests/device_change.rs
@@ -337,6 +337,7 @@ fn test_register_device_changed_callback_to_check_default_device_changed(stm_typ
 
     if !run_available {
         println!("No enough devices to run the test!");
+        return;
     }
 
     let changed_count = Arc::new(Mutex::new(0u32));

--- a/src/backend/tests/utils.rs
+++ b/src/backend/tests/utils.rs
@@ -503,6 +503,7 @@ pub fn test_audiounit_scope_is_enabled(unit: AudioUnit, scope: Scope) -> bool {
         Scope::Input => (kAudioUnitScope_Input, AU_IN_BUS),
         Scope::Output => (kAudioUnitScope_Output, AU_OUT_BUS),
     };
+    let mut size = mem::size_of::<UInt32>();
     assert_eq!(
         audio_unit_get_property(
             unit,
@@ -510,7 +511,7 @@ pub fn test_audiounit_scope_is_enabled(unit: AudioUnit, scope: Scope) -> bool {
             scope,
             element,
             &mut has_io,
-            &mut mem::size_of::<UInt32>()
+            &mut size
         ),
         NO_ERR
     );

--- a/src/backend/utils.rs
+++ b/src/backend/utils.rs
@@ -43,7 +43,9 @@ struct Finalizer<F: FnOnce()>(Option<F>);
 
 impl<F: FnOnce()> Drop for Finalizer<F> {
     fn drop(&mut self) {
-        self.0.take().map(|f| f());
+        if let Some(f) = self.0.take() {
+            f()
+        }
     }
 }
 

--- a/src/backend/utils.rs
+++ b/src/backend/utils.rs
@@ -5,18 +5,14 @@
 use cubeb_backend::SampleFormat as fmt;
 use std::mem;
 
-pub fn allocate_array_by_size<T>(size: usize) -> Vec<T> {
+pub fn allocate_array_by_size<T: Clone + Default>(size: usize) -> Vec<T> {
     assert_eq!(size % mem::size_of::<T>(), 0);
     let elements = size / mem::size_of::<T>();
     allocate_array::<T>(elements)
 }
 
-pub fn allocate_array<T>(elements: usize) -> Vec<T> {
-    let mut array = Vec::<T>::with_capacity(elements);
-    unsafe {
-        array.set_len(elements);
-    }
-    array
+pub fn allocate_array<T: Clone + Default>(elements: usize) -> Vec<T> {
+    vec![T::default(); elements]
 }
 
 pub fn forget_vec<T>(v: Vec<T>) -> (*mut T, usize) {

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -7,7 +7,9 @@ use crate::backend::AudioUnitContext;
 use cubeb_backend::{capi, ffi};
 use std::os::raw::{c_char, c_int};
 
-// Entry point from C code.
+/// # Safety
+///
+/// This function should only be called once per process.
 #[no_mangle]
 pub unsafe extern "C" fn audiounit_rust_init(
     c: *mut *mut ffi::cubeb,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@ extern crate bitflags;
 #[macro_use]
 extern crate cubeb_backend;
 #[macro_use]
+extern crate float_cmp;
+#[macro_use]
 extern crate lazy_static;
 extern crate mach;
 


### PR DESCRIPTION
Huge clean up for the *clippy* warnings and errors and enable the `cargo fmt` and `cargo clippy` checks on Travis CI.