### PR TITLE
Implement a API to get `groupd_id` with special case handling

### DIFF
--- a/coreaudio-sys-utils/src/string.rs
+++ b/coreaudio-sys-utils/src/string.rs
@@ -44,11 +44,6 @@ impl StringRef {
         Self(string_ref)
     }
 
-    #[allow(clippy::should_implement_trait)] // No need to implement `FromStr` trait for now.
-    pub fn from_str(string: &'static str) -> Self {
-        Self(cfstringref_from_static_string(string) as CFStringRef)
-    }
-
     pub fn into_string(self) -> String {
         self.to_string()
     }

--- a/coreaudio-sys-utils/src/string.rs
+++ b/coreaudio-sys-utils/src/string.rs
@@ -44,6 +44,11 @@ impl StringRef {
         Self(string_ref)
     }
 
+    #[allow(clippy::should_implement_trait)] // No need to implement `FromStr` trait for now.
+    pub fn from_str(string: &'static str) -> Self {
+        Self(cfstringref_from_static_string(string) as CFStringRef)
+    }
+
     pub fn into_string(self) -> String {
         self.to_string()
     }

--- a/src/backend/device_property.rs
+++ b/src/backend/device_property.rs
@@ -114,13 +114,6 @@ pub fn get_device_name(
     }
 }
 
-pub fn get_device_label(
-    id: AudioDeviceID,
-    devtype: DeviceType,
-) -> std::result::Result<StringRef, OSStatus> {
-    get_device_source_name(id, devtype).or_else(|_| get_device_name(id, devtype))
-}
-
 pub fn get_device_manufacturer(
     id: AudioDeviceID,
     devtype: DeviceType,

--- a/src/backend/device_property.rs
+++ b/src/backend/device_property.rs
@@ -1,9 +1,5 @@
 use super::*;
 
-pub fn get_device_global_uid(id: AudioDeviceID) -> std::result::Result<StringRef, OSStatus> {
-    get_device_uid(id, DeviceType::INPUT | DeviceType::OUTPUT)
-}
-
 pub fn get_device_uid(
     id: AudioDeviceID,
     devtype: DeviceType,

--- a/src/backend/device_property.rs
+++ b/src/backend/device_property.rs
@@ -38,6 +38,24 @@ pub fn get_device_model_uid(
     }
 }
 
+#[allow(dead_code)] // `pub` for running test
+pub fn get_device_transport_type(
+    id: AudioDeviceID,
+    devtype: DeviceType,
+) -> std::result::Result<u32, OSStatus> {
+    assert_ne!(id, kAudioObjectUnknown);
+
+    let address = get_property_address(Property::TransportType, devtype);
+    let mut size = mem::size_of::<u32>();
+    let mut transport: u32 = 0;
+    let err = audio_object_get_property_data(id, &address, &mut size, &mut transport);
+    if err == NO_ERR {
+        Ok(transport)
+    } else {
+        Err(err)
+    }
+}
+
 pub fn get_device_source(
     id: AudioDeviceID,
     devtype: DeviceType,
@@ -298,6 +316,7 @@ pub enum Property {
     HardwareDevices,
     ModelUID,
     StreamLatency,
+    TransportType,
 }
 
 impl From<Property> for AudioObjectPropertySelector {
@@ -321,6 +340,7 @@ impl From<Property> for AudioObjectPropertySelector {
             Property::HardwareDevices => kAudioHardwarePropertyDevices,
             Property::ModelUID => kAudioDevicePropertyModelUID,
             Property::StreamLatency => kAudioStreamPropertyLatency,
+            Property::TransportType => kAudioDevicePropertyTransportType,
         }
     }
 }

--- a/src/backend/device_property.rs
+++ b/src/backend/device_property.rs
@@ -293,10 +293,10 @@ pub enum Property {
     DeviceStreamFormat,
     DeviceStreams,
     DeviceUID,
-    ModelUID,
     HardwareDefaultInputDevice,
     HardwareDefaultOutputDevice,
     HardwareDevices,
+    ModelUID,
     StreamLatency,
 }
 
@@ -316,10 +316,10 @@ impl From<Property> for AudioObjectPropertySelector {
             Property::DeviceStreamFormat => kAudioDevicePropertyStreamFormat,
             Property::DeviceStreams => kAudioDevicePropertyStreams,
             Property::DeviceUID => kAudioDevicePropertyDeviceUID,
-            Property::ModelUID => kAudioDevicePropertyModelUID,
             Property::HardwareDefaultInputDevice => kAudioHardwarePropertyDefaultInputDevice,
             Property::HardwareDefaultOutputDevice => kAudioHardwarePropertyDefaultOutputDevice,
             Property::HardwareDevices => kAudioHardwarePropertyDevices,
+            Property::ModelUID => kAudioDevicePropertyModelUID,
             Property::StreamLatency => kAudioStreamPropertyLatency,
         }
     }

