### PR TITLE
`close` the CoreStreamData if it fails to `setup`

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3299,6 +3299,7 @@ impl<'ctx> AudioUnitStream<'ctx> {
                 "({:p}) Stream reinit failed.",
                 self.core_stream_data.stm_ptr
             );
+            self.core_stream_data.close();
             if has_input && input_device != kAudioObjectUnknown {
                 // Attempt to re-use the same device-id failed, so attempt again with
                 // default input device.


### PR DESCRIPTION
This should solve the crash on [BMO 1708718](https://bugzilla.mozilla.org/show_bug.cgi?id=1708718).

By the [crash reports](https://crash-stats.mozilla.org/signature/?signature=cubeb_coreaudio%3A%3Abackend%3A%3ACoreStreamData%3A%3Asetup), the *MOZ_CRASH Reason (Sanitized)* is `register default_output_listener without unregistering the one in use`. That means the assertion: https://github.com/mozilla/cubeb-coreaudio-rs/blob/5a5bc63d7ee37ea78adfa7c958d45b1595bf6c61/src/backend/mod.rs#L2984-L2987
in `install_system_changed_callback` is hit. The thread hitting the assertion is on `coreaudio_sys_utils::dispatch::Queue::create_closure_and_executor::closure_executer` so this crash is very likely to happen when running `reinit` (the stream is being reinitializing).

I managed to reproduce the crash by [the comment here](https://bugzilla.mozilla.org/show_bug.cgi?id=1708718#c5). If `default_input_listener` fails to be registered in the first `setup`: https://github.com/mozilla/cubeb-coreaudio-rs/blob/5a5bc63d7ee37ea78adfa7c958d45b1595bf6c61/src/backend/mod.rs#L3297 then `default_output_listener` is a `Some` when the second `setup` is called: https://github.com/mozilla/cubeb-coreaudio-rs/blob/5a5bc63d7ee37ea78adfa7c958d45b1595bf6c61/src/backend/mod.rs#L3312
and it ends up hitting the assertion since `default_output_listener` is not a `None`