### PR TITLE
BMO 1737833 - Return error when reinit fails if input is not defined

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3294,7 +3294,7 @@ impl<'ctx> AudioUnitStream<'ctx> {
             e
         })?;
 
-        if self.core_stream_data.setup().is_err() {
+        if let Err(setup_err) = self.core_stream_data.setup() {
             cubeb_log!(
                 "({:p}) Stream reinit failed.",
                 self.core_stream_data.stm_ptr
@@ -3317,6 +3317,9 @@ impl<'ctx> AudioUnitStream<'ctx> {
                     );
                     e
                 })?;
+            } else {
+                cubeb_log!("({:p}) Setup failed.", self.core_stream_data.stm_ptr);
+                return Err(setup_err);
             }
         }
 


### PR DESCRIPTION
If the stream is output-only, or its input device is system-default, its
reinit failure can lead to hitting an assertion in set_volume since the
program keeps running as the error doesn't occur. We should return an
error instead.