### PR TITLE
Fix device-changed test for duplex stream

### DIFF
--- a/src/backend/tests/aggregate_device.rs
+++ b/src/backend/tests/aggregate_device.rs
@@ -1,6 +1,6 @@
 use super::utils::{
     test_get_all_devices, test_get_all_onwed_devices, test_get_default_device,
-    test_get_drift_compensations, test_get_master_device, Scope,
+    test_get_drift_compensations, test_get_master_device, DeviceFilter, Scope,
 };
 use super::*;
 
@@ -42,7 +42,7 @@ fn test_aggregate_set_sub_devices_for_unknown_devices() {
 // application and print out the sub devices of them!
 #[test]
 fn test_aggregate_get_sub_devices() {
-    let devices = test_get_all_devices();
+    let devices = test_get_all_devices(DeviceFilter::ExcludeCubebAggregate);
     for device in devices {
         // `AggregateDevice::get_sub_devices(device)` will return a single-element vector
         // containing `device` itself if it's not an aggregate device. This test assumes devices
@@ -108,7 +108,7 @@ fn test_aggregate_create_blank_device() {
     // TODO: Test this when there is no available devices.
     let plugin = AggregateDevice::get_system_plugin_id().unwrap();
     let device = AggregateDevice::create_blank_device_sync(plugin).unwrap();
-    let devices = test_get_all_devices();
+    let devices = test_get_all_devices(DeviceFilter::IncludeCubebAggregate);
     let device = devices.into_iter().find(|dev| dev == &device).unwrap();
     let uid = get_device_global_uid(device).unwrap().into_string();
     assert!(uid.contains(PRIVATE_AGGREGATE_DEVICE_NAME));

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -3,7 +3,7 @@ use super::utils::{
     test_device_channels_in_scope, test_device_in_scope, test_get_all_devices,
     test_get_default_audiounit, test_get_default_device, test_get_default_raw_stream,
     test_get_default_source_name, test_get_devices_in_scope, test_get_raw_context,
-    ComponentSubType, PropertyScope, Scope,
+    ComponentSubType, DeviceFilter, PropertyScope, Scope,
 };
 use super::*;
 
@@ -1523,7 +1523,7 @@ fn test_get_devices_of_type() {
     let input_devices = audiounit_get_devices_of_type(DeviceType::INPUT);
     let output_devices = audiounit_get_devices_of_type(DeviceType::OUTPUT);
 
-    let mut expected_all = test_get_all_devices();
+    let mut expected_all = test_get_all_devices(DeviceFilter::ExcludeCubebAggregate);
     expected_all.sort();
     assert_eq!(all_devices, expected_all);
     for device in all_devices.iter() {


### PR DESCRIPTION
`test_register_device_changed_callback_to_check_default_device_changed_duplex` doesn't work when we have a single input device and multiple output devices. This PR fix this case.