### PR TITLE
Add device selection for stream tester

### DIFF
--- a/src/backend/tests/manual.rs
+++ b/src/backend/tests/manual.rs
@@ -1,6 +1,6 @@
 use super::utils::{
     test_get_devices_in_scope, test_ops_context_operation, test_ops_stream_operation, Scope,
-    StreamType, TestDeviceSwitcher,
+    StreamType, TestDeviceInfo, TestDeviceSwitcher,
 };
 use super::*;
 use std::io;
@@ -285,18 +285,74 @@ fn test_stream_tester() {
             }
         }
 
+        let device_selector = |scope: Scope| -> AudioObjectID {
+            loop {
+                println!(
+                    "Select {} device:\n",
+                    if scope == Scope::Input {
+                        "input"
+                    } else {
+                        "output"
+                    }
+                );
+                let mut list = vec![];
+                list.push(kAudioObjectUnknown);
+                println!("{:>4}: System default", 0);
+                let devices = test_get_devices_in_scope(scope.clone());
+                for (idx, device) in devices.iter().enumerate() {
+                    list.push(*device);
+                    let info = TestDeviceInfo::new(*device, scope.clone());
+                    println!(
+                        "{:>4}: {}\n\tAudioObjectID: {}\n\tuid: {}",
+                        idx + 1,
+                        info.label,
+                        device,
+                        info.uid
+                    );
+                }
+
+                let mut input = String::new();
+                io::stdin().read_line(&mut input).unwrap();
+                let n: usize = match input.trim().parse() {
+                    Err(_) => {
+                        println!("Invalid option. Try again.\n");
+                        continue;
+                    }
+                    Ok(n) => n,
+                };
+                if n >= list.len() {
+                    println!("Invalid option. Try again.\n");
+                    continue;
+                }
+                return list[n];
+            }
+        };
+
         let mut input_params = get_dummy_stream_params(Scope::Input);
         let mut output_params = get_dummy_stream_params(Scope::Output);
 
-        let input_stream_params = if stream_type.contains(StreamType::INPUT) {
-            &mut input_params as *mut ffi::cubeb_stream_params
+        let (input_device, input_stream_params) = if stream_type.contains(StreamType::INPUT) {
+            (
+                device_selector(Scope::Input),
+                &mut input_params as *mut ffi::cubeb_stream_params,
+            )
         } else {
-            ptr::null_mut()
+            (
+                kAudioObjectUnknown, /* default input device */
+                ptr::null_mut(),
+            )
         };
-        let output_stream_params = if stream_type.contains(StreamType::OUTPUT) {
-            &mut output_params as *mut ffi::cubeb_stream_params
+
+        let (output_device, output_stream_params) = if stream_type.contains(StreamType::OUTPUT) {
+            (
+                device_selector(Scope::Output),
+                &mut output_params as *mut ffi::cubeb_stream_params,
+            )
         } else {
-            ptr::null_mut()
+            (
+                kAudioObjectUnknown, /* default output device */
+                ptr::null_mut(),
+            )
         };
 
         let stream_name = CString::new("stream tester").unwrap();
@@ -307,9 +363,9 @@ fn test_stream_tester() {
                     context_ptr,
                     stream_ptr,
                     stream_name.as_ptr(),
-                    ptr::null_mut(), // default input device
+                    input_device as ffi::cubeb_devid,
                     input_stream_params,
-                    ptr::null_mut(), // default output device
+                    output_device as ffi::cubeb_devid,
                     output_stream_params,
                     4096, // latency
                     Some(data_callback),

--- a/src/backend/tests/utils.rs
+++ b/src/backend/tests/utils.rs
@@ -330,13 +330,13 @@ fn test_print_devices_in_scope(devices: &Vec<AudioObjectID>, scope: Scope) {
 }
 
 #[derive(Debug)]
-struct TestDeviceInfo {
+pub struct TestDeviceInfo {
     id: AudioObjectID,
-    label: String,
-    uid: String,
+    pub label: String,
+    pub uid: String,
 }
 impl TestDeviceInfo {
-    fn new(id: AudioObjectID, scope: Scope) -> Self {
+    pub fn new(id: AudioObjectID, scope: Scope) -> Self {
         Self {
             id,
             label: Self::get_label(id, scope.clone()),


### PR DESCRIPTION
It would be much easier to test the stream with different devices if we
can set the device for the stream in test_stream_tester