### PR TITLE
Add a GitHub Actions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # cubeb-coreaudio-rs
 
 [![CircleCI](https://circleci.com/gh/mozilla/cubeb-coreaudio-rs.svg?style=svg)](https://circleci.com/gh/mozilla/cubeb-coreaudio-rs)
+[![Build & Test](https://github.com/mozilla/cubeb-coreaudio-rs/actions/workflows/test.yml/badge.svg)](https://github.com/mozilla/cubeb-coreaudio-rs/actions/workflows/test.yml)
 
 *Rust* implementation of [Cubeb][cubeb] on [the MacOS platform][cubeb-au].
 


### PR DESCRIPTION
Simply add a status badge for GitHub Actions