### PR TITLE
Update to cubeb-backend 0.6.3.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["staticlib", "rlib"]
 atomic = "0.4"
 bitflags = "1.0"
 coreaudio-sys-utils = { path = "coreaudio-sys-utils" }
-cubeb-backend = "0.6"
+cubeb-backend = "0.6.3"
 float-cmp = "0.6"
 libc = "0.2"
 lazy_static = "1.2"


### PR DESCRIPTION
For [BMO 1628132](https://bugzilla.mozilla.org/show_bug.cgi?id=1628132).