### PR TITLE
Try using the model id as group id.

### DIFF
--- a/src/backend/device_property.rs
+++ b/src/backend/device_property.rs
@@ -21,6 +21,23 @@ pub fn get_device_uid(
     }
 }
 
+pub fn get_device_model_uid(
+    id: AudioDeviceID,
+    devtype: DeviceType,
+) -> std::result::Result<StringRef, OSStatus> {
+    assert_ne!(id, kAudioObjectUnknown);
+
+    let address = get_property_address(Property::ModelUID, devtype);
+    let mut size = mem::size_of::<CFStringRef>();
+    let mut uid: CFStringRef = ptr::null();
+    let err = audio_object_get_property_data(id, &address, &mut size, &mut uid);
+    if err == NO_ERR {
+        Ok(StringRef::new(uid as _))
+    } else {
+        Err(err)
+    }
+}
+
 pub fn get_device_source(
     id: AudioDeviceID,
     devtype: DeviceType,
@@ -276,6 +293,7 @@ pub enum Property {
     DeviceStreamFormat,
     DeviceStreams,
     DeviceUID,
+    ModelUID,
     HardwareDefaultInputDevice,
     HardwareDefaultOutputDevice,
     HardwareDevices,
@@ -298,6 +316,7 @@ impl From<Property> for AudioObjectPropertySelector {
             Property::DeviceStreamFormat => kAudioDevicePropertyStreamFormat,
             Property::DeviceStreams => kAudioDevicePropertyStreams,
             Property::DeviceUID => kAudioDevicePropertyDeviceUID,
+            Property::ModelUID => kAudioDevicePropertyModelUID,
             Property::HardwareDefaultInputDevice => kAudioHardwarePropertyDefaultInputDevice,
             Property::HardwareDefaultOutputDevice => kAudioHardwarePropertyDefaultOutputDevice,
             Property::HardwareDevices => kAudioHardwarePropertyDevices,

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1394,7 +1394,8 @@ fn test_create_cubeb_device_info() {
         assert_eq!(info.devid as AudioObjectID, id);
         assert!(!info.device_id.is_null());
         assert!(!info.friendly_name.is_null());
-        assert_eq!(info.group_id, info.device_id);
+        assert!(!info.group_id.is_null());
+
         // TODO: Hit a kAudioHardwareUnknownPropertyError for AirPods
         // assert!(!info.vendor_name.is_null());
 
@@ -1495,8 +1496,8 @@ fn test_device_destroy() {
     let vendor_name = CString::new("test: vendor name").unwrap();
 
     device.device_id = device_id.into_raw();
-    // The group_id is a mirror to device_id in our implementation, so we could skip it.
-    device.group_id = device.device_id;
+    let group_id = CString::new("test: group id").unwrap();
+    device.group_id = group_id.into_raw();
     device.friendly_name = friendly_name.into_raw();
     device.vendor_name = vendor_name.into_raw();
 
@@ -1506,15 +1507,6 @@ fn test_device_destroy() {
     assert!(device.group_id.is_null());
     assert!(device.friendly_name.is_null());
     assert!(device.vendor_name.is_null());
-}
-
-#[test]
-#[should_panic]
-fn test_device_destroy_with_different_device_id_and_group_id() {
-    let mut device = ffi::cubeb_device_info::default();
-    device.device_id = 0xdeaddead as *const _;
-    device.group_id = 0xdeadbeef as *const _;
-    destroy_cubeb_device_info(&mut device);
 }
 
 #[test]


### PR DESCRIPTION
It works for the all the external devices that I have, but not for the
built-in mic/speakers and the trrs plug of the macbook. I wonder if we could hardcode those.