### PR TITLE
Bail out in `activate_clock_drift_compensation` if no enough sub devices

### DIFF
--- a/src/backend/aggregate_device.rs
+++ b/src/backend/aggregate_device.rs
@@ -15,7 +15,7 @@ pub struct AggregateDevice {
 pub enum Error {
     OS(OSStatus),
     Timeout(std::time::Duration),
-    LessDevicesThan2(usize),
+    LessThan2Devices(usize),
 }
 
 impl From<OSStatus> for Error {
@@ -32,7 +32,7 @@ impl From<std::time::Duration> for Error {
 
 impl From<usize> for Error {
     fn from(number: usize) -> Self {
-        Error::LessDevicesThan2(number)
+        Error::LessThan2Devices(number)
     }
 }
 
@@ -41,7 +41,7 @@ impl std::fmt::Display for Error {
         match self {
             Error::OS(status) => write!(f, "OSStatus({})", status),
             Error::Timeout(duration) => write!(f, "Timeout({:?})", duration),
-            Error::LessDevicesThan2(number) => write!(f, "LessDevicesThan2({} only)", number),
+            Error::LessThan2Devices(number) => write!(f, "LessThan2Devices({} only)", number),
         }
     }
 }
@@ -523,7 +523,7 @@ impl AggregateDevice {
                 device_id,
                 subdevices_num
             );
-            return Err(Error::LessDevicesThan2(subdevices_num));
+            return Err(Error::LessThan2Devices(subdevices_num));
         }
         let mut sub_devices: Vec<AudioObjectID> = allocate_array(subdevices_num);
         let status = audio_object_get_property_data_with_qualifier(

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2474,12 +2474,12 @@ impl<'ctx> CoreStreamData<'ctx> {
                         self.aggregate_device.get_device_id()
                     );
                 }
-                Err(status) => {
+                Err(e) => {
                     cubeb_log!(
                         "({:p}) Create aggregate devices failed. Error: {}.\
                          Use assigned devices directly instead.",
                         self.stm_ptr,
-                        status
+                        e
                     );
                 }
             }


### PR DESCRIPTION
This works around the crash in [BMO 1677766](https://bugzilla.mozilla.org/show_bug.cgi?id=1677766).

It's not clear why the number of the owning sub-devices in the created
aggregate device is less than 2, after setting sub devices from input
and output sides via `AggregateDevice::set_sub_devices_sync`. The
sub-devices should be set synchronously when the above function is
called. Maybe `kAudioObjectPropertyOwnedObjects` is not synchronous or
symmetric to `kAudioAggregateDevicePropertyFullSubDeviceList`, which is
the property set in `AggregateDevice::set_sub_devices_sync`.

If the sub devices are less than 2 (we should have at least one input
and one output) in `AggregateDevice::activate_clock_drift_compensation`,
the `AggregateDevice::new` should bail out with an error returned. Then
the cubeb stream can follow the fallback mechanism to create a duplex
stream without using an aggregate-device.