### PR TITLE
Run the tests in the subcrate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ before_script:
   - cargo --version
   - sh install_rustfmt_clippy.sh
 script:
-  - cargo fmt --all -- --check
-  - cargo clippy -- -D warnings
   - cargo build --verbose
   - sh run_tests.sh
   - sh run_sanitizers.sh

--- a/run_sanitizers.sh
+++ b/run_sanitizers.sh
@@ -14,6 +14,26 @@ else
    exit
 fi
 
+# Run tests in the sub crate
+# -------------------------------------------------------------------------------------------------
+cd coreaudio-sys-utils
+
+echo "\n\nRun ASan\n-----------\n"
+RUSTFLAGS="-Z sanitizer=address" cargo test
+
+echo "\n\nRun LSan\n-----------\n"
+RUSTFLAGS="-Z sanitizer=leak" cargo test
+
+echo "\n\nRun MSan\n-----------\n"
+RUSTFLAGS="-Z sanitizer=memory" cargo test
+
+echo "\n\nRun TSan\n-----------\n"
+RUSTFLAGS="-Z sanitizer=thread" cargo test
+
+cd ..
+
+# Run tests in the main crate
+# -------------------------------------------------------------------------------------------------
 echo "\n\nRun ASan\n-----------\n"
 RUSTFLAGS="-Z sanitizer=address" sh run_tests.sh
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -4,11 +4,26 @@ export RUST_BACKTRACE=1
 # Run tests in the sub crate
 # -------------------------------------------------------------------------------------------------
 cd coreaudio-sys-utils
+
+# Format check
+cargo fmt --all -- --check
+
+# Lints check
+cargo clippy -- -D warnings
+
+# Regular Tests
 cargo test
+
 cd ..
 
 # Run tests in the main crate
 # -------------------------------------------------------------------------------------------------
+# Format check
+cargo fmt --all -- --check
+
+# Lints check
+cargo clippy -- -D warnings
+
 # Regular Tests
 cargo test --verbose
 cargo test test_configure_output -- --ignored

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,6 +1,14 @@
 # display backtrace for debugging
 export RUST_BACKTRACE=1
 
+# Run tests in the sub crate
+# -------------------------------------------------------------------------------------------------
+cd coreaudio-sys-utils
+cargo test
+cd ..
+
+# Run tests in the main crate
+# -------------------------------------------------------------------------------------------------
 # Regular Tests
 cargo test --verbose
 cargo test test_configure_output -- --ignored


### PR DESCRIPTION
The test in the sub-crate, *coreaudio-sys-utils*, aren't run in both local device and *Travis CI* server. Those tests in the *coreaudio-sys-utils* should also be run with the sanitizers. It will be easier to identify the problem (if any) is in the underlying system API implemented in the sub-crate, or it's in the main crate, by running the tests in the sub crate. 

Running those tests is helpful to diagnose the problem, or narrow down the scope of the problem at least. For example, there are memory leaks found by running *MemorySanitier* with the tests in the *coreaudio-sys-utils*. It indicates the memory is leaking when calling the underlying APIs. It's helpful to address the leak issue found in #45.

On the other hand, the format check and the lints/clippy check should always be run, instead of running in *Travis CI* server only. It makes sure every commit follows the *Rust* coding style properly.

