### PR TITLE
Revert `derive(Debug)` removal

### DIFF
--- a/coreaudio-sys-utils/src/audio_object.rs
+++ b/coreaudio-sys-utils/src/audio_object.rs
@@ -111,6 +111,7 @@ pub fn audio_object_remove_property_listener<T>(
     unsafe { AudioObjectRemovePropertyListener(id, address, Some(listener), data as *mut c_void) }
 }
 
+#[derive(Debug)]
 pub struct PropertySelector(AudioObjectPropertySelector);
 
 impl PropertySelector {

--- a/coreaudio-sys-utils/src/dispatch.rs
+++ b/coreaudio-sys-utils/src/dispatch.rs
@@ -8,6 +8,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 // Queue: A wrapper around `dispatch_queue_t`.
 // ------------------------------------------------------------------------------------------------
+#[derive(Debug)]
 pub struct Queue(dispatch_queue_t);
 
 impl Queue {

--- a/coreaudio-sys-utils/src/string.rs
+++ b/coreaudio-sys-utils/src/string.rs
@@ -36,6 +36,7 @@ pub fn cfstringref_from_string(string: &str) -> coreaudio_sys::CFStringRef {
     cfstringref as coreaudio_sys::CFStringRef
 }
 
+#[derive(Debug)]
 pub struct StringRef(CFStringRef);
 impl StringRef {
     pub fn new(string_ref: CFStringRef) -> Self {

--- a/src/backend/aggregate_device.rs
+++ b/src/backend/aggregate_device.rs
@@ -4,11 +4,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
 const APPLE_EVENT_TIMEOUT: OSStatus = -1712;
 pub const DRIFT_COMPENSATION: u32 = 1;
 
+#[derive(Debug)]
 pub struct AggregateDevice {
     plugin_id: AudioObjectID,
     device_id: AudioObjectID,
-    _input_id: AudioObjectID,
-    _output_id: AudioObjectID,
+    input_id: AudioObjectID,
+    output_id: AudioObjectID,
 }
 
 impl AggregateDevice {
@@ -48,8 +49,8 @@ impl AggregateDevice {
         Ok(Self {
             plugin_id,
             device_id,
-            _input_id: input_id,
-            _output_id: output_id,
+            input_id,
+            output_id,
         })
     }
 
@@ -601,8 +602,8 @@ impl Default for AggregateDevice {
         Self {
             plugin_id: kAudioObjectUnknown,
             device_id: kAudioObjectUnknown,
-            _input_id: kAudioObjectUnknown,
-            _output_id: kAudioObjectUnknown,
+            input_id: kAudioObjectUnknown,
+            output_id: kAudioObjectUnknown,
         }
     }
 }

--- a/src/backend/buffer_manager.rs
+++ b/src/backend/buffer_manager.rs
@@ -1,5 +1,6 @@
 use std::os::raw::c_void;
 use std::slice;
+use std::fmt;
 
 use cubeb_backend::SampleFormat;
 
@@ -172,5 +173,11 @@ impl BufferManager {
                 c.pop_slice(&mut slice_to_pop.0);
             }
         }
+    }
+}
+
+impl fmt::Debug for BufferManager {
+    fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Ok(())
     }
 }

--- a/src/backend/mixer.rs
+++ b/src/backend/mixer.rs
@@ -58,6 +58,7 @@ fn get_default_channel_order(channel_count: usize) -> Vec<audio_mixer::Channel> 
     channels
 }
 
+#[derive(Debug)]
 enum MixerType {
     IntegerMixer(audio_mixer::Mixer<i16>),
     FloatMixer(audio_mixer::Mixer<f32>),
@@ -160,6 +161,7 @@ impl MixerType {
     }
 }
 
