### PR TITLE
Disable switching nondefault input

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The tests that may affect others are marked `#[ignore]`.
 They will be run by `cargo test ... -- --ignored ...`
 after finishing normal tests.
 Most of the tests are executed in `run_tests.sh`.
-Only those tests commented with *FIXIT* are left.
+Only those tests commented with *FIXME* are left.
 
 ### Git Hooks
 

--- a/coreaudio-sys-utils/src/audio_object.rs
+++ b/coreaudio-sys-utils/src/audio_object.rs
@@ -112,26 +112,38 @@ pub fn audio_object_remove_property_listener<T>(
 }
 
 #[derive(Debug)]
-pub struct PropertySelector(AudioObjectPropertySelector);
+pub enum PropertySelector {
+    DefaultOutputDevice,
+    DefaultInputDevice,
+    DeviceIsAlive,
+    DataSource,
+    Unknown,
+}
 
-impl PropertySelector {
-    pub fn new(selector: AudioObjectPropertySelector) -> Self {
-        Self(selector)
+impl From<AudioObjectPropertySelector> for PropertySelector {
+    fn from(p: AudioObjectPropertySelector) -> Self {
+        use coreaudio_sys as sys;
+        match p {
+            sys::kAudioHardwarePropertyDefaultOutputDevice => Self::DefaultOutputDevice,
+            sys::kAudioHardwarePropertyDefaultInputDevice => Self::DefaultInputDevice,
+            sys::kAudioDevicePropertyDeviceIsAlive => Self::DeviceIsAlive,
+            sys::kAudioDevicePropertyDataSource => Self::DataSource,
+            _ => Self::Unknown
+        }
     }
 }
 
 impl fmt::Display for PropertySelector {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use coreaudio_sys as sys;
-        let s = match self.0 {
-            sys::kAudioHardwarePropertyDefaultOutputDevice => {
+        let s = match self {
+            Self::DefaultOutputDevice => {
                 "kAudioHardwarePropertyDefaultOutputDevice"
             }
-            sys::kAudioHardwarePropertyDefaultInputDevice => {
+            Self::DefaultInputDevice => {
                 "kAudioHardwarePropertyDefaultInputDevice"
             }
-            sys::kAudioDevicePropertyDeviceIsAlive => "kAudioDevicePropertyDeviceIsAlive",
-            sys::kAudioDevicePropertyDataSource => "kAudioDevicePropertyDataSource",
+            Self::DeviceIsAlive => "kAudioDevicePropertyDeviceIsAlive",
+            Self::DataSource => "kAudioDevicePropertyDataSource",
             _ => "Unknown",
         };
         write!(f, "{}", s)

--- a/coreaudio-sys-utils/src/audio_object.rs
+++ b/coreaudio-sys-utils/src/audio_object.rs
@@ -111,7 +111,7 @@ pub fn audio_object_remove_property_listener<T>(
     unsafe { AudioObjectRemovePropertyListener(id, address, Some(listener), data as *mut c_void) }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum PropertySelector {
     DefaultOutputDevice,
     DefaultInputDevice,
@@ -128,7 +128,7 @@ impl From<AudioObjectPropertySelector> for PropertySelector {
             sys::kAudioHardwarePropertyDefaultInputDevice => Self::DefaultInputDevice,
             sys::kAudioDevicePropertyDeviceIsAlive => Self::DeviceIsAlive,
             sys::kAudioDevicePropertyDataSource => Self::DataSource,
-            _ => Self::Unknown
+            _ => Self::Unknown,
         }
     }
 }
@@ -136,12 +136,8 @@ impl From<AudioObjectPropertySelector> for PropertySelector {
 impl fmt::Display for PropertySelector {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let s = match self {
-            Self::DefaultOutputDevice => {
-                "kAudioHardwarePropertyDefaultOutputDevice"
-            }
-            Self::DefaultInputDevice => {
-                "kAudioHardwarePropertyDefaultInputDevice"
-            }
+            Self::DefaultOutputDevice => "kAudioHardwarePropertyDefaultOutputDevice",
+            Self::DefaultInputDevice => "kAudioHardwarePropertyDefaultInputDevice",
             Self::DeviceIsAlive => "kAudioDevicePropertyDeviceIsAlive",
             Self::DataSource => "kAudioDevicePropertyDataSource",
             _ => "Unknown",

--- a/run_device_tests.sh
+++ b/run_device_tests.sh
@@ -9,8 +9,9 @@ fi
 echo "RUST_BACKTRACE is set to ${RUST_BACKTRACE}\n"
 
 cargo test test_switch_device -- --ignored --nocapture
+
 cargo test test_plug_and_unplug_device -- --ignored --nocapture
-# cargo test test_register_device_changed_callback -- --ignored --nocapture --test-threads=1
+
 cargo test test_register_device_changed_callback_to_check_default_device_changed_input -- --ignored --nocapture
 cargo test test_register_device_changed_callback_to_check_default_device_changed_output -- --ignored --nocapture
 cargo test test_register_device_changed_callback_to_check_default_device_changed_duplex -- --ignored --nocapture

--- a/run_device_tests.sh
+++ b/run_device_tests.sh
@@ -20,22 +20,22 @@ cargo test test_register_device_changed_callback_to_check_input_alive_changed_du
 
 cargo test test_destroy_input_stream_after_unplugging_a_nondefault_input_device -- --ignored --nocapture
 cargo test test_destroy_input_stream_after_unplugging_a_default_input_device -- --ignored --nocapture
-# FIXIT: The following test will hang since we don't monitor the alive status of the output device
+# FIXME: The following test will hang since we don't monitor the alive status of the output device
 # cargo test test_destroy_output_stream_after_unplugging_a_nondefault_output_device -- --ignored --nocapture
 cargo test test_destroy_output_stream_after_unplugging_a_default_output_device -- --ignored --nocapture
 cargo test test_destroy_duplex_stream_after_unplugging_a_nondefault_input_device -- --ignored --nocapture
 cargo test test_destroy_duplex_stream_after_unplugging_a_default_input_device -- --ignored --nocapture
-# FIXIT: The following test will hang since we don't monitor the alive status of the output device
+# FIXME: The following test will hang since we don't monitor the alive status of the output device
 # cargo test test_destroy_duplex_stream_after_unplugging_a_nondefault_output_device -- --ignored --nocapture
 cargo test test_destroy_duplex_stream_after_unplugging_a_default_output_device -- --ignored --nocapture
 
 cargo test test_reinit_input_stream_by_unplugging_a_nondefault_input_device -- --ignored --nocapture
 cargo test test_reinit_input_stream_by_unplugging_a_default_input_device -- --ignored --nocapture
-# FIXIT: The following test will hang since we don't monitor the alive status of the output device
+# FIXME: The following test will hang since we don't monitor the alive status of the output device
 # cargo test test_reinit_output_stream_by_unplugging_a_nondefault_output_device -- --ignored --nocapture
 cargo test test_reinit_output_stream_by_unplugging_a_default_output_device -- --ignored --nocapture
 cargo test test_reinit_duplex_stream_by_unplugging_a_nondefault_input_device -- --ignored --nocapture
 cargo test test_reinit_duplex_stream_by_unplugging_a_default_input_device -- --ignored --nocapture
-# FIXIT: The following test will hang since we don't monitor the alive status of the output device
+# FIXME: The following test will hang since we don't monitor the alive status of the output device
 # cargo test test_reinit_duplex_stream_by_unplugging_a_nondefault_output_device -- --ignored --nocapture
 cargo test test_reinit_duplex_stream_by_unplugging_a_default_output_device -- --ignored --nocapture

--- a/run_device_tests.sh
+++ b/run_device_tests.sh
@@ -19,23 +19,29 @@ cargo test test_register_device_changed_callback_to_check_input_alive_changed_in
 cargo test test_register_device_changed_callback_to_check_input_alive_changed_duplex -- --ignored --nocapture
 
 cargo test test_destroy_input_stream_after_unplugging_a_nondefault_input_device -- --ignored --nocapture
-cargo test test_destroy_input_stream_after_unplugging_a_default_input_device -- --ignored --nocapture
-# FIXME: The following test will hang since we don't monitor the alive status of the output device
-# cargo test test_destroy_output_stream_after_unplugging_a_nondefault_output_device -- --ignored --nocapture
-cargo test test_destroy_output_stream_after_unplugging_a_default_output_device -- --ignored --nocapture
-cargo test test_destroy_duplex_stream_after_unplugging_a_nondefault_input_device -- --ignored --nocapture
-cargo test test_destroy_duplex_stream_after_unplugging_a_default_input_device -- --ignored --nocapture
-# FIXME: The following test will hang since we don't monitor the alive status of the output device
-# cargo test test_destroy_duplex_stream_after_unplugging_a_nondefault_output_device -- --ignored --nocapture
-cargo test test_destroy_duplex_stream_after_unplugging_a_default_output_device -- --ignored --nocapture
+cargo test test_suspend_input_stream_by_unplugging_a_nondefault_input_device -- --ignored --nocapture
 
-cargo test test_reinit_input_stream_by_unplugging_a_nondefault_input_device -- --ignored --nocapture
+cargo test test_destroy_input_stream_after_unplugging_a_default_input_device -- --ignored --nocapture
 cargo test test_reinit_input_stream_by_unplugging_a_default_input_device -- --ignored --nocapture
-# FIXME: The following test will hang since we don't monitor the alive status of the output device
-# cargo test test_reinit_output_stream_by_unplugging_a_nondefault_output_device -- --ignored --nocapture
+
+# FIXME: We don't monitor the alive-status for output device currently
+# cargo test test_destroy_output_stream_after_unplugging_a_nondefault_output_device -- --ignored --nocapture
+# FIXME: We don't monitor the alive-status for output device currently
+# cargo test test_suspend_output_stream_by_unplugging_a_nondefault_output_device -- --ignored --nocapture
+
+cargo test test_destroy_output_stream_after_unplugging_a_default_output_device -- --ignored --nocapture
 cargo test test_reinit_output_stream_by_unplugging_a_default_output_device -- --ignored --nocapture
-cargo test test_reinit_duplex_stream_by_unplugging_a_nondefault_input_device -- --ignored --nocapture
+
+cargo test test_destroy_duplex_stream_after_unplugging_a_nondefault_input_device -- --ignored --nocapture
+cargo test test_suspend_duplex_stream_by_unplugging_a_nondefault_input_device
+
+# FIXME: We don't monitor the alive-status for output device currently
+# cargo test test_destroy_duplex_stream_after_unplugging_a_nondefault_output_device -- --ignored --nocapture
+# FIXME: We don't monitor the alive-status for output device currently
+# cargo test test_suspend_duplex_stream_by_unplugging_a_nondefault_output_device -- --ignored --nocapture
+
+cargo test test_destroy_duplex_stream_after_unplugging_a_default_input_device -- --ignored --nocapture
 cargo test test_reinit_duplex_stream_by_unplugging_a_default_input_device -- --ignored --nocapture
-# FIXME: The following test will hang since we don't monitor the alive status of the output device
-# cargo test test_reinit_duplex_stream_by_unplugging_a_nondefault_output_device -- --ignored --nocapture
+
+cargo test test_destroy_duplex_stream_after_unplugging_a_default_output_device -- --ignored --nocapture
 cargo test test_reinit_duplex_stream_by_unplugging_a_default_output_device -- --ignored --nocapture

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -777,7 +777,7 @@ extern "C" fn audiounit_property_listener_callback(
         }
     }
 
-    for _addr in addrs.iter() {
+    {
         let callback = stm.device_changed_callback.lock().unwrap();
         if let Some(device_changed_callback) = *callback {
             unsafe {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -750,23 +750,20 @@ extern "C" fn audiounit_property_listener_callback(
 
     // Handle the events
 
-    for addr in addrs {
-        let p = PropertySelector::from(addr.mSelector);
-        assert_ne!(p, PropertySelector::Unknown);
-
-        // If this is the default input device ignore the event,
-        // kAudioHardwarePropertyDefaultInputDevice will take care of the switch
-        if p == PropertySelector::DeviceIsAlive
-            && stm
-                .core_stream_data
-                .input_device
-                .flags
-                .contains(device_flags::DEV_SYSTEM_DEFAULT)
-        {
-            cubeb_log!("It's the default input device, ignore the event");
-            stm.switching_device.store(false, Ordering::SeqCst);
-            return NO_ERR;
-        }
+    // If this is the default input device ignore the event,
+    // kAudioHardwarePropertyDefaultInputDevice will take care of the switch
+    if addrs.len() == 1
+        && PropertySelector::from(addrs.first().unwrap().mSelector)
+            == PropertySelector::DeviceIsAlive
+        && stm
+            .core_stream_data
+            .input_device
+            .flags
+            .contains(device_flags::DEV_SYSTEM_DEFAULT)
+    {
+        cubeb_log!("It's the default input device, ignore the event");
+        stm.switching_device.store(false, Ordering::SeqCst);
+        return NO_ERR;
     }
 
     for _addr in addrs.iter() {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -787,13 +787,7 @@ extern "C" fn audiounit_property_listener_callback(
                 );
             }
             _ => {
-                cubeb_log!(
-                    "Event[{}] - mSelector == Unexpected Event id {}, return",
-                    i,
-                    addr.mSelector
-                );
-                stm.switching_device.store(false, Ordering::SeqCst);
-                return NO_ERR;
+                panic!("Receive unexpected event");
             }
         }
     }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -728,7 +728,7 @@ extern "C" fn audiounit_property_listener_callback(
 
     let stm = unsafe { &mut *(user as *mut AudioUnitStream) };
     let addrs = unsafe { slice::from_raw_parts(addresses, address_count as usize) };
-    let property_selector = PropertySelector::new(addrs[0].mSelector);
+    let property_selector = PropertySelector::from(addrs[0].mSelector);
     if stm.switching_device.load(Ordering::SeqCst) {
         cubeb_log!(
             "Switching is already taking place. Skip Event {} for id={}",

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -190,7 +190,7 @@ fn test_set_device_info_to_system_output_device() {
     let _device = create_device_info(kAudioObjectSystemObject, DeviceType::OUTPUT);
 }
 
-// FIXIT: Is it ok to set input device to a nonexistent device ?
+// FIXME: Is it ok to set input device to a nonexistent device ?
 #[ignore]
 #[test]
 #[should_panic]
@@ -199,7 +199,7 @@ fn test_set_device_info_to_nonexistent_input_device() {
     let _device = create_device_info(nonexistent_id, DeviceType::INPUT);
 }
 
-// FIXIT: Is it ok to set output device to a nonexistent device ?
+// FIXME: Is it ok to set output device to a nonexistent device ?
 #[ignore]
 #[test]
 #[should_panic]
@@ -1408,7 +1408,7 @@ fn test_create_cubeb_device_info() {
         // TODO: Hit a kAudioHardwareUnknownPropertyError for AirPods
         // assert!(!info.vendor_name.is_null());
 
-        // FIXIT: The device is defined to input-only or output-only, but some device is in-out!
+        // FIXME: The device is defined to input-only or output-only, but some device is in-out!
         assert_eq!(info.device_type, DeviceType::from(scope.clone()).bits());
         assert_eq!(info.state, ffi::CUBEB_DEVICE_STATE_ENABLED);
         // TODO: The preference is set when the device is default input/output device if the device

--- a/src/backend/tests/device_change.rs
+++ b/src/backend/tests/device_change.rs
@@ -424,7 +424,7 @@ fn test_destroy_input_stream_after_unplugging_a_default_input_device() {
     test_unplug_a_device_on_an_active_stream(StreamType::INPUT, Scope::Input, true, 0);
 }
 
-// FIXIT: The following test will hang since we don't monitor the alive status of the output device
+// FIXME: The following test will hang since we don't monitor the alive status of the output device
 #[ignore]
 #[test]
 fn test_destroy_output_stream_after_unplugging_a_nondefault_output_device() {
@@ -449,7 +449,7 @@ fn test_destroy_duplex_stream_after_unplugging_a_default_input_device() {
     test_unplug_a_device_on_an_active_stream(StreamType::DUPLEX, Scope::Input, true, 0);
 }
 
-// FIXIT: The following test will hang since we don't monitor the alive status of the output device
+// FIXME: The following test will hang since we don't monitor the alive status of the output device
 #[ignore]
 #[test]
 fn test_destroy_duplex_stream_after_unplugging_a_nondefault_output_device() {
@@ -474,7 +474,7 @@ fn test_reinit_input_stream_by_unplugging_a_default_input_device() {
     test_unplug_a_device_on_an_active_stream(StreamType::INPUT, Scope::Input, true, 500);
 }
 
-// FIXIT: The following test will hang since we don't monitor the alive status of the output device
+// FIXME: The following test will hang since we don't monitor the alive status of the output device
 #[ignore]
 #[test]
 fn test_reinit_output_stream_by_unplugging_a_nondefault_output_device() {
@@ -499,7 +499,7 @@ fn test_reinit_duplex_stream_by_unplugging_a_default_input_device() {
     test_unplug_a_device_on_an_active_stream(StreamType::DUPLEX, Scope::Input, true, 500);
 }
 
-// FIXIT: The following test will hang since we don't monitor the alive status of the output device
+// FIXME: The following test will hang since we don't monitor the alive status of the output device
 #[ignore]
 #[test]
 fn test_reinit_duplex_stream_by_unplugging_a_nondefault_output_device() {

--- a/src/backend/tests/device_change.rs
+++ b/src/backend/tests/device_change.rs
@@ -517,7 +517,7 @@ fn test_unplug_a_device_on_an_active_stream(
     }
 
     if stream_type.contains(StreamType::OUTPUT) && !has_output {
-        println!("No output device for ouput or duplex stream.");
+        println!("No output device for output or duplex stream.");
         return;
     }
 

--- a/src/backend/tests/device_change.rs
+++ b/src/backend/tests/device_change.rs
@@ -24,6 +24,8 @@ use super::*;
 use std::fmt::Debug;
 use std::thread;
 
+// Switch default devices used by the active streams, to test stream reinitialization
+// ================================================================================================
 #[ignore]
 #[test]
 fn test_switch_device() {
@@ -176,6 +178,8 @@ where
     );
 }
 
+// Plug and unplug devices, to test device collection changed callback
+// ================================================================================================
 #[ignore]
 #[test]
 fn test_plug_and_unplug_device() {
@@ -298,6 +302,8 @@ fn test_plug_and_unplug_device_in_scope(scope: Scope) {
     }
 }
 
+// Switch default devices used by the active streams, to test device changed callback
+// ================================================================================================
 #[ignore]
 #[test]
 fn test_register_device_changed_callback_to_check_default_device_changed_input() {
@@ -402,6 +408,10 @@ fn test_register_device_changed_callback_to_check_default_device_changed(stm_typ
     }
 }
 
+// Unplug the devices used by the active streams, to test
+// 1) device changed callback
+// 2) stream reinitialization that may race with stream destroying
+// ================================================================================================
 #[ignore]
 #[test]
 fn test_destroy_input_stream_after_unplugging_a_nondefault_input_device() {

--- a/src/backend/tests/device_change.rs
+++ b/src/backend/tests/device_change.rs
@@ -654,6 +654,7 @@ impl<T: Clone + PartialEq> Watcher<T> {
             if self.current_result() != self.current.clone().unwrap() {
                 break;
             }
+            thread::sleep(Duration::from_millis(1));
         }
     }
 

--- a/src/backend/tests/device_change.rs
+++ b/src/backend/tests/device_change.rs
@@ -603,12 +603,17 @@ fn test_unplug_a_device_on_an_active_stream(
             let dev = plugger.get_device_id();
             assert!(plugger.unplug().is_ok());
             changed_watcher.wait_for_change();
-            // Wait for stream re-initialization or destroy stream directly.
             if wait_for_reinit_millis > 0 {
+                println!(
+                    "Wait {} ms for stream re-initialization",
+                    wait_for_reinit_millis
+                );
                 thread::sleep(Duration::from_millis(wait_for_reinit_millis));
+            } else {
+                println!("Destroy the stream immediately. Stream re-initialization may run at the same time when stream is being destroyed");
             }
             println!(
-                "Device {} for {:?} is unplugged. The default {:?} device now is {}",
+                "Device {} for {:?} has been unplugged. The default {:?} device now is {}",
                 dev,
                 device_scope,
                 device_scope,

--- a/src/backend/tests/manual.rs
+++ b/src/backend/tests/manual.rs
@@ -384,7 +384,6 @@ fn test_stream_tester() {
             state: ffi::cubeb_state,
         ) {
             assert!(!stream.is_null());
-            assert_ne!(state, ffi::CUBEB_STATE_ERROR);
             let s = State::from(state);
             println!("state: {:?}", s);
         }

--- a/todo.md
+++ b/todo.md
@@ -3,7 +3,7 @@
 ## General
 
 - Resolve the [issues](https://github.com/mozilla/cubeb-coreaudio-rs/issues)
-- Some of bugs are found when adding tests. Search *FIXIT* to find them.
+- Some of bugs are found when adding tests. Search *FIXME* to find them.
 - Remove `#[allow(non_camel_case_types)]`, `#![allow(unused_assignments)]`, `#![allow(unused_must_use)]`
 - Use `ErrorChain`
 - Centralize the error log in one place

--- a/todo.md
+++ b/todo.md
@@ -122,3 +122,4 @@ and create a new one. It's easier than the current implementation.
   - Add tests for capturing/recording, output, duplex streams
 - Update the manual tests
   - Those tests are created in the middle of the development. Thay might be not outdated now.
+- Add in-out support for `TestDevicePlugger`


### PR DESCRIPTION
By the comments [1,2] in the BMO 1735201, we should not switch the input device behind the scenes when users specify what devices they want. That is, we should not automatically re-initialize the input or duplex stream when the input device is gone. We will get a device-collection changed event as well when this happen and Gecko/Firefox will stop the paired MediaStreamTrack soon in this case.

When the user-select input device is gone, we can simply fire an error callback so the GraphDriver can switch from an `AudioCallbackDriver` to a `SystemClockDriver` [3].

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1735201#c0
[2] https://bugzilla.mozilla.org/show_bug.cgi?id=1735201#c11
[3] https://searchfox.org/mozilla-central/rev/b96000c5311dd5f2065ff7fc97d92bb8753dc3f4/dom/media/GraphDriver.cpp#1076
