### PR TITLE
Use default channel layout if layout have non silent duplicate channels

### DIFF
--- a/src/backend/mixer.rs
+++ b/src/backend/mixer.rs
@@ -212,7 +212,7 @@ impl Mixer {
         if output_channels.is_empty()
             || out_channel_count != output_channels.len()
             || all_silence == output_channels
-            || Self::have_non_silent_duplicate_channels(&output_channels)
+            || Self::non_silent_duplicate_channel_present(&output_channels)
         {
             cubeb_log!("Use invalid layout. Apply default layout instead");
             output_channels = get_default_channel_order(out_channel_count);
@@ -259,7 +259,7 @@ impl Mixer {
         )
     }
 
-    fn have_non_silent_duplicate_channels(channels: &[audio_mixer::Channel]) -> bool {
+    fn non_silent_duplicate_channel_present(channels: &[audio_mixer::Channel]) -> bool {
         let mut bitmap: u32 = 0;
         for channel in channels {
             if channel != &Channel::Silence {
@@ -476,7 +476,7 @@ fn test_non_silent_duplicate_channels() {
         Channel::Silence,
         Channel::FrontRight,
     ];
-    assert!(Mixer::have_non_silent_duplicate_channels(&duplicate));
+    assert!(Mixer::non_silent_duplicate_channel_present(&duplicate));
 
     let non_duplicate = [
         Channel::FrontLeft,
@@ -486,5 +486,5 @@ fn test_non_silent_duplicate_channels() {
         Channel::Silence,
         Channel::Silence,
     ];
-    assert!(!Mixer::have_non_silent_duplicate_channels(&non_duplicate));
+    assert!(!Mixer::non_silent_duplicate_channel_present(&non_duplicate));
 }

--- a/src/backend/mixer.rs
+++ b/src/backend/mixer.rs
@@ -212,6 +212,7 @@ impl Mixer {
         if output_channels.is_empty()
             || out_channel_count != output_channels.len()
             || all_silence == output_channels
+            || Self::have_non_silent_duplicate_channels(&output_channels)
         {
             cubeb_log!("Use invalid layout. Apply default layout instead");
             output_channels = get_default_channel_order(out_channel_count);
@@ -256,6 +257,19 @@ impl Mixer {
             self.buffer.as_ptr(),
             self.buffer.len() * mem::size_of::<u8>(),
         )
+    }
+
+    fn have_non_silent_duplicate_channels(channels: &[audio_mixer::Channel]) -> bool {
+        let mut bitmap: u32 = 0;
+        for channel in channels {
+            if channel != &Channel::Silence {
+                if (bitmap & channel.bitmask()) != 0 {
+                    return true;
+                }
+                bitmap |= channel.bitmask();
+            }
+        }
+        false
     }
 }
 
@@ -450,4 +464,27 @@ fn test_get_default_channel_order() {
             assert_eq!(&channels[CHANNEL_OERDER.len()..], silences.as_slice());
         }
     }
+}
+
+#[test]
+fn test_non_silent_duplicate_channels() {
+    let duplicate = [
+        Channel::FrontLeft,
+        Channel::Silence,
+        Channel::FrontRight,
+        Channel::FrontCenter,
+        Channel::Silence,
+        Channel::FrontRight,
+    ];
+    assert!(Mixer::have_non_silent_duplicate_channels(&duplicate));
+
+    let non_duplicate = [
+        Channel::FrontLeft,
+        Channel::Silence,
+        Channel::FrontRight,
+        Channel::FrontCenter,
+        Channel::Silence,
+        Channel::Silence,
+    ];
+    assert!(!Mixer::have_non_silent_duplicate_channels(&non_duplicate));
 }


### PR DESCRIPTION
This solves the [BMO 1675719](https://bugzilla.mozilla.org/show_bug.cgi?id=1675719).

The channel layout set in the output device might have non silent
duplicate channels (e.g., having two Front-Right in the channels), which
is not a valid case of our audio mixer usages. It will lead to a panic in
our code. The Audio MIDI Setup on MacOS disallows setting duplicate
channels within a channel layout. It will throw a "Overlapping Channels"
error in that case. It implies that the "overlapping channels" setting
is not defined by the user. It's likely to be defined in the firmware
instead. Since the user doesn't ask it explicitly, it's not necessary to
accept this kind of layout that is forbidden on Mac OS by default.

When there are duplicate non-silent channel in the output channel
layout, we can ignore this invalid channel layout and apply a standard
SMPTE layout instead.