### PR TITLE
Remove `kAudioUnitSubType_DefaultOutput` and its friend

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3248,7 +3248,6 @@ impl<'ctx> AudioUnitStream<'ctx> {
         self.core_stream_data.close();
 
         // Reinit occurs in one of the following case:
-        // - When the device is not alive any more
         // - When the default system device change.
         // - The bluetooth device changed from A2DP to/from HFP/HSP profile
         // We first attempt to re-use the same device id, should that fail we will

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -65,8 +65,7 @@ bitflags! {
         const DEV_UNKNOWN           = 0b0000_0000; // Unknown
         const DEV_INPUT             = 0b0000_0001; // Record device like mic
         const DEV_OUTPUT            = 0b0000_0010; // Playback device like speakers
-        const DEV_SYSTEM_DEFAULT    = 0b0000_0100; // System default device
-        const DEV_SELECTED_DEFAULT  = 0b0000_1000; // User selected to use the system default device
+        const DEV_SELECTED_DEFAULT  = 0b0000_0100; // User selected to use the system default device
     }
 }
 
@@ -212,11 +211,6 @@ fn create_device_info(id: AudioDeviceID, devtype: DeviceType) -> Result<device_i
         info.id = default_device_id;
         cubeb_log!("Creating a default device info.");
         info.flags |= device_flags::DEV_SELECTED_DEFAULT;
-    }
-
-    if info.id == default_device_id {
-        cubeb_log!("Requesting default system device.");
-        info.flags |= device_flags::DEV_SYSTEM_DEFAULT;
     }
 
     Ok(info)

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -153,9 +153,7 @@ fn test_create_device_info_from_unknown_input_device() {
         assert_eq!(default_device.id, default_device_id);
         assert_eq!(
             default_device.flags,
-            device_flags::DEV_INPUT
-                | device_flags::DEV_SELECTED_DEFAULT
-                | device_flags::DEV_SYSTEM_DEFAULT
+            device_flags::DEV_INPUT | device_flags::DEV_SELECTED_DEFAULT
         );
     } else {
         println!("No input device to perform test.");
@@ -169,9 +167,7 @@ fn test_create_device_info_from_unknown_output_device() {
         assert_eq!(default_device.id, default_device_id);
         assert_eq!(
             default_device.flags,
-            device_flags::DEV_OUTPUT
-                | device_flags::DEV_SELECTED_DEFAULT
-                | device_flags::DEV_SYSTEM_DEFAULT
+            device_flags::DEV_OUTPUT | device_flags::DEV_SELECTED_DEFAULT
         );
     } else {
         println!("No output device to perform test.");
@@ -849,12 +845,7 @@ fn test_enable_audiounit_scope_with_null_unit() {
 // ------------------------------------
 #[test]
 fn test_for_create_audiounit() {
-    let flags_list = [
-        device_flags::DEV_INPUT,
-        device_flags::DEV_OUTPUT,
-        device_flags::DEV_INPUT | device_flags::DEV_SYSTEM_DEFAULT,
-        device_flags::DEV_OUTPUT | device_flags::DEV_SYSTEM_DEFAULT,
-    ];
+    let flags_list = [device_flags::DEV_INPUT, device_flags::DEV_OUTPUT];
 
     let default_input = test_get_default_device(Scope::Input);
     let default_output = test_get_default_device(Scope::Output);
@@ -865,30 +856,10 @@ fn test_for_create_audiounit() {
 
         // Check the output scope is enabled.
         if device.flags.contains(device_flags::DEV_OUTPUT) && default_output.is_some() {
-            let device_id = default_output.clone().unwrap();
-            device.id = device_id;
+            device.id = default_output.clone().unwrap();
             let unit = create_audiounit(&device).unwrap();
             assert!(!unit.is_null());
             assert!(test_audiounit_scope_is_enabled(unit, Scope::Output));
-
-            // For default output device, the input scope is enabled
-            // if it's also a input device. Otherwise, it's disabled.
-            if device
-                .flags
-                .contains(device_flags::DEV_INPUT | device_flags::DEV_SYSTEM_DEFAULT)
-            {
-                assert_eq!(
-                    test_device_in_scope(device_id, Scope::Input),
-                    test_audiounit_scope_is_enabled(unit, Scope::Input)
-                );
-
-                // Destroy the AudioUnit.
-                unsafe {
-                    AudioUnitUninitialize(unit);
-                    AudioComponentInstanceDispose(unit);
-                }
-                continue;
-            }
 
             // Destroy the AudioUnit.
             unsafe {

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -786,28 +786,16 @@ fn test_create_stream_description() {
     }
 }
 
-// create_default_audiounit
+// create_blank_audiounit
 // ------------------------------------
 #[test]
-fn test_create_default_audiounit() {
-    let flags_list = [
-        device_flags::DEV_UNKNOWN,
-        device_flags::DEV_INPUT,
-        device_flags::DEV_OUTPUT,
-        device_flags::DEV_INPUT | device_flags::DEV_OUTPUT,
-        device_flags::DEV_INPUT | device_flags::DEV_SYSTEM_DEFAULT,
-        device_flags::DEV_OUTPUT | device_flags::DEV_SYSTEM_DEFAULT,
-        device_flags::DEV_INPUT | device_flags::DEV_OUTPUT | device_flags::DEV_SYSTEM_DEFAULT,
-    ];
-
-    for flags in flags_list.iter() {
-        let unit = create_default_audiounit(*flags).unwrap();
-        assert!(!unit.is_null());
-        // Destroy the AudioUnits
-        unsafe {
-            AudioUnitUninitialize(unit);
-            AudioComponentInstanceDispose(unit);
-        }
+fn test_create_blank_audiounit() {
+    let unit = create_blank_audiounit().unwrap();
+    assert!(!unit.is_null());
+    // Destroy the AudioUnit
+    unsafe {
+        AudioUnitUninitialize(unit);
+        AudioComponentInstanceDispose(unit);
     }
 }
 

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -894,7 +894,7 @@ fn test_for_create_audiounit() {
                     test_audiounit_scope_is_enabled(unit, Scope::Input)
                 );
 
-                // Destroy the audioUnit.
+                // Destroy the AudioUnit.
                 unsafe {
                     AudioUnitUninitialize(unit);
                     AudioComponentInstanceDispose(unit);
@@ -902,7 +902,7 @@ fn test_for_create_audiounit() {
                 continue;
             }
 
-            // Destroy the audioUnit.
+            // Destroy the AudioUnit.
             unsafe {
                 AudioUnitUninitialize(unit);
                 AudioComponentInstanceDispose(unit);
@@ -916,7 +916,7 @@ fn test_for_create_audiounit() {
             let unit = create_audiounit(&device).unwrap();
             assert!(!unit.is_null());
             assert!(test_audiounit_scope_is_enabled(unit, Scope::Input));
-            // Destroy the audioUnit.
+            // Destroy the AudioUnit.
             unsafe {
                 AudioUnitUninitialize(unit);
                 AudioComponentInstanceDispose(unit);


### PR DESCRIPTION
We use `kAudioUnitSubType_DefaultOutput` to create an `AudioUnit` when users request to use the default output device. However, we can use `kAudioUnitSubType_HALOutput` to achieve what we want as well, like what [chromium does][1], and we don't need a `DEV_SYSTEM_DEFAULT` anymore after doing this. This simplifies the code path and remove the unnecessary bit flag.

[1]: https://source.chromium.org/chromium/chromium/src/+/main:media/audio/mac/scoped_audio_unit.cc;l=12;drc=3ccfcbbac6f7055e92d9da39be10c656617468fb