### PR TITLE
Restore the ability to open a stream with more channels than the output device has channels

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2614,12 +2614,6 @@ impl<'ctx> CoreStreamData<'ctx> {
                 out_dev_info
             );
 
-            let device_channel_count =
-                get_device_channel_count(self.output_device.id, DeviceType::OUTPUT).unwrap_or(0);
-            if device_channel_count < self.output_stream_params.channels() {
-                return Err(Error::invalid_parameter());
-            }
-
             self.output_unit = create_audiounit(&out_dev_info).map_err(|e| {
                 cubeb_log!("({:p}) AudioUnit creation for output failed.", self.stm_ptr);
                 e
@@ -2659,12 +2653,10 @@ impl<'ctx> CoreStreamData<'ctx> {
                 self.stm_ptr,
                 output_hw_desc
             );
-            assert!(output_hw_desc.mChannelsPerFrame >= device_channel_count);
             // Notice: when we are using aggregate device, the output_hw_desc.mChannelsPerFrame is
             // the total of all the output channel count of the devices added in the aggregate device.
             // Due to our aggregate device settings, the data recorded by the input device's output
             // channels will be appended at the end of the raw data given by the output callback.
-
             let params = unsafe {
                 let mut p = *self.output_stream_params.as_ptr();
                 p.channels = output_hw_desc.mChannelsPerFrame;


### PR DESCRIPTION
The mixer handles it. This allows playing e.g. a 5.1 file correctly on 2.0 hardware.

This reverts part of https://github.com/mozilla/cubeb-coreaudio-rs/pull/153/commits/8d7d78637d839d8b9e0be04762ea964999a6091f#diff-b1bbc13b52b920f2cfb842559dcccfa6a836168e2061e22d8a897c82af70c3a7R2645, so that we don't return an error, we simply set up the mixer correctly.