### PR TITLE
Isolate device tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,15 @@ It's used to verify our callbacks for minitoring the system devices work.
 - Device collection change
   - `cargo test test_device_collection_change -- --ignored --nocapture`
   - Plug/Unplug devices to see events log.
+- Manual Stream Tester
+  - `cargo test test_stream_tester -- --ignored --nocapture`
+    - `c` to create a stream
+    - `d` to destroy a stream
+    - `s` to start the created stream
+    - `t` to stop the created stream
+    - `q` to quit the test
+  - It's useful to simulate the stream bahavior to reproduce the bug we found,
+    with some modified code.
 
 ## TODO
 

--- a/README.md
+++ b/README.md
@@ -43,14 +43,22 @@ by `sh run_sanitizers.sh`.
 The above command will run all the test suits in *run_tests.sh* by all the available _sanitizers_.
 However, it takes a long time for finshing the tests.
 
-### Device Switching
+### Device Tests
+
+Run `run_device_tests.sh`.
+
+If you'd like to run all the device tests with sanitizers,
+use `RUSTFLAGS="-Z sanitizer=<SAN>" sh run_device_tests.sh`
+with valid `<SAN>` such as `address` or `thread`.
+
+#### Device Switching
 
 The system default device will be changed during our tests.
 All the available devices will take turns being the system default device.
 However, after finishing the tests, the default device will be set to the original one.
 The sounds in the tests should be able to continue whatever the system default device is.
 
-### Device Plugging/Unplugging
+#### Device Plugging/Unplugging
 
 We implement APIs simulating plugging or unplugging a device
 by adding or removing an aggregate device programmatically.

--- a/run_device_tests.sh
+++ b/run_device_tests.sh
@@ -1,0 +1,30 @@
+cargo test test_switch_device -- --ignored --nocapture
+cargo test test_plug_and_unplug_device -- --ignored --nocapture
+# cargo test test_register_device_changed_callback -- --ignored --nocapture --test-threads=1
+cargo test test_register_device_changed_callback_to_check_default_device_changed_input -- --ignored --nocapture
+cargo test test_register_device_changed_callback_to_check_default_device_changed_output -- --ignored --nocapture
+cargo test test_register_device_changed_callback_to_check_default_device_changed_duplex -- --ignored --nocapture
+cargo test test_register_device_changed_callback_to_check_input_alive_changed_input -- --ignored --nocapture
+cargo test test_register_device_changed_callback_to_check_input_alive_changed_duplex -- --ignored --nocapture
+
+cargo test test_destroy_input_stream_after_unplugging_a_nondefault_input_device -- --ignored --nocapture
+cargo test test_destroy_input_stream_after_unplugging_a_default_input_device -- --ignored --nocapture
+# FIXIT: The following test will hang since we don't monitor the alive status of the output device
+# cargo test test_destroy_output_stream_after_unplugging_a_nondefault_output_device -- --ignored --nocapture
+cargo test test_destroy_output_stream_after_unplugging_a_default_output_device -- --ignored --nocapture
+cargo test test_destroy_duplex_stream_after_unplugging_a_nondefault_input_device -- --ignored --nocapture
+cargo test test_destroy_duplex_stream_after_unplugging_a_default_input_device -- --ignored --nocapture
+# FIXIT: The following test will hang since we don't monitor the alive status of the output device
+# cargo test test_destroy_duplex_stream_after_unplugging_a_nondefault_output_device -- --ignored --nocapture
+cargo test test_destroy_duplex_stream_after_unplugging_a_default_output_device -- --ignored --nocapture
+
+cargo test test_reinit_input_stream_by_unplugging_a_nondefault_input_device -- --ignored --nocapture
+cargo test test_reinit_input_stream_by_unplugging_a_default_input_device -- --ignored --nocapture
+# FIXIT: The following test will hang since we don't monitor the alive status of the output device
+# cargo test test_reinit_output_stream_by_unplugging_a_nondefault_output_device -- --ignored --nocapture
+cargo test test_reinit_output_stream_by_unplugging_a_default_output_device -- --ignored --nocapture
+cargo test test_reinit_duplex_stream_by_unplugging_a_nondefault_input_device -- --ignored --nocapture
+cargo test test_reinit_duplex_stream_by_unplugging_a_default_input_device -- --ignored --nocapture
+# FIXIT: The following test will hang since we don't monitor the alive status of the output device
+# cargo test test_reinit_duplex_stream_by_unplugging_a_nondefault_output_device -- --ignored --nocapture
+cargo test test_reinit_duplex_stream_by_unplugging_a_default_output_device -- --ignored --nocapture

