### PR TITLE
Update xcode version on circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 jobs:
   regular_test:
     macos:  # indicate that we are using the macOS executor
-      xcode: 11.3.0 # indicate our selected version of Xcode
+      xcode: 12.5.1 # indicate our selected version of Xcode
     steps:
       - checkout
       - run: brew install cmake # for libcubeb in cubeb-sys crate


### PR DESCRIPTION
Xcode 11.3 is going to be removed on 12 January 2022. Update Xcode to 12.5.1