### PR TITLE
Return a position even when not latency info are available

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3477,7 +3477,7 @@ impl<'ctx> StreamOps for AudioUnitStream<'ctx> {
             };
             return Ok(position);
         }
-        Err(Error::error())
+        Ok(frames_played)
     }
     #[cfg(target_os = "ios")]
     fn latency(&mut self) -> Result<u32> {


### PR DESCRIPTION
The behaviour changed in
https://github.com/ChunMinChang/cubeb-coreaudio-rs/commit/38e0c0ffebf2902e310f7ed35e90cfe92075cf5c