### PR TITLE
Save the duplicate tests and compilings when running sanitizers

### DIFF
--- a/run_sanitizers.sh
+++ b/run_sanitizers.sh
@@ -14,26 +14,6 @@ else
    exit
 fi
 
-# Run tests in the sub crate
-# -------------------------------------------------------------------------------------------------
-cd coreaudio-sys-utils
-
-echo "\n\nRun ASan\n-----------\n"
-RUSTFLAGS="-Z sanitizer=address" cargo test
-
-echo "\n\nRun LSan\n-----------\n"
-RUSTFLAGS="-Z sanitizer=leak" cargo test
-
-echo "\n\nRun MSan\n-----------\n"
-RUSTFLAGS="-Z sanitizer=memory" cargo test
-
-echo "\n\nRun TSan\n-----------\n"
-RUSTFLAGS="-Z sanitizer=thread" cargo test
-
-cd ..
-
-# Run tests in the main crate
-# -------------------------------------------------------------------------------------------------
 echo "\n\nRun ASan\n-----------\n"
 RUSTFLAGS="-Z sanitizer=address" sh run_tests.sh
 

--- a/run_sanitizers.sh
+++ b/run_sanitizers.sh
@@ -6,22 +6,15 @@
 toolchain=$(rustup default)
 echo "\nUse Rust toolchain: $toolchain"
 
-if [[ $toolchain == nightly-* ]]
-then
-   echo "Run sanitizers!"
-else
+if [[ $toolchain != nightly-* ]]; then
    echo "The sanitizer is only available on Rust Nightly only. Skip."
    exit
 fi
 
-echo "\n\nRun ASan\n-----------\n"
-RUSTFLAGS="-Z sanitizer=address" sh run_tests.sh
-
-echo "\n\nRun LSan\n-----------\n"
-RUSTFLAGS="-Z sanitizer=leak" sh run_tests.sh
-
-echo "\n\nRun MSan\n-----------\n"
-RUSTFLAGS="-Z sanitizer=memory" sh run_tests.sh
-
-echo "\n\nRun TSan\n-----------\n"
-RUSTFLAGS="-Z sanitizer=thread" sh run_tests.sh
+sanitizers=("address" "leak" "memory" "thread")
+for san in "${sanitizers[@]}"
+do
+    San="$(tr '[:lower:]' '[:upper:]' <<< ${san:0:1})${san:1}"
+    echo "\n\nRun ${San}Sanitizer\n------------------------------"
+    RUSTFLAGS="-Z sanitizer=${san}" sh run_tests.sh
+done

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -2,19 +2,24 @@
 export RUST_BACKTRACE=1
 
 # Run tests in the sub crate
+# Run the tests by `cargo * -p <SUB_CRATE>` if it's possible. By doing so, the duplicate compiling
+# between this crate and the <SUB_CRATE> can be saved. The compiling for <SUB_CRATE> can be reused
+# when running `cargo *` with this crate.
 # -------------------------------------------------------------------------------------------------
-cd coreaudio-sys-utils
+SUB_CRATE="coreaudio-sys-utils"
 
 # Format check
+# `cargo fmt -p *` is only usable in workspaces, so a workaround is to enter to the sub crate
+# and then exit from it.
+cd $SUB_CRATE
 cargo fmt --all -- --check
+cd ..
 
 # Lints check
-cargo clippy -- -D warnings
+cargo clippy -p $SUB_CRATE -- -D warnings
 
 # Regular Tests
-cargo test
-
-cd ..
+cargo test -p $SUB_CRATE
 
 # Run tests in the main crate
 # -------------------------------------------------------------------------------------------------

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,4 +1,4 @@
-# display backtrace for debugging
+# Display backtrace for debugging
 export RUST_BACKTRACE=1
 
 # Run tests in the sub crate


### PR DESCRIPTION
There is no need to call `RUSTFLAGS="-Z sanitizer=*" cargo test` under *coreaudio-sys-utils* in *run_sanitizers.sh* directly since running `RUSTFLAGS="-Z sanitizer=address" sh run_tests.sh` under the main run those tests indirectly. The tests in the sub crate will run in *run_tests.sh*.

On the other hand, the *run_tests.sh* should use `cargo * -p <SUB_CRATE>` if it's possible. By doing so, the compiling for `<SUB_CRATE>` can be reused when building for the main crate. It will save plenty of compiling time, especially when compiling the main crate for the sanitizers.
