### PR TITLE
Update links

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This is now the _Firefox_'s default audio backend on *Mac OS*.
 
 Run the following command:
 ```sh
-curl https://raw.githubusercontent.com/ChunMinChang/cubeb-coreaudio-rs/trailblazer/build-audiounit-rust-in-cubeb.sh | sh
+curl https://raw.githubusercontent.com/mozilla/cubeb-coreaudio-rs/trailblazer/build-audiounit-rust-in-cubeb.sh | sh
 ```
 
 ### Other
@@ -126,8 +126,8 @@ See [todo list][todo]
 - [plain-translation-from-c][from-c]: The code is rewritten from C code on a line-by-line basis
 - [ocs-disposal][ocs-disposal]: The first version that replace our custom mutex by Rust Mutex
 
-[cubeb]: https://github.com/kinetiknz/cubeb "Cross platform audio library"
-[cubeb-au]: https://github.com/kinetiknz/cubeb/blob/master/src/cubeb_audiounit.cpp "Cubeb AudioUnit"
+[cubeb]: https://github.com/mozilla/cubeb "Cross platform audio library"
+[cubeb-au]: https://github.com/mozilla/cubeb/blob/master/src/cubeb_audiounit.cpp "Cubeb AudioUnit"
 
 [chg-buf-sz]: https://cs.chromium.org/chromium/src/media/audio/mac/audio_manager_mac.cc?l=982-989&rcl=0207eefb445f9855c2ed46280cb835b6f08bdb30 "issue on changing buffer size"
 
@@ -136,6 +136,6 @@ See [todo list][todo]
 [bmo1572273]: https://bugzilla.mozilla.org/show_bug.cgi?id=1572273
 [bmo1572273-c13]: https://bugzilla.mozilla.org/show_bug.cgi?id=1572273#c13
 
-[from-c]: https://github.com/ChunMinChang/cubeb-coreaudio-rs/tree/plain-translation-from-c
-[ocs-disposal]: https://github.com/ChunMinChang/cubeb-coreaudio-rs/tree/ocs-disposal
-[trailblazer]: https://github.com/ChunMinChang/cubeb-coreaudio-rs/tree/trailblazer
+[from-c]: https://github.com/mozilla/cubeb-coreaudio-rs/tree/plain-translation-from-c
+[ocs-disposal]: https://github.com/mozilla/cubeb-coreaudio-rs/tree/ocs-disposal
+[trailblazer]: https://github.com/mozilla/cubeb-coreaudio-rs/tree/trailblazer

--- a/build-audiounit-rust-in-cubeb.sh
+++ b/build-audiounit-rust-in-cubeb.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-git clone --recursive https://github.com/kinetiknz/cubeb.git
+git clone --recursive https://github.com/mozilla/cubeb.git
 cd cubeb/src
-git clone https://github.com/ChunMinChang/cubeb-coreaudio-rs.git
+git clone https://github.com/mozilla/cubeb-coreaudio-rs.git
 cd ../..
 mkdir cubeb-build
 cd cubeb-build

--- a/todo.md
+++ b/todo.md
@@ -2,7 +2,7 @@
 
 ## General
 
-- Resolve the [issues](https://github.com/ChunMinChang/cubeb-coreaudio-rs/issues)
+- Resolve the [issues](https://github.com/mozilla/cubeb-coreaudio-rs/issues)
 - Some of bugs are found when adding tests. Search *FIXIT* to find them.
 - Remove `#[allow(non_camel_case_types)]`, `#![allow(unused_assignments)]`, `#![allow(unused_must_use)]`
 - Use `ErrorChain`
@@ -114,7 +114,7 @@ and create a new one. It's easier than the current implementation.
 
 [cubeb-rs]: https://github.com/djg/cubeb-rs "cubeb-rs"
 [cubeb-rs-stmparamsref]: https://github.com/djg/cubeb-rs/blob/78ed9459b8ac2ca50ea37bb72f8a06847eb8d379/cubeb-core/src/stream.rs#L61 "StreamParamsRef"
-[cubeb-stm-check]: https://github.com/kinetiknz/cubeb/blob/a971bf1a045b0e5dcaffd2a15c3255677f43cd2d/src/cubeb.c#L70-L108
+[cubeb-stm-check]: https://github.com/mozilla/cubeb/blob/a971bf1a045b0e5dcaffd2a15c3255677f43cd2d/src/cubeb.c#L70-L108
 
 ## Test
 


### PR DESCRIPTION
Update outdated links. All the cubeb repos are hosted by mozilla now.