### PR TITLE
Fix a couple of clippy warnings

### DIFF
--- a/coreaudio-sys-utils/src/dispatch.rs
+++ b/coreaudio-sys-utils/src/dispatch.rs
@@ -162,7 +162,7 @@ fn run_tasks_in_order() {
     fn visit(v: u32, visited_ptr: usize) {
         let visited = unsafe { &mut *(visited_ptr as *mut Vec<u32>) };
         visited.push(v);
-    };
+    }
 
     let queue = Queue::new("Run tasks in order");
 
@@ -189,7 +189,7 @@ fn run_final_task() {
         fn visit(v: u32, visited_ptr: usize) {
             let visited = unsafe { &mut *(visited_ptr as *mut Vec<u32>) };
             visited.push(v);
-        };
+        }
 
         let queue = Queue::new("Task after run_final will be cancelled");
 

--- a/src/backend/buffer_manager.rs
+++ b/src/backend/buffer_manager.rs
@@ -139,7 +139,7 @@ impl BufferManager {
                 let available = c.len();
                 assert!(available >= final_size);
                 let to_pop = available - final_size;
-                let mut buffer = [0 as i16; INPUT_BUFFER_CAPACITY];
+                let mut buffer = [0_i16; INPUT_BUFFER_CAPACITY];
                 let mut slice_to_pop = buffer.split_at_mut(to_pop);
                 c.pop_slice(&mut slice_to_pop.0);
             }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1489,8 +1489,10 @@ fn create_cubeb_device_info(
         return Err(Error::error());
     }
 
-    let mut dev_info = ffi::cubeb_device_info::default();
-    dev_info.max_channels = channels;
+    let mut dev_info = ffi::cubeb_device_info {
+        max_channels: channels,
+        ..Default::default()
+    };
 
     assert!(
         mem::size_of::<ffi::cubeb_devid>() >= mem::size_of_val(&devid),

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -336,7 +336,7 @@ extern "C" fn audiounit_input_callback(
     enum ErrorHandle {
         Return(OSStatus),
         Reinit,
-    };
+    }
 
     assert!(input_frames > 0);
     assert_eq!(bus, AU_IN_BUS);

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -136,10 +136,10 @@ impl device_property_listener {
 #[derive(Debug, PartialEq)]
 struct CAChannelLabel(AudioChannelLabel);
 
-impl Into<mixer::Channel> for CAChannelLabel {
-    fn into(self) -> mixer::Channel {
+impl From<CAChannelLabel> for mixer::Channel {
+    fn from(label: CAChannelLabel) -> mixer::Channel {
         use self::coreaudio_sys_utils::sys;
-        match self.0 {
+        match label.0 {
             sys::kAudioChannelLabel_Left => mixer::Channel::FrontLeft,
             sys::kAudioChannelLabel_Right => mixer::Channel::FrontRight,
             sys::kAudioChannelLabel_Center | sys::kAudioChannelLabel_Mono => {

--- a/src/backend/tests/tone.rs
+++ b/src/backend/tests/tone.rs
@@ -28,7 +28,7 @@ fn test_dial_tone() {
     struct Closure {
         buffer_size: AtomicI64,
         phase: i64,
-    };
+    }
     let mut closure = Closure {
         buffer_size: AtomicI64::new(0),
         phase: 0,
@@ -55,7 +55,7 @@ fn test_dial_tone() {
                 Paused,
                 Resumed,
                 End,
-            };
+            }
             let mut state = State::WaitingForStart;
             let mut position: u64 = 0;
             let mut prev_position: u64 = 0;


### PR DESCRIPTION
Fix some warnings caught by Rust 1.52