### PR TITLE
BMO 1692910: Avoid the race between `set_volume` and stream-reinitialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ It's used to verify our callbacks for minitoring the system devices work.
     - `d` to destroy a stream
     - `s` to start the created stream
     - `t` to stop the created stream
+    - `r` to register a device changed callback to the created stream
+    - `v` to set volume to the created stream
     - `q` to quit the test
   - It's useful to simulate the stream bahavior to reproduce the bug we found,
     with some modified code.

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3560,7 +3560,24 @@ impl<'ctx> StreamOps for AudioUnitStream<'ctx> {
         }
     }
     fn set_volume(&mut self, volume: f32) -> Result<()> {
-        set_volume(self.core_stream_data.output_unit, volume)
+        // Execute set_volume in serial queue to avoid racing with destroy or reinit.
+        let mut result = Err(Error::error());
+        let set = &mut result;
+        let stream = &self;
+        self.queue.run_sync(move || {
+            *set = set_volume(stream.core_stream_data.output_unit, volume);
+        });
+
+        if result.is_err() {
+            return result;
+        }
+
+        cubeb_log!(
+            "Cubeb stream ({:p}) set volume to {}.",
+            self as *const AudioUnitStream,
+            volume
+        );
+        Ok(())
     }
     fn set_name(&mut self, _: &CStr) -> Result<()> {
         Err(Error::not_supported())

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3279,6 +3279,10 @@ impl<'ctx> AudioUnitStream<'ctx> {
 
         self.core_stream_data.close();
 
+        let sleep_time = Duration::from_secs(5);
+        println!("1 Reinit > Sleep for {:?}", sleep_time);
+        std::thread::sleep(sleep_time);
+
         // Reinit occurs in one of the following case:
         // - When the device is not alive any more
         // - When the default system device change.

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3279,10 +3279,6 @@ impl<'ctx> AudioUnitStream<'ctx> {
 
         self.core_stream_data.close();
 
-        let sleep_time = Duration::from_secs(5);
-        println!("1 Reinit > Sleep for {:?}", sleep_time);
-        std::thread::sleep(sleep_time);
-
         // Reinit occurs in one of the following case:
         // - When the device is not alive any more
         // - When the default system device change.

--- a/src/backend/tests/manual.rs
+++ b/src/backend/tests/manual.rs
@@ -165,7 +165,8 @@ fn test_stream_tester() {
                  \t'd': destroy a stream\n\
                  \t's': start the created stream\n\
                  \t't': stop the created stream\n\
-                 \t'r': register a device changed callback"
+                 \t'r': register a device changed callback\n\
+                 \t'v': set volume"
             );
 
             let mut command = String::new();
@@ -183,6 +184,7 @@ fn test_stream_tester() {
                 "s" => start_stream(stream_ptr),
                 "t" => stop_stream(stream_ptr),
                 "r" => register_device_change_callback(stream_ptr),
+                "v" => set_volume(stream_ptr),
                 x => println!("Unknown command: {}", x),
             }
         }
@@ -210,6 +212,19 @@ fn test_stream_tester() {
             ffi::CUBEB_OK
         );
         println!("Stream {:p} stopped.", stream_ptr);
+    }
+
+    fn set_volume(stream_ptr: *mut ffi::cubeb_stream) {
+        if stream_ptr.is_null() {
+            println!("No stream can set volume.");
+            return;
+        }
+        const VOL: f32 = 0.5;
+        assert_eq!(
+            unsafe { OPS.stream_set_volume.unwrap()(stream_ptr, VOL) },
+            ffi::CUBEB_OK
+        );
+        println!("Set stream {:p} volume to {}", stream_ptr, VOL);
     }
 
     fn register_device_change_callback(stream_ptr: *mut ffi::cubeb_stream) {


### PR DESCRIPTION
This solves the assertion-failed issue in [BMO 1692910](https://bugzilla.mozilla.org/show_bug.cgi?id=1692910).

This is a data-racing issue.  The assertion will be hit when the
1. `set_volume` is called on thread *A* at the same time when the stream is being reinitialized at thread *B*
2. `set_volume` is called on thread *A* just after the `self.core_stream_data.close()` is called on thread *B*, which will uninitialize and dispose the AudioUnit called in `set_volume` on thread *A*

This issue can be reproduced by operating `test_stream_tester()`  with the code added
in 8c1e3f91bd05643113d00ba93c965711f5ac3c10 and 32f840c338900515452f4f7cc2be6e97ddd21279, by following the commit message in 8c1e3f91bd05643113d00ba93c965711f5ac3c10. The code added in 8c1e3f91bd05643113d00ba93c965711f5ac3c10 in stream-reinitialization task can buy us some time to call `set_volume` when the stream is being reinitialized. That code is removed in bf40fb55d5ab4f7dcd1dc7fcd267520bd88ddfbf since it's just used to reproduce the issue and check the code in 601d37fbba3951929411cca8f335974097f6bd09 can fix the issue.