### PR TITLE
Add circle-ci setting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,15 @@
+# See lastest version from: https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+
+jobs:
+  build:
+    macos:  # indicate that we are using the macOS executor
+      xcode: 11.3.0 # indicate our selected version of Xcode
+    steps:
+      - checkout
+      - run: brew install cmake # for libcubeb in cubeb-sys crate
+      - run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+      - run: rustc --version
+      - run: cargo --version
+      - run: cargo build --verbose
+      - run: sh run_tests.sh


### PR DESCRIPTION
Add a simple circle-ci setting. In the setting, we install rust manually instead of using a prebuilt image from https://circleci.com/developer/images/image/cimg/rust. The reason is that `macos` and `docker` cannot exist at the same time under `build`, so we need to install *Rust* manually if we want to run the project on macOS.

The setting doesn't run the sanitizer tests, which requires *Rust nightly*. I'll add a follow-up issue for it. Now we simply run the regular tests with *Rust stable*.