### PR TITLE
Fix two bugs and add logs

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -660,7 +660,7 @@ extern "C" fn audiounit_output_callback(
             let input_frames_needed = minimum_resampling_input_frames(
                 stm.core_stream_data.input_hw_rate,
                 f64::from(stm.core_stream_data.output_stream_params.rate()),
-                frames_written,
+                output_frames as i64,
             );
             let missing_frames = input_frames_needed - stm.frames_read.load(Ordering::SeqCst);
             // Else if the input has buffered a lot already because the output started late, we

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -204,15 +204,18 @@ fn create_device_info(id: AudioDeviceID, devtype: DeviceType) -> Result<device_i
 
     let default_device_id = audiounit_get_default_device_id(devtype);
     if default_device_id == kAudioObjectUnknown {
+        cubeb_log!("Could not find default audio device for {:?}", devtype);
         return Err(Error::error());
     }
 
     if id == kAudioObjectUnknown {
         info.id = default_device_id;
+        cubeb_log!("Falling back to default device, after having requested a specific device.");
         info.flags |= device_flags::DEV_SELECTED_DEFAULT;
     }
 
     if info.id == default_device_id {
+        cubeb_log!("Requesting default input device.");
         info.flags |= device_flags::DEV_SYSTEM_DEFAULT;
     }
 
@@ -669,7 +672,7 @@ extern "C" fn audiounit_output_callback(
                     .push_zeros(elements);
                 stm.frames_read.store(input_frames_needed, Ordering::SeqCst);
                 cubeb_log!(
-                    "({:p}) {} pushed {} frames of input silence.",
+                    "({:p}) Missing Frames {} pushed {} frames of input silence.",
                     stm.core_stream_data.stm_ptr,
                     if stm.frames_read.load(Ordering::SeqCst) == 0 {
                         "Input hasn't started,"


### PR DESCRIPTION
This is about duplex stream that have to use non-aggregate devices.

Bug #1 (https://github.com/ChunMinChang/cubeb-coreaudio-rs/commit/89147a72e90716d3e4cd37230d4d8f166c15c506) was that we're not draining the `linear_input_buffer`. If the output is super long to start compared to the output, a lot of input audio has been buffered. We need to remove most of the input frames when we have the first output callback. The opposite case was covered, not having audio input data when the first output callback was early.

Bug #2 (https://github.com/ChunMinChang/cubeb-coreaudio-rs/commit/5499668a61454dc7f51bd78ad13ab94b8c1d3f0e) was that the code was completely wrong, the function is to be able to feed the right amount of data into the resampler, to have continuous audio, and to detect when we're under-running, to try to correct it. This is the right code. The C++ has the same bug so it's not cause by rewrite I guess.

Then I'm adding some logs that I found useful to debug (https://github.com/ChunMinChang/cubeb-coreaudio-rs/commit/5499668a61454dc7f51bd78ad13ab94b8c1d3f0e).