### PR TITLE
Correct the master device of the aggregate device

### DIFF
--- a/src/backend/tests/aggregate_device.rs
+++ b/src/backend/tests/aggregate_device.rs
@@ -66,7 +66,7 @@ fn test_aggregate_get_sub_devices_for_a_unknown_device() {
 #[test]
 #[should_panic]
 fn test_aggregate_set_master_device_for_an_unknown_aggregate_device() {
-    assert!(AggregateDevice::set_master_device(kAudioObjectUnknown).is_err());
+    assert!(AggregateDevice::set_master_device(kAudioObjectUnknown, kAudioObjectUnknown).is_err());
 }
 
 // AggregateDevice::activate_clock_drift_compensation
@@ -243,10 +243,9 @@ fn test_aggregate_set_master_device() {
     let plugin = AggregateDevice::get_system_plugin_id().unwrap();
     let device = AggregateDevice::create_blank_device_sync(plugin).unwrap();
     assert!(AggregateDevice::set_sub_devices_sync(device, input_device, output_device).is_ok());
-    assert!(AggregateDevice::set_master_device(device).is_ok());
+    assert!(AggregateDevice::set_master_device(device, output_device).is_ok());
 
     // Check if master is set to the first sub device of the default output device.
-    // TODO: What if the output device in the aggregate device is not the default output device?
     let first_output_sub_device_uid =
         get_device_uid(AggregateDevice::get_sub_devices(device).unwrap()[0]);
     let master_device_uid = test_get_master_device(device);
@@ -266,7 +265,7 @@ fn test_aggregate_set_master_device_for_a_blank_aggregate_device() {
 
     let plugin = AggregateDevice::get_system_plugin_id().unwrap();
     let device = AggregateDevice::create_blank_device_sync(plugin).unwrap();
-    assert!(AggregateDevice::set_master_device(device).is_ok());
+    assert!(AggregateDevice::set_master_device(device, output_device.unwrap()).is_ok());
 
     // TODO: it's really weird the aggregate device actually own nothing
     //       but its master device can be set successfully!
@@ -301,7 +300,7 @@ fn test_aggregate_activate_clock_drift_compensation() {
     let plugin = AggregateDevice::get_system_plugin_id().unwrap();
     let device = AggregateDevice::create_blank_device_sync(plugin).unwrap();
     assert!(AggregateDevice::set_sub_devices_sync(device, input_device, output_device).is_ok());
-    assert!(AggregateDevice::set_master_device(device).is_ok());
+    assert!(AggregateDevice::set_master_device(device, output_device).is_ok());
     assert!(AggregateDevice::activate_clock_drift_compensation(device).is_ok());
 
     // Check the compensations.

--- a/todo.md
+++ b/todo.md
@@ -77,8 +77,6 @@ and create a new one. It's easier than the current implementation.
 
 ### Setting master device
 
-- We always set the master device to the first subdevice of the default output device
-  but the output device (forming the aggregate device) may not be the default output device
 - Check if the first subdevice of the default output device is in the list of
   sub devices list of the aggregate device
 - Check the `name: CFStringRef` of the master device is not `NULL`


### PR DESCRIPTION
We should set the master device of the aggregate device to the output
device of the aggregate device, instead of the default output device.