+#[derive(Debug)]
 pub struct Mixer {
     mixer: MixerType,
     // Only accessed from callback thread.

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -96,16 +96,10 @@ fn make_sized_audio_channel_layout(sz: usize) -> AutoRelease<AudioChannelLayout>
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct device_info {
     id: AudioDeviceID,
     flags: device_flags,
-}
-
-impl std::fmt::Display for device_info {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{{ id: {}, flags: {:?} }}", self.id, self.flags)
-    }
 }
 
 impl Default for device_info {
@@ -118,6 +112,7 @@ impl Default for device_info {
 }
 
 #[allow(non_camel_case_types)]
+#[derive(Debug)]
 struct device_property_listener {
     device: AudioDeviceID,
     property: AudioObjectPropertyAddress,
@@ -138,7 +133,7 @@ impl device_property_listener {
     }
 }
 
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 struct CAChannelLabel(AudioChannelLabel);
 
 impl Into<mixer::Channel> for CAChannelLabel {
@@ -1682,6 +1677,7 @@ extern "C" fn audiounit_collection_changed_callback(
     NO_ERR
 }
 
+#[derive(Debug)]
 struct DevicesData {
     changed_callback: ffi::cubeb_device_collection_changed_callback,
     callback_user_ptr: *mut c_void,
@@ -1730,6 +1726,7 @@ impl Default for DevicesData {
     }
 }
 
+#[derive(Debug)]
 struct SharedDevices {
     input: DevicesData,
     output: DevicesData,
@@ -1744,6 +1741,7 @@ impl Default for SharedDevices {
     }
 }
 
+#[derive(Debug)]
 struct LatencyController {
     streams: u32,
     latency: Option<u32>,
@@ -1788,6 +1786,7 @@ pub const OPS: Ops = capi_new!(AudioUnitContext, AudioUnitStream);
 // the Cubeb APIs on different implementation.
 // #[repr(C)] is used to prevent any padding from being added in the beginning of the AudioUnitContext.
 #[repr(C)]
+#[derive(Debug)]
 pub struct AudioUnitContext {
     _ops: *const Ops,
     serial_queue: Queue,
@@ -2174,6 +2173,7 @@ impl Drop for AudioUnitContext {
 unsafe impl Send for AudioUnitContext {}
 unsafe impl Sync for AudioUnitContext {}
 
+#[derive(Debug)]
 struct CoreStreamData<'ctx> {
     stm_ptr: *const AudioUnitStream<'ctx>,
     aggregate_device: AggregateDevice,
@@ -2386,7 +2386,7 @@ impl<'ctx> CoreStreamData<'ctx> {
         // Configure I/O stream
         if self.has_input() {
             cubeb_log!(
-                "({:p}) Initialize input by device info: {}",
+                "({:p}) Initialize input by device info: {:?}",
                 self.stm_ptr,
                 in_dev_info
             );
@@ -2522,7 +2522,7 @@ impl<'ctx> CoreStreamData<'ctx> {
 
         if self.has_output() {
             cubeb_log!(
-                "({:p}) Initialize output by device info: {}",
+                "({:p}) Initialize output by device info: {:?}",
                 self.stm_ptr,
                 out_dev_info
             );
@@ -2998,6 +2998,7 @@ impl<'ctx> Drop for CoreStreamData<'ctx> {
 // defined pointer. The Cubeb interface use this assumption to operate the Cubeb APIs.
 // #[repr(C)] is used to prevent any padding from being added in the beginning of the AudioUnitStream.
 #[repr(C)]
+#[derive(Debug)]
 // Allow exposing this private struct in public interfaces when running tests.
 #[cfg_attr(test, allow(private_in_public))]
 struct AudioUnitStream<'ctx> {

--- a/src/backend/resampler.rs
+++ b/src/backend/resampler.rs
@@ -3,6 +3,7 @@ use cubeb_backend::ffi;
 use std::os::raw::{c_long, c_uint, c_void};
 use std::ptr;
 
+#[derive(Debug)]
 pub struct Resampler(AutoRelease<ffi::cubeb_resampler>);
 
 impl Resampler {


### PR DESCRIPTION
This will ease merging until we remove debug from other related crates