### PR TITLE
Return an error if sub-device-change cannot be monitored

### DIFF
--- a/src/backend/aggregate_device.rs
+++ b/src/backend/aggregate_device.rs
@@ -276,15 +276,15 @@ impl AggregateDevice {
         let mut cloned_condvar_pair = condvar_pair.clone();
         let data_ptr = &mut cloned_condvar_pair as *mut Arc<(Mutex<AudioObjectID>, Condvar)>;
 
-        assert_eq!(
-            audio_object_add_property_listener(
-                device_id,
-                &address,
-                devices_changed_callback,
-                data_ptr as *mut c_void,
-            ),
-            NO_ERR
+        let status = audio_object_add_property_listener(
+            device_id,
+            &address,
+            devices_changed_callback,
+            data_ptr as *mut c_void,
         );
+        if status != NO_ERR {
+            return Err(status);
+        }
 
         let _teardown = finally(|| {
             assert_eq!(


### PR DESCRIPTION
This patch tries to address [BMO 1658982](https://bugzilla.mozilla.org/show_bug.cgi?id=1658982).

One of the assertions in `set_sub_devices_sync` can be hit in the wild.
The crash-stack doesn't show which assertion is hit. My guess is that
the newly created aggregate-device may not be ready yet, to be used to
watch its own property-change, even if the created device is already in
the process-wide device list.

@kinetiknz : r?