### PR TITLE
Fix clock reporting by using the correct latency number

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3468,14 +3468,14 @@ impl<'ctx> StreamOps for AudioUnitStream<'ctx> {
         Err(Error::not_supported())
     }
     fn position(&mut self) -> Result<u64> {
-        let current_output_latency_frames =
-            u64::from(self.current_output_latency_frames.load(Ordering::SeqCst));
+        let total_output_latency_frames =
+            u64::from(self.total_output_latency_frames.load(Ordering::SeqCst));
         let frames_played = self.frames_played.load(Ordering::SeqCst);
-        if current_output_latency_frames != 0 {
-            let position = if current_output_latency_frames > frames_played {
+        if total_output_latency_frames != 0 {
+            let position = if total_output_latency_frames > frames_played {
                 0
             } else {
-                frames_played - current_output_latency_frames
+                frames_played - total_output_latency_frames
             };
             return Ok(position);
         }


### PR DESCRIPTION
It's wrong, but it matters more in some scenarii than others:

Testing on my mbp 2018 with the built-in output device the device + stream latency is 17 frames, and the total latency (taking into account the timestamp provided in the callback) is 544. This was at 48kHz and this translates to 300us and 11.3ms respectively. Quite a big difference, but not really noticeable for A/V sync when not looking for it, I assume.

For a bluetooth device (Sony WH1000-XM3) on the same machine, it's 7872 frames of latency for the device, and 9148 total, still at 48kHz, this translates to respectively 164ms and 190ms, which is quite a lot (a bit less than two frames at 60fps, a bit less than a frame at 30fps). 

Not the end of the world, but still better. This [mailing list post](https://lists.apple.com/archives/coreaudio-api/2017/Jul/msg00035.html) has background on this.