### PR TITLE
Revise git hooks

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -15,9 +15,6 @@
 # the standard input in the form:
 #
 #   <local ref> <local sha1> <remote ref> <remote sha1>
-#
-# This sample shows how to prevent push of commits where the log message starts
-# with "WIP" (work in progress).
 
 remote="$1"
 url="$2"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -22,21 +22,7 @@
 remote="$1"
 url="$2"
 
-cargo fmt
+cargo fmt -- --check || (echo "Please run 'cargo fmt'"; false);
 
-if [[ -n `git diff` ]]
-then
-  echo "Please run cargo fmt"
-  git reset -q --hard HEAD
-  exit 1
-fi
-
-cargo clippy
-
-if [[ -n `git diff` ]]
-then
-  echo "Please run cargo clippy"
-  git reset -q --hard HEAD
-  exit 1
-fi
+cargo clippy -- -D warnings || (echo "Please run 'cargo clippy'"; false);
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ after finishing normal tests.
 Most of the tests are executed in `run_tests.sh`.
 Only those tests commented with *FIXIT* are left.
 
+### Git Hooks
+
+You can install _git hooks_ by running `install_git_hook.sh`.
+Then _pre-push_ script will be run and do the `cargo fmt` and `cargo clippy` check
+before the commits are pushed to remote.
+
 ### Run Sanitizers
 
 Run _AddressSanitizer (ASan), LeakSanitizer (LSan), MemorySanitizer (MSan), ThreadSanitizer (TSan)_


### PR DESCRIPTION
The git hook is introduced in #66 but it doesn't work for `cargo clippy` check. Here is the fix.