### PR TITLE
Revise custom group id test

### DIFF
--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1245,44 +1245,48 @@ fn test_get_same_group_id_for_builtin_device_pairs() {
     const HDPN: u32 = 0x6864_706E; // "hdpn"
     let pairs = [(IMIC, ISPK), (EMIC, HDPN)];
 
-    // TODO: group_ids will have collision if one input device and one output device
-    //       has same source value.
-    let mut group_ids = HashMap::<u32, String>::new();
+    let mut input_group_ids = HashMap::<u32, String>::new();
     let input_devices = test_get_devices_in_scope(Scope::Input);
     for device in input_devices.iter() {
         match get_device_source(*device, DeviceType::INPUT) {
             Ok(source) => match get_device_group_id(*device, DeviceType::INPUT) {
-                Ok(id) => assert!(group_ids
+                Ok(id) => assert!(input_group_ids
                     .insert(source, id.into_string().unwrap())
                     .is_none()),
-                Err(e) => assert!(group_ids.insert(source, format!("Error {}", e)).is_none()),
+                Err(e) => assert!(input_group_ids
+                    .insert(source, format!("Error {}", e))
+                    .is_none()),
             },
             _ => {} // do nothing when failing to get source.
         }
     }
+
+    let mut output_group_ids = HashMap::<u32, String>::new();
     let output_devices = test_get_devices_in_scope(Scope::Output);
     for device in output_devices.iter() {
         match get_device_source(*device, DeviceType::OUTPUT) {
             Ok(source) => match get_device_group_id(*device, DeviceType::OUTPUT) {
-                Ok(id) => assert!(group_ids
+                Ok(id) => assert!(output_group_ids
                     .insert(source, id.into_string().unwrap())
                     .is_none()),
-                Err(e) => assert!(group_ids.insert(source, format!("Error {}", e)).is_none()),
+                Err(e) => assert!(output_group_ids
+                    .insert(source, format!("Error {}", e))
+                    .is_none()),
             },
             _ => {} // do nothing when failing to get source.
         }
     }
 
-    for (dev1, dev2) in pairs.iter() {
-        let id1 = group_ids.get(dev1);
-        let id2 = group_ids.get(dev2);
+    for (input, output) in pairs.iter() {
+        let input_group_id = input_group_ids.get(input);
+        let output_group_id = output_group_ids.get(output);
 
-        if id1.is_some() && id2.is_some() {
-            assert_eq!(id1, id2);
+        if input_group_id.is_some() && output_group_id.is_some() {
+            assert_eq!(input_group_id, output_group_id);
         }
 
-        group_ids.remove(dev1);
-        group_ids.remove(dev2);
+        input_group_ids.remove(input);
+        output_group_ids.remove(output);
     }
 }
 

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1238,6 +1238,7 @@ fn test_get_device_group_id() {
 fn test_get_same_group_id_for_builtin_device_pairs() {
     use std::collections::HashMap;
 
+    // These device sources have custom group id. See `get_custom_group_id`.
     const IMIC: u32 = 0x696D_6963; // "imic"
     const ISPK: u32 = 0x6973_706B; // "ispk"
     const EMIC: u32 = 0x656D_6963; // "emic"


### PR DESCRIPTION
This patch solves #138.

The [Blackhole](https://github.com/ExistentialAudio/BlackHole/) device's input and output data source values are the same. As a result, the hash-map, whose key is the data source value, has a collision when we use the same hash-map to store both input and output device's group ids.

To avoid the collision, we should use different hash maps for the input and output devices to store the group id values.