--- a/src/backend/device_property.rs
+++ b/src/backend/device_property.rs
@@ -21,6 +21,10 @@ pub fn get_device_uid(
     }
 }
 
+pub fn get_device_global_model_uid(id: AudioDeviceID) -> std::result::Result<StringRef, OSStatus> {
+    get_device_model_uid(id, DeviceType::INPUT | DeviceType::OUTPUT)
+}
+
 pub fn get_device_model_uid(
     id: AudioDeviceID,
     devtype: DeviceType,

--- a/src/backend/device_property.rs
+++ b/src/backend/device_property.rs
@@ -21,10 +21,6 @@ pub fn get_device_uid(
     }
 }
 
-pub fn get_device_global_model_uid(id: AudioDeviceID) -> std::result::Result<StringRef, OSStatus> {
-    get_device_model_uid(id, DeviceType::INPUT | DeviceType::OUTPUT)
-}
-
 pub fn get_device_model_uid(
     id: AudioDeviceID,
     devtype: DeviceType,

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1537,7 +1537,10 @@ fn get_device_group_id(
         }
     }
 
+    // Some devices (e.g. AirPods) might only set the model-uid in the global scope.
+    // The query might fail if the scope is input-only or output-only.
     get_device_model_uid(id, devtype)
+        .or_else(|_| get_device_model_uid(id, DeviceType::INPUT | DeviceType::OUTPUT))
 }
 
 fn create_cubeb_device_info(

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1483,6 +1483,63 @@ fn get_presentation_latency(devid: AudioObjectID, devtype: DeviceType) -> u32 {
     device_latency + stream_latency
 }
 
+fn get_device_group_id(
+    id: AudioDeviceID,
+    devtype: DeviceType,
+) -> std::result::Result<StringRef, OSStatus> {
+    match get_device_transport_type(id, devtype) {
+        // If the device type is "bltn" (builtin)
+        Ok(0x626C_746E) => {
+            cubeb_log!(
+                "transport type is {:?}",
+                convert_uint32_into_string(0x626C_746E)
+            );
+            match get_device_source(id, devtype) {
+                Ok(source) => {
+                    let msg = format!("source is {:?}", convert_uint32_into_string(source));
+                    match source {
+                        // "imic" (internal microphone) or "ispk" (internal speaker)
+                        0x696D_6963 | 0x6973_706B => {
+                            const GROUP_ID: &str = "builtin-internal-mic|spk";
+                            cubeb_log!("{}. Use hardcode group id: {}.", msg, GROUP_ID);
+                            return Ok(StringRef::from_str(GROUP_ID));
+                        }
+                        // "emic" (external microphone) or "hdpn" (headphone)
+                        0x656D_6963 | 0x6864_706E => {
+                            const GROUP_ID: &str = "builtin-external-mic|hdpn";
+                            cubeb_log!("{}. Use hardcode group id: {}", msg, GROUP_ID);
+                            return Ok(StringRef::from_str("builtin-external-mic|hdpn"));
+                        }
+                        _ => {
+                            cubeb_log!("{}. Get model uid instead.", msg);
+                        }
+                    }
+                }
+                Err(e) => {
+                    cubeb_log!(
+                        "Error: {} when getting device source. Get model uid instead.",
+                        e
+                    );
+                }
+            }
+        }
+        Ok(trans_type) => {
+            cubeb_log!(
+                "transport type is {:?}. Get model uid instead.",
+                convert_uint32_into_string(trans_type)
+            );
+        }
+        Err(e) => {
+            cubeb_log!(
+                "Error: {} when getting transport type. Get model uid instead.",
+                e
+            );
+        }
+    }
+
+    get_device_model_uid(id, devtype)
+}
+
 fn create_cubeb_device_info(
     devid: AudioObjectID,
     devtype: DeviceType,
@@ -1517,9 +1574,9 @@ fn create_cubeb_device_info(
         }
     }
 
-    match get_device_model_uid(devid, devtype) {
-        Ok(uid) => {
-            let c_string = uid.into_cstring();
+    match get_device_group_id(devid, devtype) {
+        Ok(group_id) => {
+            let c_string = group_id.into_cstring();
             dev_info.group_id = c_string.into_raw();
         }
         Err(e) => {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1550,6 +1550,10 @@ fn get_device_label(
     get_device_source_name(id, devtype).or_else(|_| get_device_name(id, devtype))
 }
 
+fn get_device_global_uid(id: AudioDeviceID) -> std::result::Result<StringRef, OSStatus> {
+    get_device_uid(id, DeviceType::INPUT | DeviceType::OUTPUT)
+}
+
 fn create_cubeb_device_info(
     devid: AudioObjectID,
     devtype: DeviceType,

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1517,9 +1517,7 @@ fn create_cubeb_device_info(
         }
     }
 
-    // Some devices (e.g., AirPods) fails to get model uid in a specific scope
-    // so we use global scope instead.
-    match get_device_global_model_uid(devid) {
+    match get_device_model_uid(devid, devtype) {
         Ok(uid) => {
             let c_string = uid.into_cstring();
             dev_info.group_id = c_string.into_raw();

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1517,7 +1517,9 @@ fn create_cubeb_device_info(
         }
     }
 
-    match get_device_model_uid(devid, devtype) {
+    // Some devices (e.g., AirPods) fails to get model uid in a specific scope
+    // so we use global scope instead.
+    match get_device_global_model_uid(devid) {
         Ok(uid) => {
             let c_string = uid.into_cstring();
             dev_info.group_id = c_string.into_raw();

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1543,6 +1543,13 @@ fn get_device_group_id(
         .or_else(|_| get_device_model_uid(id, DeviceType::INPUT | DeviceType::OUTPUT))
 }
 
+fn get_device_label(
+    id: AudioDeviceID,
+    devtype: DeviceType,
+) -> std::result::Result<StringRef, OSStatus> {
+    get_device_source_name(id, devtype).or_else(|_| get_device_name(id, devtype))
+}
+
 fn create_cubeb_device_info(
     devid: AudioObjectID,
     devtype: DeviceType,

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1413,6 +1413,12 @@ fn test_get_same_group_id_for_builtin_device_pairs() {
     }
 }
 
+#[test]
+#[should_panic]
+fn test_get_device_group_id_by_unknown_device() {
+    assert!(get_device_group_id(kAudioObjectUnknown, DeviceType::INPUT).is_err());
+}
+
 // get_device_label
 // ------------------------------------
 #[test]

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1339,6 +1339,29 @@ fn test_get_device_presentation_latency() {
     }
 }
 
+// get_device_group_id
+// ------------------------------------
+#[test]
+fn test_get_device_group_id() {
+    if let Some(device) = test_get_default_device(Scope::Input) {
+        match get_device_group_id(device, DeviceType::INPUT) {
+            Ok(id) => println!("input group id: {}", id.into_string()),
+            Err(e) => println!("No input group id. Error: {}", e),
+        }
+    } else {
+        println!("No input device.");
+    }
+
+    if let Some(device) = test_get_default_device(Scope::Output) {
+        match get_device_group_id(device, DeviceType::OUTPUT) {
+            Ok(id) => println!("output group id: {}", id.into_string()),
+            Err(e) => println!("No output group id. Error: {}", e),
+        }
+    } else {
+        println!("No output device.");
+    }
+}
+
 // create_cubeb_device_info
 // destroy_cubeb_device_info
 // ------------------------------------

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1362,6 +1362,31 @@ fn test_get_device_group_id() {
     }
 }
 
+// get_device_label
+// ------------------------------------
+#[test]
+fn test_get_device_label() {
+    if let Some(device) = test_get_default_device(Scope::Input) {
+        let name = get_device_label(device, DeviceType::INPUT).unwrap();
+        println!("input device label: {}", name.into_string());
+    } else {
+        println!("No input device.");
+    }
+
+    if let Some(device) = test_get_default_device(Scope::Output) {
+        let name = get_device_label(device, DeviceType::OUTPUT).unwrap();
+        println!("output device label: {}", name.into_string());
+    } else {
+        println!("No output device.");
+    }
+}
+
+#[test]
+#[should_panic]
+fn test_get_device_label_by_unknown_device() {
+    assert!(get_device_label(kAudioObjectUnknown, DeviceType::INPUT).is_err());
+}
+
 // create_cubeb_device_info
 // destroy_cubeb_device_info
 // ------------------------------------

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1345,7 +1345,7 @@ fn test_get_device_presentation_latency() {
 fn test_get_device_group_id() {
     if let Some(device) = test_get_default_device(Scope::Input) {
         match get_device_group_id(device, DeviceType::INPUT) {
-            Ok(id) => println!("input group id: {}", id.into_string()),
+            Ok(id) => println!("input group id: {:?}", id),
             Err(e) => println!("No input group id. Error: {}", e),
         }
     } else {
@@ -1354,7 +1354,7 @@ fn test_get_device_group_id() {
 
     if let Some(device) = test_get_default_device(Scope::Output) {
         match get_device_group_id(device, DeviceType::OUTPUT) {
-            Ok(id) => println!("output group id: {}", id.into_string()),
+            Ok(id) => println!("output group id: {:?}", id),
             Err(e) => println!("No output group id. Error: {}", e),
         }
     } else {

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1395,8 +1395,7 @@ fn test_create_cubeb_device_info() {
         assert_eq!(info.devid as AudioObjectID, id);
         assert!(!info.device_id.is_null());
         assert!(!info.friendly_name.is_null());
-        // Hit a kAudioHardwareUnknownPropertyError for AirPods
-        // assert!(!info.group_id.is_null());
+        assert!(!info.group_id.is_null());
 
         // TODO: Hit a kAudioHardwareUnknownPropertyError for AirPods
         // assert!(!info.vendor_name.is_null());

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1418,8 +1418,7 @@ fn test_create_cubeb_device_info() {
         assert_eq!(info.devid as AudioObjectID, id);
         assert!(!info.device_id.is_null());
         assert!(!info.friendly_name.is_null());
-        // Hit a kAudioHardwareUnknownPropertyError for AirPods
-        // assert!(!info.group_id.is_null());
+        assert!(!info.group_id.is_null());
 
         // TODO: Hit a kAudioHardwareUnknownPropertyError for AirPods
         // assert!(!info.vendor_name.is_null());

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1395,7 +1395,8 @@ fn test_create_cubeb_device_info() {
         assert_eq!(info.devid as AudioObjectID, id);
         assert!(!info.device_id.is_null());
         assert!(!info.friendly_name.is_null());
-        assert!(!info.group_id.is_null());
+        // Hit a kAudioHardwareUnknownPropertyError for AirPods
+        // assert!(!info.group_id.is_null());
 
         // TODO: Hit a kAudioHardwareUnknownPropertyError for AirPods
         // assert!(!info.vendor_name.is_null());

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1387,6 +1387,32 @@ fn test_get_device_label_by_unknown_device() {
     assert!(get_device_label(kAudioObjectUnknown, DeviceType::INPUT).is_err());
 }
 
+// get_device_global_uid
+// ------------------------------------
+#[test]
+fn test_get_device_global_uid() {
+    // Input device.
+    if let Some(input) = test_get_default_device(Scope::Input) {
+        let uid = get_device_global_uid(input).unwrap();
+        let uid = uid.into_string();
+        assert!(!uid.is_empty());
+    }
+
+    // Output device.
+    if let Some(output) = test_get_default_device(Scope::Output) {
+        let uid = get_device_global_uid(output).unwrap();
+        let uid = uid.into_string();
+        assert!(!uid.is_empty());
+    }
+}
+
+#[test]
+#[should_panic]
+fn test_get_device_global_uid_by_unknwon_device() {
+    // Unknown device.
+    assert!(get_device_global_uid(kAudioObjectUnknown).is_err());
+}
+
 // create_cubeb_device_info
 // destroy_cubeb_device_info
 // ------------------------------------

--- a/src/backend/tests/device_property.rs
+++ b/src/backend/tests/device_property.rs
@@ -1,32 +1,6 @@
 use super::utils::{test_get_default_device, Scope};
 use super::*;
 
-// get_device_global_uid
-// ------------------------------------
-#[test]
-fn test_get_device_global_uid() {
-    // Input device.
-    if let Some(input) = test_get_default_device(Scope::Input) {
-        let uid = get_device_global_uid(input).unwrap();
-        let uid = uid.into_string();
-        assert!(!uid.is_empty());
-    }
-
-    // Output device.
-    if let Some(output) = test_get_default_device(Scope::Output) {
-        let uid = get_device_global_uid(output).unwrap();
-        let uid = uid.into_string();
-        assert!(!uid.is_empty());
-    }
-}
-
-#[test]
-#[should_panic]
-fn test_get_device_global_uid_by_unknwon_device() {
-    // Unknown device.
-    assert!(get_device_global_uid(kAudioObjectUnknown).is_err());
-}
-
 // get_device_uid
 // ------------------------------------
 #[test]

--- a/src/backend/tests/device_property.rs
+++ b/src/backend/tests/device_property.rs
@@ -53,6 +53,36 @@ fn test_get_device_uid_by_unknwon_device() {
     assert!(get_device_uid(kAudioObjectUnknown, DeviceType::INPUT).is_err());
 }
 
+// get_device_model_uid
+// ------------------------------------
+// Some devices (e.g., AirPods) fail to get model uid.
+#[test]
+fn test_get_device_model_uid() {
+    if let Some(device) = test_get_default_device(Scope::Input) {
+        match get_device_model_uid(device, DeviceType::INPUT) {
+            Ok(uid) => println!("input model uid: {}", uid.into_string()),
+            Err(e) => println!("No input model uid. Error: {}", e),
+        }
+    } else {
+        println!("No input device.");
+    }
+
+    if let Some(device) = test_get_default_device(Scope::Output) {
+        match get_device_model_uid(device, DeviceType::OUTPUT) {
+            Ok(uid) => println!("output model uid: {}", uid.into_string()),
+            Err(e) => println!("No output model uid. Error: {}", e),
+        }
+    } else {
+        println!("No output device.");
+    }
+}
+
+#[test]
+#[should_panic]
+fn test_get_device_model_uid_by_unknown_device() {
+    assert!(get_device_model_uid(kAudioObjectUnknown, DeviceType::INPUT).is_err());
+}
+
 // get_device_source
 // ------------------------------------
 // Some USB headsets (e.g., Plantronic .Audio 628) fails to get data source.

--- a/src/backend/tests/device_property.rs
+++ b/src/backend/tests/device_property.rs
@@ -396,7 +396,6 @@ fn test_get_device_stream_configuration() {
     if let Some(device) = test_get_default_device(Scope::Input) {
         let buffers = get_device_stream_configuration(device, DeviceType::INPUT).unwrap();
         println!("input stream config: {:?}", buffers);
-        dbg!(buffers);
     } else {
         println!("No input device.");
     }
@@ -404,7 +403,6 @@ fn test_get_device_stream_configuration() {
     if let Some(device) = test_get_default_device(Scope::Output) {
         let buffers = get_device_stream_configuration(device, DeviceType::OUTPUT).unwrap();
         println!("output stream config: {:?}", buffers);
-        dbg!(buffers);
     } else {
         println!("No output device.");
     }

--- a/src/backend/tests/device_property.rs
+++ b/src/backend/tests/device_property.rs
@@ -53,25 +53,6 @@ fn test_get_device_uid_by_unknwon_device() {
     assert!(get_device_uid(kAudioObjectUnknown, DeviceType::INPUT).is_err());
 }
 
-// get_device_global_model_uid
-// ------------------------------------
-#[test]
-fn test_get_device_global_model_uid() {
-    // Input device.
-    if let Some(input) = test_get_default_device(Scope::Input) {
-        let uid = get_device_global_model_uid(input).unwrap();
-        let uid = uid.into_string();
-        assert!(!uid.is_empty());
-    }
-
-    // Output device.
-    if let Some(output) = test_get_default_device(Scope::Output) {
-        let uid = get_device_global_model_uid(output).unwrap();
-        let uid = uid.into_string();
-        assert!(!uid.is_empty());
-    }
-}
-
 // get_device_model_uid
 // ------------------------------------
 // Some devices (e.g., AirPods) fail to get model uid.

--- a/src/backend/tests/device_property.rs
+++ b/src/backend/tests/device_property.rs
@@ -83,6 +83,43 @@ fn test_get_device_model_uid_by_unknown_device() {
     assert!(get_device_model_uid(kAudioObjectUnknown, DeviceType::INPUT).is_err());
 }
 
+// get_device_transport_type
+// ------------------------------------
+#[test]
+fn test_get_device_transport_type() {
+    if let Some(device) = test_get_default_device(Scope::Input) {
+        match get_device_transport_type(device, DeviceType::INPUT) {
+            Ok(trans_type) => println!(
+                "input transport type: {:X}, {:?}",
+                trans_type,
+                convert_uint32_into_string(trans_type)
+            ),
+            Err(e) => println!("No input transport type. Error: {}", e),
+        }
+    } else {
+        println!("No input device.");
+    }
+
+    if let Some(device) = test_get_default_device(Scope::Output) {
+        match get_device_transport_type(device, DeviceType::OUTPUT) {
+            Ok(trans_type) => println!(
+                "output transport type: {:X}, {:?}",
+                trans_type,
+                convert_uint32_into_string(trans_type)
+            ),
+            Err(e) => println!("No output transport type. Error: {}", e),
+        }
+    } else {
+        println!("No output device.");
+    }
+}
+
+#[test]
+#[should_panic]
+fn test_get_device_transport_type_by_unknown_device() {
+    assert!(get_device_transport_type(kAudioObjectUnknown, DeviceType::INPUT).is_err());
+}
+
 // get_device_source
 // ------------------------------------
 // Some USB headsets (e.g., Plantronic .Audio 628) fails to get data source.

--- a/src/backend/tests/device_property.rs
+++ b/src/backend/tests/device_property.rs
@@ -212,31 +212,6 @@ fn test_get_device_name_by_unknown_device() {
     assert!(get_device_name(kAudioObjectUnknown, DeviceType::INPUT).is_err());
 }
 
-// get_device_label
-// ------------------------------------
-#[test]
-fn test_get_device_label() {
-    if let Some(device) = test_get_default_device(Scope::Input) {
-        let name = get_device_label(device, DeviceType::INPUT).unwrap();
-        println!("input device label: {}", name.into_string());
-    } else {
-        println!("No input device.");
-    }
-
-    if let Some(device) = test_get_default_device(Scope::Output) {
-        let name = get_device_label(device, DeviceType::OUTPUT).unwrap();
-        println!("output device label: {}", name.into_string());
-    } else {
-        println!("No output device.");
-    }
-}
-
-#[test]
-#[should_panic]
-fn test_get_device_label_by_unknown_device() {
-    assert!(get_device_label(kAudioObjectUnknown, DeviceType::INPUT).is_err());
-}
-
 // get_device_manufacturer
 // ------------------------------------
 #[test]

--- a/src/backend/tests/device_property.rs
+++ b/src/backend/tests/device_property.rs
@@ -89,28 +89,26 @@ fn test_get_device_model_uid_by_unknown_device() {
 #[test]
 fn test_get_device_source() {
     if let Some(device) = test_get_default_device(Scope::Input) {
-        if let Ok(source) = get_device_source(device, DeviceType::INPUT) {
-            println!(
+        match get_device_source(device, DeviceType::INPUT) {
+            Ok(source) => println!(
                 "input: {:X}, {:?}",
                 source,
                 convert_uint32_into_string(source)
-            );
-        } else {
-            println!("No input data source.");
+            ),
+            Err(e) => println!("No input data source. Error: {}", e),
         }
     } else {
         println!("No input device.");
     }
 
     if let Some(device) = test_get_default_device(Scope::Output) {
-        if let Ok(source) = get_device_source(device, DeviceType::OUTPUT) {
-            println!(
+        match get_device_source(device, DeviceType::OUTPUT) {
+            Ok(source) => println!(
                 "output: {:X}, {:?}",
                 source,
                 convert_uint32_into_string(source)
-            );
-        } else {
-            println!("No output data source.");
+            ),
+            Err(e) => println!("No output data source. Error: {}", e),
         }
     } else {
         println!("No output device.");
@@ -128,20 +126,18 @@ fn test_get_device_source_by_unknown_device() {
 #[test]
 fn test_get_device_source_name() {
     if let Some(device) = test_get_default_device(Scope::Input) {
-        if let Ok(name) = get_device_source_name(device, DeviceType::INPUT) {
-            println!("input: {}", name.into_string());
-        } else {
-            println!("No input data source name.");
+        match get_device_source_name(device, DeviceType::INPUT) {
+            Ok(name) => println!("input: {}", name.into_string()),
+            Err(e) => println!("No input data source name. Error: {}", e),
         }
     } else {
         println!("No input device.");
     }
 
     if let Some(device) = test_get_default_device(Scope::Output) {
-        if let Ok(name) = get_device_source_name(device, DeviceType::OUTPUT) {
-            println!("output: {}", name.into_string());
-        } else {
-            println!("No output data source name.");
+        match get_device_source_name(device, DeviceType::OUTPUT) {
+            Ok(name) => println!("output: {}", name.into_string()),
+            Err(e) => println!("No output data source name. Error: {}", e),
         }
     } else {
         println!("No output device.");

--- a/src/backend/tests/device_property.rs
+++ b/src/backend/tests/device_property.rs
@@ -128,7 +128,7 @@ fn test_get_device_source() {
     if let Some(device) = test_get_default_device(Scope::Input) {
         match get_device_source(device, DeviceType::INPUT) {
             Ok(source) => println!(
-                "input: {:X}, {:?}",
+                "input source: {:X}, {:?}",
                 source,
                 convert_uint32_into_string(source)
             ),
@@ -141,7 +141,7 @@ fn test_get_device_source() {
     if let Some(device) = test_get_default_device(Scope::Output) {
         match get_device_source(device, DeviceType::OUTPUT) {
             Ok(source) => println!(
-                "output: {:X}, {:?}",
+                "output source: {:X}, {:?}",
                 source,
                 convert_uint32_into_string(source)
             ),

--- a/src/backend/tests/device_property.rs
+++ b/src/backend/tests/device_property.rs
@@ -53,6 +53,25 @@ fn test_get_device_uid_by_unknwon_device() {
     assert!(get_device_uid(kAudioObjectUnknown, DeviceType::INPUT).is_err());
 }
 
+// get_device_global_model_uid
+// ------------------------------------
+#[test]
+fn test_get_device_global_model_uid() {
+    // Input device.
+    if let Some(input) = test_get_default_device(Scope::Input) {
+        let uid = get_device_global_model_uid(input).unwrap();
+        let uid = uid.into_string();
+        assert!(!uid.is_empty());
+    }
+
+    // Output device.
+    if let Some(output) = test_get_default_device(Scope::Output) {
+        let uid = get_device_global_model_uid(output).unwrap();
+        let uid = uid.into_string();
+        assert!(!uid.is_empty());
+    }
+}
+
 // get_device_model_uid
 // ------------------------------------
 // Some devices (e.g., AirPods) fail to get model uid.


### PR DESCRIPTION
This address #73. In general, we use *model-uid* as `group_id` of *cuben-device-info*. However, the `group_id` for *built-in mic* and *built-in speaker* might be different (or *TRRS mic* and *TRRS headphone*), so we use a hardcode `group_id` for those devices. 

On the other hand, I find my *AirPods* will return an error when querying `kAudioDevicePropertyModelUID` within input or output scope (`kAudioDevicePropertyScopeInput` or `kAudioDevicePropertyScopeOutput`), but it's ok within global (`kAudioObjectPropertyScopeGlobal`) scope. So it might be good if we fallback to use global scope for querying *model-uid* when querying in input or output scope fails.