### PR TITLE
Use the user-provided rate to open the output device, and not the hardware rate

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2660,7 +2660,6 @@ impl<'ctx> CoreStreamData<'ctx> {
             let params = unsafe {
                 let mut p = *self.output_stream_params.as_ptr();
                 p.channels = output_hw_desc.mChannelsPerFrame;
-                p.rate = output_hw_desc.mSampleRate as _;
                 StreamParams::from(p)
             };
 


### PR DESCRIPTION
Fix for [BMO#1761392](https://bugzilla.mozilla.org/show_bug.cgi?id=1761392).