--- a/run_device_tests.sh
+++ b/run_device_tests.sh
@@ -1,3 +1,11 @@
+echo "\n\nRun device-changed tests\n===================="
+
+if [[ -z "${RUST_BACKTRACE}" ]]; then
+  # Display backtrace for debugging
+  export RUST_BACKTRACE=1
+fi
+echo "RUST_BACKTRACE is set to ${RUST_BACKTRACE}\n"
+
 cargo test test_switch_device -- --ignored --nocapture
 cargo test test_plug_and_unplug_device -- --ignored --nocapture
 # cargo test test_register_device_changed_callback -- --ignored --nocapture --test-threads=1

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,5 +1,10 @@
-# Display backtrace for debugging
-export RUST_BACKTRACE=1
+echo "\n\nTest suite for cubeb-coreaudio\n========================================"
+
+if [[ -z "${RUST_BACKTRACE}" ]]; then
+  # Display backtrace for debugging
+  export RUST_BACKTRACE=1
+fi
+echo "RUST_BACKTRACE is set to ${RUST_BACKTRACE}\n"
 
 # Run tests in the sub crate
 # Run the tests by `cargo * -p <SUB_CRATE>` if it's possible. By doing so, the duplicate compiling

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -38,36 +38,7 @@ cargo test test_aggregate -- --ignored --test-threads=1
 cargo test test_parallel -- --ignored --nocapture --test-threads=1
 
 # Device-changed Tests
-cargo test test_switch_device -- --ignored --nocapture
-cargo test test_plug_and_unplug_device -- --ignored --nocapture
-# cargo test test_register_device_changed_callback -- --ignored --nocapture --test-threads=1
-cargo test test_register_device_changed_callback_to_check_default_device_changed_input -- --ignored --nocapture
-cargo test test_register_device_changed_callback_to_check_default_device_changed_output -- --ignored --nocapture
-cargo test test_register_device_changed_callback_to_check_default_device_changed_duplex -- --ignored --nocapture
-cargo test test_register_device_changed_callback_to_check_input_alive_changed_input -- --ignored --nocapture
-cargo test test_register_device_changed_callback_to_check_input_alive_changed_duplex -- --ignored --nocapture
-
-cargo test test_destroy_input_stream_after_unplugging_a_nondefault_input_device -- --ignored --nocapture
-cargo test test_destroy_input_stream_after_unplugging_a_default_input_device -- --ignored --nocapture
-# FIXIT: The following test will hang since we don't monitor the alive status of the output device
-# cargo test test_destroy_output_stream_after_unplugging_a_nondefault_output_device -- --ignored --nocapture
-cargo test test_destroy_output_stream_after_unplugging_a_default_output_device -- --ignored --nocapture
-cargo test test_destroy_duplex_stream_after_unplugging_a_nondefault_input_device -- --ignored --nocapture
-cargo test test_destroy_duplex_stream_after_unplugging_a_default_input_device -- --ignored --nocapture
-# FIXIT: The following test will hang since we don't monitor the alive status of the output device
-# cargo test test_destroy_duplex_stream_after_unplugging_a_nondefault_output_device -- --ignored --nocapture
-cargo test test_destroy_duplex_stream_after_unplugging_a_default_output_device -- --ignored --nocapture
-
-cargo test test_reinit_input_stream_by_unplugging_a_nondefault_input_device -- --ignored --nocapture
-cargo test test_reinit_input_stream_by_unplugging_a_default_input_device -- --ignored --nocapture
-# FIXIT: The following test will hang since we don't monitor the alive status of the output device
-# cargo test test_reinit_output_stream_by_unplugging_a_nondefault_output_device -- --ignored --nocapture
-cargo test test_reinit_output_stream_by_unplugging_a_default_output_device -- --ignored --nocapture
-cargo test test_reinit_duplex_stream_by_unplugging_a_nondefault_input_device -- --ignored --nocapture
-cargo test test_reinit_duplex_stream_by_unplugging_a_default_input_device -- --ignored --nocapture
-# FIXIT: The following test will hang since we don't monitor the alive status of the output device
-# cargo test test_reinit_duplex_stream_by_unplugging_a_nondefault_output_device -- --ignored --nocapture
-cargo test test_reinit_duplex_stream_by_unplugging_a_default_output_device -- --ignored --nocapture
+sh run_device_tests.sh
 
 # Manual Tests
 # cargo test test_switch_output_device -- --ignored --nocapture


### PR DESCRIPTION
When debugging device-related issues, there is a need to run the device-related tests as quickly as possible, without running the regular tests at first. Instead of commenting the scripts in the *run_tests.sh* to do that, the device-related tests should be isolated in a standalone test script. Then it's easier to run those tests by a command like `sh  run_device_tests.sh`. In addition, it can be run with other available flags together, such as `RUSTFLAGS="-Z sanitizer=*"` or `RUST_BACKTRACE=full`.

Within this change, the *README* is also updated to reflect the usage of the current tests. It helps the readers to know how to test the library in different ways.