### PR TITLE
`0` is valid buffer-frame-size

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1147,7 +1147,6 @@ fn get_buffer_size(unit: AudioUnit, devtype: DeviceType) -> std::result::Result<
         &mut size,
     );
     if status == NO_ERR {
-        assert_ne!(frames, 0);
         Ok(frames)
     } else {
         Err(status)


### PR DESCRIPTION
The current implementation `panic!()` when getting a `0` buffer-frame-size. However, by [BMO 1637347](https://bugzilla.mozilla.org/show_bug.cgi?id=1637347), `0` is a valid buffer-frame-size value in the wild.