### PR TITLE
Revise `destroy_cubeb_device_info`

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1641,21 +1641,25 @@ fn is_aggregate_device(device_info: &ffi::cubeb_device_info) -> bool {
 }
 
 fn destroy_cubeb_device_info(device: &mut ffi::cubeb_device_info) {
-    // This should be mapped to the memory allocation in create_cubeb_device_info.
+    // This should be mapped to the memory allocation in `create_cubeb_device_info`.
+    // The `device_id`, `group_id`, `vendor_name` can be null pointer if the queries
+    // failed, while `friendly_name` will be assigned to a default empty "" string.
     // Set the pointers to null in case it points to some released memory.
     unsafe {
-        assert!(!device.device_id.is_null());
-        let _ = CString::from_raw(device.device_id as *mut _);
-        device.device_id = ptr::null();
-
-        assert!(!device.group_id.is_null());
-        let _ = CString::from_raw(device.group_id as *mut _);
-        device.group_id = ptr::null();
-
-        if !device.friendly_name.is_null() {
-            let _ = CString::from_raw(device.friendly_name as *mut _);
-            device.friendly_name = ptr::null();
+        if !device.device_id.is_null() {
+            let _ = CString::from_raw(device.device_id as *mut _);
+            device.device_id = ptr::null();
         }
+
+        if !device.group_id.is_null() {
+            let _ = CString::from_raw(device.group_id as *mut _);
+            device.group_id = ptr::null();
+        }
+
+        assert!(!device.friendly_name.is_null());
+        let _ = CString::from_raw(device.friendly_name as *mut _);
+        device.friendly_name = ptr::null();
+
         if !device.vendor_name.is_null() {
             let _ = CString::from_raw(device.vendor_name as *mut _);
             device.vendor_name = ptr::null();

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1340,6 +1340,7 @@ fn test_get_device_presentation_latency() {
 }
 
 // create_cubeb_device_info
+// destroy_cubeb_device_info
 // ------------------------------------
 #[test]
 fn test_create_cubeb_device_info() {
@@ -1452,6 +1453,25 @@ fn test_create_device_info_with_unknown_type() {
 }
 
 #[test]
+#[should_panic]
+fn test_device_destroy_empty_device() {
+    let mut device = ffi::cubeb_device_info::default();
+
+    assert!(device.device_id.is_null());
+    assert!(device.group_id.is_null());
+    assert!(device.friendly_name.is_null());
+    assert!(device.vendor_name.is_null());
+
+    // `friendly_name` must be set.
+    destroy_cubeb_device_info(&mut device);
+
+    assert!(device.device_id.is_null());
+    assert!(device.group_id.is_null());
+    assert!(device.friendly_name.is_null());
+    assert!(device.vendor_name.is_null());
+}
+
+#[test]
 fn test_create_device_from_hwdev_with_inout_type() {
     test_create_device_from_hwdev_with_inout_type_by_scope(Scope::Input);
     test_create_device_from_hwdev_with_inout_type_by_scope(Scope::Output);
@@ -1483,47 +1503,6 @@ fn test_is_aggregate_device() {
     let non_aggregate_name_cstring = CString::new("Hello World!").unwrap();
     info.friendly_name = non_aggregate_name_cstring.as_ptr();
     assert!(!is_aggregate_device(&info));
-}
-
-// destroy_cubeb_device_info
-// ------------------------------------
-#[test]
-fn test_device_destroy() {
-    let mut device = ffi::cubeb_device_info::default();
-
-    let device_id = CString::new("test: device id").unwrap();
-    let friendly_name = CString::new("test: friendly name").unwrap();
-    let vendor_name = CString::new("test: vendor name").unwrap();
-
-    device.device_id = device_id.into_raw();
-    let group_id = CString::new("test: group id").unwrap();
-    device.group_id = group_id.into_raw();
-    device.friendly_name = friendly_name.into_raw();
-    device.vendor_name = vendor_name.into_raw();
-
-    destroy_cubeb_device_info(&mut device);
-
-    assert!(device.device_id.is_null());
-    assert!(device.group_id.is_null());
-    assert!(device.friendly_name.is_null());
-    assert!(device.vendor_name.is_null());
-}
-
-#[test]
-fn test_device_destroy_empty_device() {
-    let mut device = ffi::cubeb_device_info::default();
-
-    assert!(device.device_id.is_null());
-    assert!(device.group_id.is_null());
-    assert!(device.friendly_name.is_null());
-    assert!(device.vendor_name.is_null());
-
-    destroy_cubeb_device_info(&mut device);
-
-    assert!(device.device_id.is_null());
-    assert!(device.group_id.is_null());
-    assert!(device.friendly_name.is_null());
-    assert!(device.vendor_name.is_null());
 }
 
 // get_devices_of_type


### PR DESCRIPTION
The `device_id`, `group_id`, and `vendor_name` can be `null` pointer if `get_device_uid`, `get_device_model_uid`, `get_device_manufacturer` fails, while `friendly_name` will always be assigned to a pointer pointing to a valid `CString`. As a result, the memory retrieve of `device_id`, `group_id`, and `vendor_name` should be done only when they are not `null` and we should always assert `friendly_name` points to a valid address.

@padenot : I made a mistake to ask you change the `destroy_cubeb_device_info`. Here is a fix.