### PR TITLE
Show devices information before running unplug tests

### DIFF
--- a/src/backend/tests/device_change.rs
+++ b/src/backend/tests/device_change.rs
@@ -645,6 +645,11 @@ fn test_unplug_a_device_on_an_active_stream(
 
     // Ignore the return devices' info since we only need to print them.
     let _ = get_devices_info_in_scope(device_scope.clone());
+    println!(
+        "Current default {:?} device is {}",
+        device_scope,
+        test_get_default_device(device_scope.clone()).unwrap()
+    );
 
     let (input_device, output_device) = match device_scope {
         Scope::Input => (

--- a/src/backend/tests/device_change.rs
+++ b/src/backend/tests/device_change.rs
@@ -15,10 +15,10 @@
 // in the run_tests.sh script and marked by `ignore` by default.
 
 use super::utils::{
-    test_create_device_change_listener, test_device_in_scope, test_get_default_device,
-    test_get_devices_in_scope, test_get_stream_with_default_data_callback_by_type,
-    test_ops_stream_operation, test_set_default_device, Scope, StreamType, TestDevicePlugger,
-    TestDeviceSwitcher,
+    get_devices_info_in_scope, test_create_device_change_listener, test_device_in_scope,
+    test_get_default_device, test_get_devices_in_scope,
+    test_get_stream_with_default_data_callback_by_type, test_ops_stream_operation,
+    test_set_default_device, Scope, StreamType, TestDevicePlugger, TestDeviceSwitcher,
 };
 use super::*;
 use std::fmt::Debug;
@@ -642,6 +642,9 @@ fn test_unplug_a_device_on_an_active_stream(
             assert_eq!(prev_def_dev, default_device_after_plugging);
         }
     }
+
+    // Ignore the return devices' info since we only need to print them.
+    let _ = get_devices_info_in_scope(device_scope.clone());
 
     let (input_device, output_device) = match device_scope {
         Scope::Input => (

--- a/src/backend/tests/utils.rs
+++ b/src/backend/tests/utils.rs
@@ -312,26 +312,31 @@ pub fn test_get_devices_in_scope(scope: Scope) -> Vec<AudioObjectID> {
     devices
 }
 
-fn test_print_devices_in_scope(devices: &Vec<AudioObjectID>, scope: Scope) {
+pub fn get_devices_info_in_scope(scope: Scope) -> Vec<TestDeviceInfo> {
+    fn print_info(info: &TestDeviceInfo) {
+        println!("{:>4}: {}\n\tuid: {}", info.id, info.label, info.uid);
+    }
+
     println!(
         "\n{:?} devices\n\
          --------------------",
         scope
     );
+
+    let mut infos = vec![];
+    let devices = test_get_devices_in_scope(scope.clone());
     for device in devices {
-        let info = TestDeviceInfo::new(*device, scope.clone());
-        print_info(&info);
+        infos.push(TestDeviceInfo::new(device, scope.clone()));
+        print_info(infos.last().unwrap());
     }
     println!("");
 
-    fn print_info(info: &TestDeviceInfo) {
-        println!("{:>4}: {}\n\tuid: {}", info.id, info.label, info.uid);
-    }
+    infos
 }
 
 #[derive(Debug)]
 pub struct TestDeviceInfo {
-    id: AudioObjectID,
+    pub id: AudioObjectID,
     pub label: String,
     pub uid: String,
 }
@@ -621,13 +626,13 @@ pub struct TestDeviceSwitcher {
 
 impl TestDeviceSwitcher {
     pub fn new(scope: Scope) -> Self {
-        let devices = test_get_devices_in_scope(scope.clone());
+        let infos = get_devices_info_in_scope(scope.clone());
+        let devices: Vec<AudioObjectID> = infos.into_iter().map(|info| info.id).collect();
         let current = test_get_default_device(scope.clone()).unwrap();
         let index = devices
             .iter()
             .position(|device| *device == current)
             .unwrap();
-        test_print_devices_in_scope(&devices, scope.clone());
         Self {
             scope: scope,
             devices: devices,


### PR DESCRIPTION
It's easier to debug issues on the server if we can show the devices information before running unplug tests