### PR TITLE
BMO 1727598 - Fix audio cut

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -615,20 +615,23 @@ extern "C" fn audiounit_output_callback(
             cubeb_log!("Dropping {} frames in input buffer.", popped_frames);
         }
 
-        let input_frames = if input_frames_needed > buffered_input_frames {
+        let input_frames = if input_frames_needed > buffered_input_frames
+            && (stm.switching_device.load(Ordering::SeqCst)
+                || stm.reinit_pending.load(Ordering::SeqCst)
+                || stm.frames_read.load(Ordering::SeqCst) == 0)
+        {
             // The silent frames will be inserted in `get_linear_data` below.
             let silent_frames_to_push = input_frames_needed - buffered_input_frames;
             cubeb_log!(
-                "({:p}) Missing Frames: {}, will append {} frames of input silence.",
+                "({:p}) Missing Frames: {} will append {} frames of input silence.",
                 stm.core_stream_data.stm_ptr,
                 if stm.frames_read.load(Ordering::SeqCst) == 0 {
-                    "input hasn't started"
+                    "input hasn't started,"
                 } else if stm.switching_device.load(Ordering::SeqCst) {
-                    "device switching"
-                } else if stm.reinit_pending.load(Ordering::SeqCst) {
-                    "reinit pending"
+                    "device switching,"
                 } else {
-                    "not enough buffered frames"
+                    assert!(stm.reinit_pending.load(Ordering::SeqCst));
+                    "reinit pending,"
                 },
                 silent_frames_to_push
             );

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -630,7 +630,6 @@ extern "C" fn audiounit_output_callback(
                 } else if stm.switching_device.load(Ordering::SeqCst) {
                     "device switching,"
                 } else {
-                    assert!(stm.reinit_pending.load(Ordering::SeqCst));
                     "reinit pending,"
                 },
                 silent_frames_to_push


### PR DESCRIPTION
This reverts commit 246b7873761390d30ed32b37419350f2c2e72572 in #133. This should fix [BMO 1727598](https://bugzilla.mozilla.org/show_bug.cgi?id=1727598). 

After applying this patch, the silence frames will only be appended when the resampler asking for more input frames than what we have *and* the device is switching or the stream is re-initializing. If the resampler asking for more input frames than what we have but the device is not switching or the stream is not re-initializing, now we count on [cubeb resmapler](https://github.com/mozilla/cubeb/blob/6ce95962c8bb1442a725cbacdc77d5d8cbce43ad/src/cubeb_resampler.h)'s help.