### PR TITLE
Bail if `cargo clippy` or `cargo fmt` fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,11 @@ os:
   - osx
 env:
   - RUST_BACKTRACE=1
+install:
+  - sh install_rustfmt_clippy.sh
 before_script:
   - rustc --version
   - cargo --version
-  - sh install_rustfmt_clippy.sh
 script:
   - cargo build --verbose
   - sh run_tests.sh

--- a/run_sanitizers.sh
+++ b/run_sanitizers.sh
@@ -6,7 +6,7 @@
 toolchain=$(rustup default)
 echo "\nUse Rust toolchain: $toolchain"
 
-if [[ $toolchain != nightly-* ]]; then
+if [[ $toolchain != nightly* ]]; then
    echo "The sanitizer is only available on Rust Nightly only. Skip."
    exit
 fi

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -15,6 +15,19 @@ format_check() {
   return $result
 }
 
+lints_check() {
+  if [[ -n "$1" ]]; then
+    cargo clippy -p $1 -- -D warnings
+  else
+    cargo clippy -- -D warnings
+  fi
+  local result=$?
+  if [[ $result -ne 0 ]]; then
+    echo "Please fix errors with 'cargo clippy' (version $(cargo clippy -- --version))"
+  fi
+  return $result
+}
+
 # Run tests in the sub crate
 # Run the tests by `cargo * -p <SUB_CRATE>` if it's possible. By doing so, the duplicate compiling
 # between this crate and the <SUB_CRATE> can be saved. The compiling for <SUB_CRATE> can be reused
@@ -30,7 +43,7 @@ format_check || exit $?
 cd ..
 
 # Lints check
-cargo clippy -p $SUB_CRATE -- -D warnings
+(lints_check $SUB_CRATE) || exit $?
 
 # Regular Tests
 cargo test -p $SUB_CRATE
@@ -41,7 +54,7 @@ cargo test -p $SUB_CRATE
 format_check || exit $?
 
 # Lints check
-cargo clippy -- -D warnings
+lints_check || exit $?
 
 # Regular Tests
 cargo test --verbose

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -6,6 +6,15 @@ if [[ -z "${RUST_BACKTRACE}" ]]; then
 fi
 echo "RUST_BACKTRACE is set to ${RUST_BACKTRACE}\n"
 
+format_check() {
+  cargo fmt --all -- --check
+  local result=$?
+  if [[ $result -ne 0 ]]; then
+    echo "Please format the code with 'cargo fmt' (version $(cargo fmt -- --version))"
+  fi
+  return $result
+}
+
 # Run tests in the sub crate
 # Run the tests by `cargo * -p <SUB_CRATE>` if it's possible. By doing so, the duplicate compiling
 # between this crate and the <SUB_CRATE> can be saved. The compiling for <SUB_CRATE> can be reused
@@ -17,7 +26,7 @@ SUB_CRATE="coreaudio-sys-utils"
 # `cargo fmt -p *` is only usable in workspaces, so a workaround is to enter to the sub crate
 # and then exit from it.
 cd $SUB_CRATE
-cargo fmt --all -- --check
+format_check || exit $?
 cd ..
 
 # Lints check
@@ -29,7 +38,7 @@ cargo test -p $SUB_CRATE
 # Run tests in the main crate
 # -------------------------------------------------------------------------------------------------
 # Format check
-cargo fmt --all -- --check
+format_check || exit $?
 
 # Lints check
 cargo clippy -- -D warnings


### PR DESCRIPTION
Update the test script to make the failures of `cargo fmt` or `cargo clippy` more obvious, and make Travis server senses it.

This should fix #59 and #60.