### PR TITLE
Update core-foundation-sys

### DIFF
--- a/coreaudio-sys-utils/Cargo.toml
+++ b/coreaudio-sys-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coreaudio-sys-utils"
-version = "0.1.1"
+version = "0.1.0"
 authors = ["Chun-Min Chang <chun.m.chang@gmail.com>"]
 edition = "2018"
 license = "ISC"

--- a/coreaudio-sys-utils/Cargo.toml
+++ b/coreaudio-sys-utils/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "coreaudio-sys-utils"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Chun-Min Chang <chun.m.chang@gmail.com>"]
 edition = "2018"
 license = "ISC"
 
 [dependencies]
-core-foundation-sys = { version = "0.6" }
+core-foundation-sys = { version = "0.7" }
 
 [dependencies.coreaudio-sys]
 default-features = false


### PR DESCRIPTION
This is a strawman PR: I don't know anything about this library, in particular - about whether the dependency is public or not. I'm trying to align Gecko to the same `core-foundation-sys` and this would let us drop 0.6 from third-party dependencies (as a part of https://phabricator.services.mozilla.com/D70140)