### PR TITLE
Revise prepush when deleting branch

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -26,12 +26,19 @@ IS_DESTRUCTIVE="\-\-delete|\-f"
 PROTECTED_BRANCH="trailblazer"
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
+WILL_DELETE_PROTECTED_BRANCH=":$PROTECTED_BRANCH"
+
 if [[ $PUSH_COMMAND =~ $IS_DESTRUCTIVE ]]; then
     if [ $CURRENT_BRANCH = $PROTECTED_BRANCH ] || [[ $PUSH_COMMAND =~ $PROTECTED_BRANCH ]]; then
         echo "'$PROTECTED_BRANCH' cannot be deleted!"
         exit 1
     fi
     exit 0
+fi
+
+if [[ $PUSH_COMMAND =~ $WILL_DELETE_PROTECTED_BRANCH ]]; then
+    echo "'$PROTECTED_BRANCH' cannot be deleted!"
+    exit 1
 fi
 
 cargo fmt -- --check || (echo "Please run 'cargo fmt'"; false);

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -16,8 +16,8 @@
 #
 #   <local ref> <local sha1> <remote ref> <remote sha1>
 
-remote="$1"
-url="$2"
+REMOTE="$1"
+URL="$2"
 
 cargo fmt -- --check || (echo "Please run 'cargo fmt'"; false);
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -23,7 +23,14 @@ PUSH_COMMAND=$(ps -ocommand= -p $PPID)
 
 IS_DESTRUCTIVE="\-\-delete|\-f"
 
+PROTECTED_BRANCH="trailblazer"
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
 if [[ $PUSH_COMMAND =~ $IS_DESTRUCTIVE ]]; then
+    if [ $CURRENT_BRANCH = $PROTECTED_BRANCH ] || [[ $PUSH_COMMAND =~ $PROTECTED_BRANCH ]]; then
+        echo "'$PROTECTED_BRANCH' cannot be deleted!"
+        exit 1
+    fi
     exit 0
 fi
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -19,6 +19,14 @@
 REMOTE="$1"
 URL="$2"
 
+PUSH_COMMAND=$(ps -ocommand= -p $PPID)
+
+IS_DESTRUCTIVE="\-\-delete|\-f"
+
+if [[ $PUSH_COMMAND =~ $IS_DESTRUCTIVE ]]; then
+    exit 0
+fi
+
 cargo fmt -- --check || (echo "Please run 'cargo fmt'"; false);
 
 cargo clippy -- -D warnings || (echo "Please run 'cargo clippy'"; false);

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 # An example hook script to verify what is about to be pushed.  Called by "git
 # push" after it has checked the remote status, but before anything has been

--- a/run_device_tests.sh
+++ b/run_device_tests.sh
@@ -1,8 +1,8 @@
 echo "\n\nRun device-changed tests\n===================="
 
 if [[ -z "${RUST_BACKTRACE}" ]]; then
-  # Display backtrace for debugging
-  export RUST_BACKTRACE=1
+    # Display backtrace for debugging
+    export RUST_BACKTRACE=1
 fi
 echo "RUST_BACKTRACE is set to ${RUST_BACKTRACE}\n"
 

--- a/run_sanitizers.sh
+++ b/run_sanitizers.sh
@@ -7,8 +7,8 @@ toolchain=$(rustup default)
 echo "\nUse Rust toolchain: $toolchain"
 
 if [[ $toolchain != nightly* ]]; then
-   echo "The sanitizer is only available on Rust Nightly only. Skip."
-   exit
+    echo "The sanitizer is only available on Rust Nightly only. Skip."
+    exit
 fi
 
 sanitizers=("address" "leak" "memory" "thread")

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,31 +1,31 @@
 echo "\n\nTest suite for cubeb-coreaudio\n========================================"
 
 if [[ -z "${RUST_BACKTRACE}" ]]; then
-  # Display backtrace for debugging
-  export RUST_BACKTRACE=1
+    # Display backtrace for debugging
+    export RUST_BACKTRACE=1
 fi
 echo "RUST_BACKTRACE is set to ${RUST_BACKTRACE}\n"
 
 format_check() {
-  cargo fmt --all -- --check
-  local result=$?
-  if [[ $result -ne 0 ]]; then
-    echo "Please format the code with 'cargo fmt' (version $(cargo fmt -- --version))"
-  fi
-  return $result
+    cargo fmt --all -- --check
+    local result=$?
+    if [[ $result -ne 0 ]]; then
+        echo "Please format the code with 'cargo fmt' (version $(cargo fmt -- --version))"
+    fi
+    return $result
 }
 
 lints_check() {
-  if [[ -n "$1" ]]; then
-    cargo clippy -p $1 -- -D warnings
-  else
-    cargo clippy -- -D warnings
-  fi
-  local result=$?
-  if [[ $result -ne 0 ]]; then
-    echo "Please fix errors with 'cargo clippy' (version $(cargo clippy -- --version))"
-  fi
-  return $result
+    if [[ -n "$1" ]]; then
+        cargo clippy -p $1 -- -D warnings
+    else
+        cargo clippy -- -D warnings
+    fi
+    local result=$?
+    if [[ $result -ne 0 ]]; then
+        echo "Please fix errors with 'cargo clippy' (version $(cargo clippy -- --version))"
+    fi
+    return $result
 }
 
 # Run tests in the sub crate


### PR DESCRIPTION
When deleting a branch, there is no need to run `cargo fmt` and `cargo clippy`, so we should skip those checks. On the other hand, we should prevent the main branch from being deleted, so a check is added to prepush. In addition, the indent of all the scripts are updated to 4 spaces.