### PR TITLE
Rework threading model

### DIFF
--- a/coreaudio-sys-utils/src/dispatch.rs
+++ b/coreaudio-sys-utils/src/dispatch.rs
@@ -68,9 +68,14 @@ impl Queue {
         set_dispatch_context(self.0, context);
     }
 
-    // This will release the inner `dispatch_queue_t` asynchronously.
     fn release(&self) {
-        release_dispatch_queue(self.0);
+        unsafe {
+            // This will release the inner `dispatch_queue_t` asynchronously.
+            // TODO: This is incredibly unsafe. Find another way to release the queue.
+            dispatch_release(mem::transmute::<dispatch_queue_t, dispatch_object_t>(
+                self.0,
+            ));
+        }
     }
 }
 
@@ -89,13 +94,6 @@ impl Clone for Queue {
 
 // Low-level Grand Central Dispatch (GCD) APIs
 // ------------------------------------------------------------------------------------------------
-fn release_dispatch_queue(queue: dispatch_queue_t) {
-    // TODO: This is incredibly unsafe. Find another way to release the queue.
-    unsafe {
-        dispatch_release(mem::transmute::<dispatch_queue_t, dispatch_object_t>(queue));
-    }
-}
-
 fn retain_dispatch_queue(queue: dispatch_queue_t) {
     // TODO: This is incredibly unsafe. Find another way to retain the queue.
     unsafe {

--- a/coreaudio-sys-utils/src/dispatch.rs
+++ b/coreaudio-sys-utils/src/dispatch.rs
@@ -98,7 +98,8 @@ impl Queue {
     fn release(&self) {
         unsafe {
             // This will release the inner `dispatch_queue_t` asynchronously.
-            // TODO: This is incredibly unsafe. Find another way to release the queue.
+            // TODO: It's incredibly unsafe to call `transmute` directly.
+            //       Find another way to release the queue.
             dispatch_release(mem::transmute::<dispatch_queue_t, dispatch_object_t>(
                 self.0,
             ));
@@ -138,7 +139,8 @@ impl Drop for Queue {
 
 impl Clone for Queue {
     fn clone(&self) -> Self {
-        // TODO: This is incredibly unsafe. Find another way to retain the queue.
+        // TODO: It's incredibly unsafe to call `transmute` directly.
+        //       Find another way to release the queue.
         unsafe {
             dispatch_retain(mem::transmute::<dispatch_queue_t, dispatch_object_t>(
                 self.0,

--- a/coreaudio-sys-utils/src/dispatch.rs
+++ b/coreaudio-sys-utils/src/dispatch.rs
@@ -50,9 +50,9 @@ impl Clone for Queue {
 
 // Low-level Grand Central Dispatch (GCD) APIs
 // ------------------------------------------------------------------------------------------------
-pub const DISPATCH_QUEUE_SERIAL: dispatch_queue_attr_t = ptr::null_mut::<dispatch_queue_attr_s>();
+const DISPATCH_QUEUE_SERIAL: dispatch_queue_attr_t = ptr::null_mut::<dispatch_queue_attr_s>();
 
-pub fn create_dispatch_queue(
+fn create_dispatch_queue(
     label: &'static str,
     queue_attr: dispatch_queue_attr_t,
 ) -> dispatch_queue_t {
@@ -61,21 +61,21 @@ pub fn create_dispatch_queue(
     unsafe { dispatch_queue_create(c_string, queue_attr) }
 }
 
-pub fn release_dispatch_queue(queue: dispatch_queue_t) {
+fn release_dispatch_queue(queue: dispatch_queue_t) {
     // TODO: This is incredibly unsafe. Find another way to release the queue.
     unsafe {
         dispatch_release(mem::transmute::<dispatch_queue_t, dispatch_object_t>(queue));
     }
 }
 
-pub fn retain_dispatch_queue(queue: dispatch_queue_t) {
+fn retain_dispatch_queue(queue: dispatch_queue_t) {
     // TODO: This is incredibly unsafe. Find another way to retain the queue.
     unsafe {
         dispatch_retain(mem::transmute::<dispatch_queue_t, dispatch_object_t>(queue));
     }
 }
 
-pub fn async_dispatch<F>(queue: dispatch_queue_t, work: F)
+fn async_dispatch<F>(queue: dispatch_queue_t, work: F)
 where
     F: Send + FnOnce(),
 {
@@ -85,7 +85,7 @@ where
     }
 }
 
-pub fn sync_dispatch<F>(queue: dispatch_queue_t, work: F)
+fn sync_dispatch<F>(queue: dispatch_queue_t, work: F)
 where
     F: Send + FnOnce(),
 {

--- a/coreaudio-sys-utils/src/dispatch.rs
+++ b/coreaudio-sys-utils/src/dispatch.rs
@@ -12,7 +12,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 pub struct Queue(dispatch_queue_t);
 
 impl Queue {
-    pub fn new(label: &'static str) -> Self {
+    pub fn new(label: &str) -> Self {
         Self(create_dispatch_queue(label, DISPATCH_QUEUE_SERIAL))
     }
 
@@ -87,10 +87,7 @@ impl Clone for Queue {
 // ------------------------------------------------------------------------------------------------
 const DISPATCH_QUEUE_SERIAL: dispatch_queue_attr_t = ptr::null_mut::<dispatch_queue_attr_s>();
 
-fn create_dispatch_queue(
-    label: &'static str,
-    queue_attr: dispatch_queue_attr_t,
-) -> dispatch_queue_t {
+fn create_dispatch_queue(label: &str, queue_attr: dispatch_queue_attr_t) -> dispatch_queue_t {
     let label = CString::new(label).unwrap();
     let c_string = label.as_ptr();
     unsafe { dispatch_queue_create(c_string, queue_attr) }

--- a/coreaudio-sys-utils/src/dispatch.rs
+++ b/coreaudio-sys-utils/src/dispatch.rs
@@ -87,20 +87,18 @@ impl Drop for Queue {
 
 impl Clone for Queue {
     fn clone(&self) -> Self {
-        retain_dispatch_queue(self.0);
+        // TODO: This is incredibly unsafe. Find another way to retain the queue.
+        unsafe {
+            dispatch_retain(mem::transmute::<dispatch_queue_t, dispatch_object_t>(
+                self.0,
+            ));
+        }
         Self(self.0)
     }
 }
 
 // Low-level Grand Central Dispatch (GCD) APIs
 // ------------------------------------------------------------------------------------------------
-fn retain_dispatch_queue(queue: dispatch_queue_t) {
-    // TODO: This is incredibly unsafe. Find another way to retain the queue.
-    unsafe {
-        dispatch_retain(mem::transmute::<dispatch_queue_t, dispatch_object_t>(queue));
-    }
-}
-
 fn async_dispatch<F>(queue: dispatch_queue_t, work: F)
 where
     F: Send + FnOnce(),

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1696,12 +1696,12 @@ extern "C" fn audiounit_collection_changed_callback(
 ) -> OSStatus {
     let context = unsafe { &mut *(in_client_data as *mut AudioUnitContext) };
 
-    let queue = context.serial_queue;
+    let queue = context.serial_queue.clone();
     let mutexed_context = Arc::new(Mutex::new(context));
     let also_mutexed_context = Arc::clone(&mutexed_context);
 
     // This can be called from inside an AudioUnit function, dispatch to another queue.
-    async_dispatch(queue, move || {
+    queue.run_async(move || {
         let ctx_guard = also_mutexed_context.lock().unwrap();
         let ctx_ptr = *ctx_guard as *const AudioUnitContext;
 
@@ -1849,10 +1849,7 @@ pub const OPS: Ops = capi_new!(AudioUnitContext, AudioUnitStream);
 #[derive(Debug)]
 pub struct AudioUnitContext {
     _ops: *const Ops,
-    // serial_queue will be created by dispatch_queue_create(create_dispatch_queue)
-    // without ARC(Automatic Reference Counting) support, so it should be released
-    // by dispatch_release(release_dispatch_queue).
-    serial_queue: dispatch_queue_t,
+    serial_queue: Queue,
     latency_controller: Mutex<LatencyController>,
     devices: Mutex<SharedDevices>,
 }
@@ -1861,7 +1858,7 @@ impl AudioUnitContext {
     fn new() -> Self {
         Self {
             _ops: &OPS as *const _,
-            serial_queue: create_dispatch_queue(DISPATCH_QUEUE_LABEL, DISPATCH_QUEUE_SERIAL),
+            serial_queue: Queue::new(DISPATCH_QUEUE_LABEL),
             latency_controller: Mutex::new(LatencyController::default()),
             devices: Mutex::new(SharedDevices::default()),
         }
@@ -2221,8 +2218,6 @@ impl Drop for AudioUnitContext {
         // Unregister the callback if necessary.
         self.remove_devices_changed_listener(DeviceType::INPUT);
         self.remove_devices_changed_listener(DeviceType::OUTPUT);
-
-        release_dispatch_queue(self.serial_queue);
     }
 }
 
@@ -3266,12 +3261,12 @@ impl<'ctx> AudioUnitStream<'ctx> {
             return;
         }
 
-        let queue = self.context.serial_queue;
+        let queue = self.context.serial_queue.clone();
         let mutexed_stm = Arc::new(Mutex::new(self));
         let also_mutexed_stm = Arc::clone(&mutexed_stm);
         // Use a new thread, through the queue, to avoid deadlock when calling
         // Get/SetProperties method from inside notify callback
-        async_dispatch(queue, move || {
+        queue.run_async(move || {
             let mut stm_guard = also_mutexed_stm.lock().unwrap();
             let stm_ptr = *stm_guard as *const AudioUnitStream;
             if stm_guard.destroy_pending.load(Ordering::SeqCst) {
@@ -3327,12 +3322,12 @@ impl<'ctx> AudioUnitStream<'ctx> {
         // Execute the stream destroy work.
         self.destroy_pending.store(true, Ordering::SeqCst);
 
-        let queue = self.context.serial_queue;
+        let queue = self.context.serial_queue.clone();
 
         let stream_ptr = self as *const AudioUnitStream;
         // Execute close in serial queue to avoid collision
         // with reinit when un/plug devices
-        sync_dispatch(queue, move || {
+        queue.run_sync(move || {
             // Call stop_audiounits to avoid potential data race. If there is a running data callback,
             // which locks a mutex inside CoreAudio framework, then this call will block the current
             // thread until the callback is finished since this call asks to lock a mutex inside
@@ -3361,11 +3356,10 @@ impl<'ctx> StreamOps for AudioUnitStream<'ctx> {
         self.draining.store(false, Ordering::SeqCst);
 
         // Execute start in serial queue to avoid racing with destroy or reinit.
-        let queue = self.context.serial_queue;
         let mut result = Err(Error::error());
         let started = &mut result;
         let stream = &self;
-        sync_dispatch(queue, move || {
+        self.context.serial_queue.run_sync(move || {
             *started = stream.core_stream_data.start_audiounits();
         });
 
@@ -3385,9 +3379,8 @@ impl<'ctx> StreamOps for AudioUnitStream<'ctx> {
         self.shutdown.store(true, Ordering::SeqCst);
 
         // Execute stop in serial queue to avoid racing with destroy or reinit.
-        let queue = self.context.serial_queue;
         let stream = &self;
-        sync_dispatch(queue, move || {
+        self.context.serial_queue.run_sync(move || {
             stream.core_stream_data.stop_audiounits();
         });
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2219,9 +2219,14 @@ impl Drop for AudioUnitContext {
             }
         }
 
-        // Unregister the callback if necessary.
-        self.remove_devices_changed_listener(DeviceType::INPUT);
-        self.remove_devices_changed_listener(DeviceType::OUTPUT);
+        // Make sure all the pending (device-collection-changed-callback) tasks
+        // in queue are done, and cancel all the tasks appended after `drop` is executed.
+        let queue = self.serial_queue.clone();
+        queue.run_final(|| {
+            // Unregister the callback if necessary.
+            self.remove_devices_changed_listener(DeviceType::INPUT);
+            self.remove_devices_changed_listener(DeviceType::OUTPUT);
+        });
     }
 }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3330,7 +3330,7 @@ impl<'ctx> AudioUnitStream<'ctx> {
         let stream_ptr = self as *const AudioUnitStream;
         // Execute close in serial queue to avoid collision
         // with reinit when un/plug devices
-        queue.run_sync(move || {
+        queue.run_final(move || {
             // Call stop_audiounits to avoid potential data race. If there is a running data callback,
             // which locks a mutex inside CoreAudio framework, then this call will block the current
             // thread until the callback is finished since this call asks to lock a mutex inside

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2165,6 +2165,10 @@ impl ContextOps for AudioUnitContext {
             global_latency_frames,
         ));
 
+        // Rename the task queue to be an unique label.
+        let queue_label = format!("{}.{:p}", DISPATCH_QUEUE_LABEL, boxed_stream.as_ref());
+        boxed_stream.queue = Queue::new(queue_label.as_str());
+
         boxed_stream.core_stream_data =
             CoreStreamData::new(boxed_stream.as_ref(), in_stm_settings, out_stm_settings);
 


### PR DESCRIPTION
The change made here can address #28, and make sure that no stream task can be executed after the stream is destroyed, which should avoid the potential data race.

The patch creates a struct `Queue` wrapping `dispatch_queue_t`, which will retain and release the reference count of `dispatch_queue_t` when it's created/cloned, or destroyed. By creating the task queue in each stream, the stream's task that don't need to share the common data among all streams can be executed in each stream's own task queue. This change also brings another benefit: now we can know what task can be canceled. All the tasks appended after the stream-destroy task should be canceled.