### PR TITLE
Bump cubeb-backend to 0.8 and add stubbed `StreamOps::set_name` implementation.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["staticlib", "rlib"]
 atomic = "0.4"
 bitflags = "1.0"
 coreaudio-sys-utils = { path = "coreaudio-sys-utils" }
-cubeb-backend = "0.7"
+cubeb-backend = "0.8"
 float-cmp = "0.6"
 libc = "0.2"
 lazy_static = "1.2"

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3539,6 +3539,9 @@ impl<'ctx> StreamOps for AudioUnitStream<'ctx> {
     fn set_volume(&mut self, volume: f32) -> Result<()> {
         set_volume(self.core_stream_data.output_unit, volume)
     }
+    fn set_name(&mut self, _: &CStr) -> Result<()> {
+        Err(Error::not_supported())
+    }
     #[cfg(target_os = "ios")]
     fn current_device(&mut self) -> Result<&DeviceRef> {
         Err(not_supported())


### PR DESCRIPTION
Related to https://github.com/kinetiknz/cubeb/pull/615

r? @ChunMinChang please