### PR TITLE
Reclock audio input, when needed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["staticlib", "rlib"]
 atomic = "0.4"
 bitflags = "1.0"
 coreaudio-sys-utils = { path = "coreaudio-sys-utils" }
-cubeb-backend = "0.9"
+cubeb-backend = "0.10"
 float-cmp = "0.6"
 libc = "0.2"
 lazy_static = "1.2"

--- a/src/backend/buffer_manager.rs
+++ b/src/backend/buffer_manager.rs
@@ -37,8 +37,9 @@ impl BufferManager {
     pub fn new(params: &StreamParams, input_buffer_size_frames: u32) -> BufferManager {
         let format = params.format();
         let channel_count = params.channels();
-        // Multiply by two for good measure.
-        let buffer_element_count = (channel_count * input_buffer_size_frames * 2) as usize;
+        // 8 times the expected callback size, to handle the input callback being caled multiple
+        //   times in a row correctly.
+        let buffer_element_count = (channel_count * input_buffer_size_frames * 8) as usize;
         if format == SampleFormat::S16LE || format == SampleFormat::S16BE {
             let ring = RingBuffer::<i16>::new(buffer_element_count);
             let (prod, cons) = ring.split();

--- a/src/backend/buffer_manager.rs
+++ b/src/backend/buffer_manager.rs
@@ -10,6 +10,100 @@ use self::LinearInputBuffer::*;
 use self::RingBufferConsumer::*;
 use self::RingBufferProducer::*;
 
+// Shuffles the data so that the first n channels of the interleaved buffer are overwritten by
+// the remaining channels.
+fn drop_first_n_channels_in_place<T: Copy>(
+    n: usize,
+    data: &mut [T],
+    frame_count: usize,
+    channel_count: usize,
+) {
+    // This function works if the numbers are equal but it's not particularly useful, so we hope to
+    // catch issues by checking using > and not >= here.
+    assert!(channel_count > n);
+    let mut read_idx: usize = 0;
+    let mut write_idx: usize = 0;
+
+    let channel_to_keep = channel_count - n;
+    for _ in 0..frame_count {
+        read_idx += n;
+        for _ in 0..channel_to_keep {
+            data[write_idx] = data[read_idx];
+            read_idx += 1;
+            write_idx += 1;
+        }
+    }
+}
+
+// It can be that the a stereo microphone is in use, but the user asked for mono input. In this
+// particular case, downmix the stereo pair into a mono channel. In all other cases, simply drop
+// the remaining channels before appending to the ringbuffer, becauses there is no right or wrong
+// way to do this, unlike with the output side, where proper channel matrixing can be done.
+// Return the number of valid samples in the buffer.
+fn remix_or_drop_channels<T: Copy + std::ops::Add<Output = T>>(
+    input_channels: usize,
+    output_channels: usize,
+    data: &mut [T],
+    frame_count: usize,
+) -> usize {
+    assert!(input_channels >= output_channels);
+    // Nothing to do, just return
+    if input_channels == output_channels {
+        return output_channels * frame_count;
+    }
+    // Simple stereo downmix
+    if input_channels == 2 && output_channels == 1 {
+        let mut read_idx = 0;
+        for (write_idx, _) in (0..frame_count).enumerate() {
+            data[write_idx] = data[read_idx] + data[read_idx + 1];
+            read_idx += 2;
+        }
+        return output_channels * frame_count;
+    }
+    // Drop excess channels
+    let mut read_idx = 0;
+    let mut write_idx = 0;
+    let channel_dropped_count = input_channels - output_channels;
+    for _ in 0..frame_count {
+        for _ in 0..output_channels {
+            data[write_idx] = data[read_idx];
+            write_idx += 1;
+            read_idx += 1;
+        }
+        read_idx += channel_dropped_count;
+    }
+    output_channels * frame_count
+}
+
+fn process_input<T: Copy + std::ops::Add<Output = T>>(
+    input_data: *mut c_void,
+    frame_count: usize,
+    input_channel_count: usize,
+    input_channels_needed: usize,
+) -> &'static [T] {
+    assert!(input_channel_count >= input_channels_needed);
+    let input_slice = unsafe {
+        slice::from_raw_parts_mut::<T>(input_data as *mut T, frame_count * input_channel_count)
+    };
+    if input_channel_count == input_channels_needed {
+        input_slice
+    } else {
+        drop_first_n_channels_in_place(
+            input_channel_count - input_channels_needed,
+            input_slice,
+            frame_count,
+            input_channel_count,
+        );
+        let new_count_remixed = remix_or_drop_channels(
+            input_channel_count,
+            input_channels_needed,
+            input_slice,
+            frame_count,
+        );
+        unsafe { slice::from_raw_parts_mut::<T>(input_data as *mut T, new_count_remixed) }
+    }
+}
+
 pub enum RingBufferConsumer {
     IntegerRingBufferConsumer(ringbuf::Consumer<i16>),
     FloatRingBufferConsumer(ringbuf::Consumer<f32>),
@@ -29,17 +123,16 @@ pub struct BufferManager {
     consumer: RingBufferConsumer,
     producer: RingBufferProducer,
     linear_input_buffer: LinearInputBuffer,
+    input_channels: usize,
 }
 
 impl BufferManager {
-    // When opening a duplex stream, the sample-spec are guaranteed to match. It's ok to have
-    // either the input or output sample-spec here.
     pub fn new(params: &StreamParams, input_buffer_size_frames: u32) -> BufferManager {
         let format = params.format();
-        let channel_count = params.channels();
+        let input_channels = params.channels() as usize;
         // 8 times the expected callback size, to handle the input callback being caled multiple
         //   times in a row correctly.
-        let buffer_element_count = (channel_count * input_buffer_size_frames * 8) as usize;
+        let buffer_element_count = input_channels * input_buffer_size_frames as usize * 8;
         if format == SampleFormat::S16LE || format == SampleFormat::S16BE {
             let ring = RingBuffer::<i16>::new(buffer_element_count);
             let (prod, cons) = ring.split();
@@ -49,6 +142,7 @@ impl BufferManager {
                 linear_input_buffer: IntegerLinearInputBuffer(Vec::<i16>::with_capacity(
                     buffer_element_count,
                 )),
+                input_channels,
             }
         } else {
             let ring = RingBuffer::<f32>::new(buffer_element_count);
@@ -59,27 +153,29 @@ impl BufferManager {
                 linear_input_buffer: FloatLinearInputBuffer(Vec::<f32>::with_capacity(
                     buffer_element_count,
                 )),
+                input_channels,
             }
         }
     }
-    pub fn push_data(&mut self, input_data: *const c_void, read_samples: usize) {
+    pub fn push_data(&mut self, input_data: *mut c_void, frame_count: usize, channel_count: usize) {
+        let to_push = frame_count * self.input_channels;
         let pushed = match &mut self.producer {
             RingBufferProducer::FloatRingBufferProducer(p) => {
-                let input_data =
-                    unsafe { slice::from_raw_parts::<f32>(input_data as *const f32, read_samples) };
-                p.push_slice(input_data)
+                let processed_input =
+                    process_input(input_data, frame_count, channel_count, self.input_channels);
+                p.push_slice(processed_input)
             }
             RingBufferProducer::IntegerRingBufferProducer(p) => {
-                let input_data =
-                    unsafe { slice::from_raw_parts::<i16>(input_data as *const i16, read_samples) };
-                p.push_slice(input_data)
+                let processed_input =
+                    process_input(input_data, frame_count, channel_count, self.input_channels);
+                p.push_slice(processed_input)
             }
         };
-        if pushed != read_samples {
+        if pushed != to_push {
             cubeb_log!(
                 "Input ringbuffer full, could only push {} instead of {}",
                 pushed,
-                read_samples
+                to_push
             );
         }
     }

--- a/src/backend/device_property.rs
+++ b/src/backend/device_property.rs
@@ -286,6 +286,23 @@ pub fn get_stream_latency(
     }
 }
 
+pub fn get_clock_domain(
+    id: AudioStreamID,
+    devtype: DeviceType,
+) -> std::result::Result<u32, OSStatus> {
+    assert_ne!(id, kAudioObjectUnknown);
+
+    let address = get_property_address(Property::ClockDomain, devtype);
+    let mut size = mem::size_of::<u32>();
+    let mut clock_domain: u32 = 0;
+    let err = audio_object_get_property_data(id, &address, &mut size, &mut clock_domain);
+    if err == NO_ERR {
+        Ok(clock_domain)
+    } else {
+        Err(err)
+    }
+}
+
 pub enum Property {
     DeviceBufferFrameSizeRange,
     DeviceIsAlive,
@@ -306,6 +323,7 @@ pub enum Property {
     ModelUID,
     StreamLatency,
     TransportType,
+    ClockDomain,
 }
 
 impl From<Property> for AudioObjectPropertySelector {
@@ -330,6 +348,7 @@ impl From<Property> for AudioObjectPropertySelector {
             Property::ModelUID => kAudioDevicePropertyModelUID,
             Property::StreamLatency => kAudioStreamPropertyLatency,
             Property::TransportType => kAudioDevicePropertyTransportType,
+            Property::ClockDomain => kAudioDevicePropertyClockDomain,
         }
     }
 }

--- a/src/backend/device_property.rs
+++ b/src/backend/device_property.rs
@@ -34,7 +34,6 @@ pub fn get_device_model_uid(
     }
 }
 
-#[allow(dead_code)] // `pub` for running test
 pub fn get_device_transport_type(
     id: AudioDeviceID,
     devtype: DeviceType,

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1244,6 +1244,7 @@ fn audiounit_get_default_datasource_string(devtype: DeviceType) -> Result<CStrin
     Ok(convert_uint32_into_string(data))
 }
 
+#[cfg(test)]
 fn is_device_a_type_of(devid: AudioObjectID, devtype: DeviceType) -> bool {
     assert_ne!(devid, kAudioObjectUnknown);
     get_channel_count(devid, devtype).unwrap_or(0) > 0

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2486,6 +2486,11 @@ impl<'ctx> CoreStreamData<'ctx> {
             );
             self.input_hw_rate = input_hw_desc.mSampleRate;
 
+            // Can't open a stream with more input channels than the device has
+            if input_hw_desc.mChannelsPerFrame < self.input_stream_params.channels() {
+                return Err(Error::error());
+            }
+
             // Set format description according to the input params.
             self.input_desc =
                 create_stream_description(&self.input_stream_params).map_err(|e| {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2355,19 +2355,8 @@ impl<'ctx> CoreStreamData<'ctx> {
     }
 
     fn should_use_aggregate_device(&self) -> bool {
-        // Only using aggregate device when the input is a mic-only device and the output is a
-        // speaker-only device. Otherwise, the mic on the output device may become the main
-        // microphone of the aggregate device for this duplex stream.
-        self.has_input()
-            && self.has_output()
-            && self.input_device.id != kAudioObjectUnknown
-            && self.input_device.flags.contains(device_flags::DEV_INPUT)
-            && self.output_device.id != kAudioObjectUnknown
-            && self.output_device.flags.contains(device_flags::DEV_OUTPUT)
-            && self.input_device.id != self.output_device.id
-            && !is_device_a_type_of(self.input_device.id, DeviceType::OUTPUT)
-            && !is_device_a_type_of(self.output_device.id, DeviceType::INPUT)
-            && false
+        // Only use an aggregate device when the device are different.
+        self.has_input() && self.has_output() && self.input_device.id != self.output_device.id
     }
 
     fn same_clock_domain(&self) -> bool {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -406,10 +406,11 @@ extern "C" fn audiounit_input_callback(
             ErrorHandle::Reinit
         } else {
             assert_eq!(status, NO_ERR);
-            // Copy input data in linear buffer.
-            let elements =
-                (input_frames * stm.core_stream_data.input_desc.mChannelsPerFrame) as usize;
-            input_buffer_manager.push_data(input_buffer_list.mBuffers[0].mData, elements);
+            input_buffer_manager.push_data(
+                input_buffer_list.mBuffers[0].mData,
+                input_frames as usize,
+                stm.core_stream_data.input_desc.mChannelsPerFrame as usize,
+            );
             ErrorHandle::Return(status)
         };
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2743,6 +2743,8 @@ impl<'ctx> CoreStreamData<'ctx> {
             target_sample_rate,
             stream.data_callback,
             stream.user_ptr,
+            ffi::CUBEB_RESAMPLER_QUALITY_DESKTOP,
+            ffi::CUBEB_RESAMPLER_RECLOCK_NONE
         );
 
         if !self.input_unit.is_null() {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1252,12 +1252,6 @@ fn audiounit_get_default_datasource_string(devtype: DeviceType) -> Result<CStrin
     Ok(convert_uint32_into_string(data))
 }
 
-#[cfg(test)]
-fn is_device_a_type_of(devid: AudioObjectID, devtype: DeviceType) -> bool {
-    assert_ne!(devid, kAudioObjectUnknown);
-    get_channel_count(devid, devtype).unwrap_or(0) > 0
-}
-
 fn get_channel_count(devid: AudioObjectID, devtype: DeviceType) -> Result<u32> {
     assert_ne!(devid, kAudioObjectUnknown);
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1318,17 +1318,16 @@ fn get_fixed_latency(devid: AudioObjectID, devtype: DeviceType) -> u32 {
     device_latency + stream_latency
 }
 
+#[allow(non_upper_case_globals)]
 fn get_device_group_id(
     id: AudioDeviceID,
     devtype: DeviceType,
 ) -> std::result::Result<CString, OSStatus> {
-    const BLTN: u32 = 0x626C_746E; // "bltn" (builtin)
-
     match get_device_transport_type(id, devtype) {
-        Ok(BLTN) => {
+        Ok(kAudioDeviceTransportTypeBuiltIn) => {
             cubeb_log!(
                 "The transport type is {:?}",
-                convert_uint32_into_string(BLTN)
+                convert_uint32_into_string(kAudioDeviceTransportTypeBuiltIn)
             );
             match get_custom_group_id(id, devtype) {
                 Some(id) => return Ok(id),

--- a/src/backend/resampler.rs
+++ b/src/backend/resampler.rs
@@ -16,7 +16,7 @@ impl Resampler {
         data_callback: ffi::cubeb_data_callback,
         user_ptr: *mut c_void,
         quality: ffi::cubeb_resampler_quality,
-        reclock: ffi::cubeb_resampler_reclock
+        reclock: ffi::cubeb_resampler_reclock,
     ) -> Self {
         let raw_resampler = unsafe {
             let in_params = if input_params.is_some() {
@@ -37,7 +37,7 @@ impl Resampler {
                 data_callback,
                 user_ptr,
                 quality,
-                reclock
+                reclock,
             )
         };
         assert!(!raw_resampler.is_null(), "Failed to create resampler");

--- a/src/backend/resampler.rs
+++ b/src/backend/resampler.rs
@@ -7,6 +7,7 @@ use std::ptr;
 pub struct Resampler(AutoRelease<ffi::cubeb_resampler>);
 
 impl Resampler {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         stream: *mut ffi::cubeb_stream,
         mut input_params: Option<ffi::cubeb_stream_params>,
@@ -14,6 +15,8 @@ impl Resampler {
         target_rate: c_uint,
         data_callback: ffi::cubeb_data_callback,
         user_ptr: *mut c_void,
+        quality: ffi::cubeb_resampler_quality,
+        reclock: ffi::cubeb_resampler_reclock
     ) -> Self {
         let raw_resampler = unsafe {
             let in_params = if input_params.is_some() {
@@ -33,7 +36,8 @@ impl Resampler {
                 target_rate,
                 data_callback,
                 user_ptr,
-                ffi::CUBEB_RESAMPLER_QUALITY_DESKTOP,
+                quality,
+                reclock
             )
         };
         assert!(!raw_resampler.is_null(), "Failed to create resampler");

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1002,22 +1002,6 @@ fn test_get_default_device_name() {
     }
 }
 
-// is_device_a_type_of
-// ------------------------------------
-#[test]
-fn test_is_device_a_type_of() {
-    test_is_device_in_scope(Scope::Input);
-    test_is_device_in_scope(Scope::Output);
-
-    fn test_is_device_in_scope(scope: Scope) {
-        if let Some(device) = test_get_default_device(scope.clone()) {
-            assert!(is_device_a_type_of(device, scope.into()));
-        } else {
-            println!("No device for {:?}.", scope);
-        }
-    }
-}
-
 // get_channel_count
 // ------------------------------------
 #[test]


### PR DESCRIPTION
This won't compile until the changes are merged in https://github.com/mozilla/cubeb/pull/690 and https://github.com/mozilla/cubeb-rs/pull/62.

When using aggregate devices, macOS reclocks for us. When not using them, it may be that they are still in the same clock domain, in which case no reclocking is necessary. If that's not the case, we want to reclock.