### PR TITLE
Call `audio_object_{add, remove}_property_listener` outside of `assert_eq`

### DIFF
--- a/src/backend/aggregate_device.rs
+++ b/src/backend/aggregate_device.rs
@@ -114,26 +114,23 @@ impl AggregateDevice {
             Property::HardwareDevices,
             DeviceType::INPUT | DeviceType::OUTPUT,
         );
-        assert_eq!(
-            audio_object_add_property_listener(
+
+        let r = audio_object_add_property_listener(
+            kAudioObjectSystemObject,
+            &address,
+            devices_changed_callback,
+            data_ptr as *mut c_void,
+        );
+        assert_eq!(r, NO_ERR);
+
+        let _teardown = finally(|| {
+            let r = audio_object_remove_property_listener(
                 kAudioObjectSystemObject,
                 &address,
                 devices_changed_callback,
                 data_ptr as *mut c_void,
-            ),
-            NO_ERR
-        );
-
-        let _teardown = finally(|| {
-            assert_eq!(
-                audio_object_remove_property_listener(
-                    kAudioObjectSystemObject,
-                    &address,
-                    devices_changed_callback,
-                    data_ptr as *mut c_void,
-                ),
-                NO_ERR
             );
+            assert_eq!(r, NO_ERR);
         });
 
         let device = Self::create_blank_device(plugin_id)?;
@@ -287,15 +284,13 @@ impl AggregateDevice {
         }
 
         let _teardown = finally(|| {
-            assert_eq!(
-                audio_object_remove_property_listener(
-                    device_id,
-                    &address,
-                    devices_changed_callback,
-                    data_ptr as *mut c_void,
-                ),
-                NO_ERR
+            let r = audio_object_remove_property_listener(
+                device_id,
+                &address,
+                devices_changed_callback,
+                data_ptr as *mut c_void,
             );
+            assert_eq!(r, NO_ERR);
         });
 
         Self::set_sub_devices(device_id, input_id, output_id)?;


### PR DESCRIPTION
In `create_blank_device_sync`, `audio_object_{add, remove}_property_listener` is called within a `assert_eq!`, which may not be executed in optimized build.