### PR TITLE
Remove most of the `Debug` trait

### DIFF
--- a/coreaudio-sys-utils/src/audio_object.rs
+++ b/coreaudio-sys-utils/src/audio_object.rs
@@ -111,7 +111,6 @@ pub fn audio_object_remove_property_listener<T>(
     unsafe { AudioObjectRemovePropertyListener(id, address, Some(listener), data as *mut c_void) }
 }
 
-#[derive(Debug)]
 pub struct PropertySelector(AudioObjectPropertySelector);
 
 impl PropertySelector {

--- a/coreaudio-sys-utils/src/dispatch.rs
+++ b/coreaudio-sys-utils/src/dispatch.rs
@@ -8,7 +8,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 // Queue: A wrapper around `dispatch_queue_t`.
 // ------------------------------------------------------------------------------------------------
-#[derive(Debug)]
 pub struct Queue(dispatch_queue_t);
 
 impl Queue {

--- a/coreaudio-sys-utils/src/string.rs
+++ b/coreaudio-sys-utils/src/string.rs
@@ -36,7 +36,6 @@ pub fn cfstringref_from_string(string: &str) -> coreaudio_sys::CFStringRef {
     cfstringref as coreaudio_sys::CFStringRef
 }
 
-#[derive(Debug)]
 pub struct StringRef(CFStringRef);
 impl StringRef {
     pub fn new(string_ref: CFStringRef) -> Self {

--- a/src/backend/aggregate_device.rs
+++ b/src/backend/aggregate_device.rs
@@ -4,12 +4,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 const APPLE_EVENT_TIMEOUT: OSStatus = -1712;
 pub const DRIFT_COMPENSATION: u32 = 1;
 
-#[derive(Debug)]
 pub struct AggregateDevice {
     plugin_id: AudioObjectID,
     device_id: AudioObjectID,
-    input_id: AudioObjectID,
-    output_id: AudioObjectID,
+    _input_id: AudioObjectID,
+    _output_id: AudioObjectID,
 }
 
 impl AggregateDevice {
@@ -49,8 +48,8 @@ impl AggregateDevice {
         Ok(Self {
             plugin_id,
             device_id,
-            input_id,
-            output_id,
+            _input_id: input_id,
+            _output_id: output_id,
         })
     }
 
@@ -602,8 +601,8 @@ impl Default for AggregateDevice {
         Self {
             plugin_id: kAudioObjectUnknown,
             device_id: kAudioObjectUnknown,
-            input_id: kAudioObjectUnknown,
-            output_id: kAudioObjectUnknown,
+            _input_id: kAudioObjectUnknown,
+            _output_id: kAudioObjectUnknown,
         }
     }
 }

--- a/src/backend/mixer.rs
+++ b/src/backend/mixer.rs
@@ -58,7 +58,6 @@ fn get_default_channel_order(channel_count: usize) -> Vec<audio_mixer::Channel> 
     channels
 }
 
-#[derive(Debug)]
 enum MixerType {
     IntegerMixer(audio_mixer::Mixer<i16>),
     FloatMixer(audio_mixer::Mixer<f32>),
@@ -161,7 +160,6 @@ impl MixerType {
     }
 }
 
-#[derive(Debug)]
 pub struct Mixer {
     mixer: MixerType,
     // Only accessed from callback thread.

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2280,7 +2280,6 @@ impl Drop for AudioUnitContext {
 unsafe impl Send for AudioUnitContext {}
 unsafe impl Sync for AudioUnitContext {}
 
-#[derive(Debug)]
 struct CoreStreamData<'ctx> {
     stm_ptr: *const AudioUnitStream<'ctx>,
     aggregate_device: AggregateDevice,
@@ -3116,7 +3115,6 @@ impl<'ctx> Drop for CoreStreamData<'ctx> {
 // defined pointer. The Cubeb interface use this assumption to operate the Cubeb APIs.
 // #[repr(C)] is used to prevent any padding from being added in the beginning of the AudioUnitStream.
 #[repr(C)]
-#[derive(Debug)]
 // Allow exposing this private struct in public interfaces when running tests.
 #[cfg_attr(test, allow(private_in_public))]
 struct AudioUnitStream<'ctx> {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1838,7 +1838,6 @@ impl Default for DevicesData {
     }
 }
 
-#[derive(Debug)]
 struct SharedDevices {
     input: DevicesData,
     output: DevicesData,

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -118,7 +118,6 @@ impl Default for device_info {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Debug)]
 struct device_property_listener {
     device: AudioDeviceID,
     property: AudioObjectPropertyAddress,

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -138,7 +138,7 @@ impl device_property_listener {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(PartialEq)]
 struct CAChannelLabel(AudioChannelLabel);
 
 impl Into<mixer::Channel> for CAChannelLabel {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1853,7 +1853,6 @@ impl Default for SharedDevices {
     }
 }
 
-#[derive(Debug)]
 struct LatencyController {
     streams: u32,
     latency: Option<u32>,

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1898,7 +1898,6 @@ pub const OPS: Ops = capi_new!(AudioUnitContext, AudioUnitStream);
 // the Cubeb APIs on different implementation.
 // #[repr(C)] is used to prevent any padding from being added in the beginning of the AudioUnitContext.
 #[repr(C)]
-#[derive(Debug)]
 pub struct AudioUnitContext {
     _ops: *const Ops,
     serial_queue: Queue,

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1789,7 +1789,6 @@ extern "C" fn audiounit_collection_changed_callback(
     NO_ERR
 }
 
-#[derive(Debug)]
 struct DevicesData {
     changed_callback: ffi::cubeb_device_collection_changed_callback,
     callback_user_ptr: *mut c_void,

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -96,10 +96,16 @@ fn make_sized_audio_channel_layout(sz: usize) -> AutoRelease<AudioChannelLayout>
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 struct device_info {
     id: AudioDeviceID,
     flags: device_flags,
+}
+
+impl std::fmt::Display for device_info {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{{ id: {}, flags: {:?} }}", self.id, self.flags)
+    }
 }
 
 impl Default for device_info {
@@ -2494,7 +2500,7 @@ impl<'ctx> CoreStreamData<'ctx> {
         // Configure I/O stream
         if self.has_input() {
             cubeb_log!(
-                "({:p}) Initialize input by device info: {:?}",
+                "({:p}) Initialize input by device info: {}",
                 self.stm_ptr,
                 in_dev_info
             );
@@ -2639,7 +2645,7 @@ impl<'ctx> CoreStreamData<'ctx> {
 
         if self.has_output() {
             cubeb_log!(
-                "({:p}) Initialize output by device info: {:?}",
+                "({:p}) Initialize output by device info: {}",
                 self.stm_ptr,
                 out_dev_info
             );

--- a/src/backend/resampler.rs
+++ b/src/backend/resampler.rs
@@ -3,7 +3,6 @@ use cubeb_backend::ffi;
 use std::os::raw::{c_long, c_uint, c_void};
 use std::ptr;
 
-#[derive(Debug)]
 pub struct Resampler(AutoRelease<ffi::cubeb_resampler>);
 
 impl Resampler {


### PR DESCRIPTION
This should address #56. This change removes all the `Debug` traits in the implementation, except the `Debug` trait for `AutoArray*` stuff. `AutoArray*` may be replaced by *ringbuf* soon so I don't bother to change it.