### PR TITLE
Correct stream identifier in log

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2235,7 +2235,7 @@ impl ContextOps for AudioUnitContext {
         let cubeb_stream = unsafe { Stream::from_ptr(Box::into_raw(boxed_stream) as *mut _) };
         cubeb_log!(
             "({:p}) Cubeb stream init successful.",
-            &cubeb_stream as *const Stream
+            cubeb_stream.as_ref()
         );
         Ok(cubeb_stream)
     }


### PR DESCRIPTION
This change will correct the cubeb stream identifier in the last log in `stream_init`.

In the last log in `stream`, `&cubeb_stream` is used to be the cubeb stream identifier but that is incorrect. The output of the log would be:
```
mod.rs:2790: (0x7f8884710e10) Output audiounit init with device 194 successfully.
mod.rs:2236: (0x7ffee737a630) Cubeb stream init successful.
```

The correct stream identifier should be `cubeb_stream.as_ref()` (or `cubeb_stream.as_ptr()`) and the output would be corrected to:
```
mod.rs:2790: (0x7f8caa711370) Output audiounit init with device 194 successfully.
mod.rs:2236: (0x7f8caa711370) Cubeb stream init successful.
```