### PR TITLE
Correct input buffer for the resampler

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -624,7 +624,7 @@ extern "C" fn audiounit_output_callback(
                 cubeb_log!("Dropping {} frames in input buffer.", popped_samples);
             }
 
-            if input_frames_needed > buffered_input_frames
+            let input_buffer_frames = if input_frames_needed > buffered_input_frames
                 && (stm.switching_device.load(Ordering::SeqCst)
                     || stm.frames_read.load(Ordering::SeqCst) == 0)
             {
@@ -643,12 +643,15 @@ extern "C" fn audiounit_output_callback(
                     },
                     silent_frames_to_push
                 );
-            }
+                input_frames_needed
+            } else {
+                buffered_input_frames
+            };
 
-            let input_samples_needed = input_frames_needed * input_channels;
+            let input_samples_needed = input_buffer_frames * input_channels;
             (
                 input_buffer_manager.get_linear_data(input_samples_needed),
-                input_frames_needed as i64,
+                input_buffer_frames as i64,
             )
         } else {
             (ptr::null_mut::<c_void>(), 0)

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -645,10 +645,10 @@ extern "C" fn audiounit_output_callback(
                 );
             }
 
-            let input_samples_needed = buffered_input_frames * input_channels;
+            let input_samples_needed = input_frames_needed * input_channels;
             (
                 input_buffer_manager.get_linear_data(input_samples_needed),
-                buffered_input_frames as i64,
+                input_frames_needed as i64,
             )
         } else {
             (ptr::null_mut::<c_void>(), 0)

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -624,7 +624,7 @@ extern "C" fn audiounit_output_callback(
                 cubeb_log!("Dropping {} frames in input buffer.", popped_samples);
             }
 
-            let input_buffer_frames = if input_frames_needed > buffered_input_frames
+            let input_frames = if input_frames_needed > buffered_input_frames
                 && (stm.switching_device.load(Ordering::SeqCst)
                     || stm.frames_read.load(Ordering::SeqCst) == 0)
             {
@@ -648,10 +648,10 @@ extern "C" fn audiounit_output_callback(
                 buffered_input_frames
             };
 
-            let input_samples_needed = input_buffer_frames * input_channels;
+            let input_samples_needed = input_frames * input_channels;
             (
                 input_buffer_manager.get_linear_data(input_samples_needed),
-                input_buffer_frames as i64,
+                input_frames as i64,
             )
         } else {
             (ptr::null_mut::<c_void>(), 0)


### PR DESCRIPTION
The change here fixes #91 and complete what we want to do in #86.

The `assert(destination && source)` in [1] will be hit in the following
scenario:

1. `audiounit_output_callback` comes before `audiounit_input_callback`
2. `audiounit_input_callback` is never called before 1
3. `input_buffer_manager.available_samples()` is `0` since no buffered
   input data
4. the `input_frame_count` of the *first* `ffi::cubeb_resampler_fill`
   would be `0`

The *silent frames* needs to be fed as the input buffer to the
resampler.

[1] https://github.com/kinetiknz/cubeb/blob/35190a8da650be297edb91d2db778bed622d8691/src/cubeb_utils.h#L31