### PR TITLE
Stop test immediately when error happens

### DIFF
--- a/run_device_tests.sh
+++ b/run_device_tests.sh
@@ -1,3 +1,5 @@
+set -e
+
 echo "\n\nRun device-changed tests\n===================="
 
 if [[ -z "${RUST_BACKTRACE}" ]]; then

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,3 +1,5 @@
+set -e
+
 echo "\n\nTest suite for cubeb-coreaudio\n========================================"
 
 if [[ -z "${RUST_BACKTRACE}" ]]; then


### PR DESCRIPTION
We should stop the tests immediately when one test fails so the failure won't be ignored on Travis CI server and can be noticed easily.