### PR TITLE
 Return error for default device if it's `kAudioObjectUnknown`

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -189,10 +189,7 @@ fn clamp_latency(latency_frames: u32) -> u32 {
     )
 }
 
-fn create_device_info(
-    devid: AudioDeviceID,
-    devtype: DeviceType,
-) -> std::result::Result<device_info, OSStatus> {
+fn create_device_info(devid: AudioDeviceID, devtype: DeviceType) -> Option<device_info> {
     assert_ne!(devid, kAudioObjectSystemObject);
 
     let mut flags = match devtype {
@@ -201,15 +198,13 @@ fn create_device_info(
         _ => panic!("Only accept input or output type"),
     };
 
-    let id = if devid == kAudioObjectUnknown {
+    if devid == kAudioObjectUnknown {
         cubeb_log!("Use the system default device");
         flags |= device_flags::DEV_SELECTED_DEFAULT;
-        get_default_device_id(devtype)?
+        get_default_device(devtype).map(|id| device_info { id, flags })
     } else {
-        devid
-    };
-
-    Ok(device_info { id, flags })
+        Some(device_info { id: devid, flags })
+    }
 }
 
 fn create_stream_description(stream_params: &StreamParams) -> Result<AudioStreamBasicDescription> {
@@ -764,6 +759,20 @@ extern "C" fn audiounit_property_listener_callback(
     NO_ERR
 }
 
+fn get_default_device(devtype: DeviceType) -> Option<AudioObjectID> {
+    match get_default_device_id(devtype) {
+        Err(e) => {
+            cubeb_log!("Cannot get default {:?} device. Error: {}", devtype, e);
+            None
+        }
+        Ok(id) if id == kAudioObjectUnknown => {
+            cubeb_log!("Get an invalid default {:?} device: {}", devtype, id);
+            None
+        }
+        Ok(id) => Some(id),
+    }
+}
+
 fn get_default_device_id(devtype: DeviceType) -> std::result::Result<AudioObjectID, OSStatus> {
     let address = get_property_address(
         match devtype {
@@ -1228,10 +1237,10 @@ fn convert_uint32_into_string(data: u32) -> CString {
     CString::new(buffer).unwrap_or(empty)
 }
 
-fn audiounit_get_default_datasource_string(
+fn get_device_source_string(
+    id: AudioDeviceID,
     devtype: DeviceType,
 ) -> std::result::Result<CString, OSStatus> {
-    let id = get_default_device_id(devtype)?;
     let data = get_device_source(id, devtype)?;
     Ok(convert_uint32_into_string(data))
 }
@@ -1488,8 +1497,8 @@ fn create_cubeb_device_info(
     };
 
     dev_info.state = ffi::CUBEB_DEVICE_STATE_ENABLED;
-    dev_info.preferred = match get_default_device_id(devtype) {
-        Ok(id) if id == devid => ffi::CUBEB_DEVICE_PREF_ALL,
+    dev_info.preferred = match get_default_device(devtype) {
+        Some(id) if id == devid => ffi::CUBEB_DEVICE_PREF_ALL,
         _ => ffi::CUBEB_DEVICE_PREF_NONE,
     };
 
@@ -1954,10 +1963,13 @@ impl ContextOps for AudioUnitContext {
     }
     #[cfg(not(target_os = "ios"))]
     fn max_channel_count(&mut self) -> Result<u32> {
-        let device = get_default_device_id(DeviceType::OUTPUT).map_err(|e| {
-            cubeb_log!("Cannot get the default output device. Error: {}", e);
-            Error::error()
-        })?;
+        let device = match get_default_device(DeviceType::OUTPUT) {
+            None => {
+                cubeb_log!("Could not get default output device");
+                return Err(Error::error());
+            }
+            Some(id) => id,
+        };
 
         let format = get_device_stream_format(device, DeviceType::OUTPUT).map_err(|e| {
             cubeb_log!(
@@ -1974,10 +1986,14 @@ impl ContextOps for AudioUnitContext {
     }
     #[cfg(not(target_os = "ios"))]
     fn min_latency(&mut self, _params: StreamParams) -> Result<u32> {
-        let device = get_default_device_id(DeviceType::OUTPUT).map_err(|e| {
-            cubeb_log!("Could not get default output device id. Error: {}", e);
-            Error::error()
-        })?;
+        let device = match get_default_device(DeviceType::OUTPUT) {
+            None => {
+                cubeb_log!("Could not get default output device");
+                return Err(Error::error());
+            }
+            Some(id) => id,
+        };
+
         let range =
             get_device_buffer_frame_size_range(device, DeviceType::OUTPUT).map_err(|e| {
                 cubeb_log!("Could not get acceptable latency range. Error: {}", e);
@@ -1992,10 +2008,13 @@ impl ContextOps for AudioUnitContext {
     }
     #[cfg(not(target_os = "ios"))]
     fn preferred_sample_rate(&mut self) -> Result<u32> {
-        let device = get_default_device_id(DeviceType::OUTPUT).map_err(|e| {
-            cubeb_log!("Could not get default output device id. Error: {}", e);
-            Error::error()
-        })?;
+        let device = match get_default_device(DeviceType::OUTPUT) {
+            None => {
+                cubeb_log!("Could not get default output device");
+                return Err(Error::error());
+            }
+            Some(id) => id,
+        };
         let rate = get_device_sample_rate(device, DeviceType::OUTPUT).map_err(|e| {
             cubeb_log!(
                 "Cannot get the sample rate of the default output device. Error: {}",
@@ -2083,11 +2102,14 @@ impl ContextOps for AudioUnitContext {
         }
 
         let in_stm_settings = if let Some(params) = input_stream_params {
-            let in_device = create_device_info(input_device as AudioDeviceID, DeviceType::INPUT)
-                .map_err(|e| {
-                    cubeb_log!("Fail to create device info for input. Error: {}", e);
-                    Error::error()
-                })?;
+            let in_device =
+                match create_device_info(input_device as AudioDeviceID, DeviceType::INPUT) {
+                    None => {
+                        cubeb_log!("Fail to create device info for input");
+                        return Err(Error::error());
+                    }
+                    Some(d) => d,
+                };
             let stm_params = StreamParams::from(unsafe { *params.as_ptr() });
             Some((stm_params, in_device))
         } else {
@@ -2095,11 +2117,14 @@ impl ContextOps for AudioUnitContext {
         };
 
         let out_stm_settings = if let Some(params) = output_stream_params {
-            let out_device = create_device_info(output_device as AudioDeviceID, DeviceType::OUTPUT)
-                .map_err(|e| {
-                    cubeb_log!("Fail to create device info for output. Error: {}", e);
-                    Error::error()
-                })?;
+            let out_device =
+                match create_device_info(output_device as AudioDeviceID, DeviceType::OUTPUT) {
+                    None => {
+                        cubeb_log!("Fail to create device info for output");
+                        return Err(Error::error());
+                    }
+                    Some(d) => d,
+                };
             let stm_params = StreamParams::from(unsafe { *params.as_ptr() });
             Some((stm_params, out_device))
         } else {
@@ -3585,18 +3610,41 @@ impl<'ctx> StreamOps for AudioUnitStream<'ctx> {
     }
     #[cfg(not(target_os = "ios"))]
     fn current_device(&mut self) -> Result<&DeviceRef> {
-        let input_name = audiounit_get_default_datasource_string(DeviceType::INPUT);
-        let output_name = audiounit_get_default_datasource_string(DeviceType::OUTPUT);
-        if input_name.is_err() && output_name.is_err() {
-            return Err(Error::error());
-        }
+        let output_device = match get_default_device(DeviceType::OUTPUT) {
+            None => {
+                cubeb_log!("Could not get default output device");
+                return Err(Error::error());
+            }
+            Some(id) => id,
+        };
+        let output_name =
+            get_device_source_string(output_device, DeviceType::OUTPUT).map_err(|e| {
+                cubeb_log!(
+                    "Could not get device source string for default output device. Error: {}",
+                    e
+                );
+                Error::error()
+            })?;
+
+        let input_device = match get_default_device(DeviceType::INPUT) {
+            None => {
+                cubeb_log!("Could not get default input device");
+                return Err(Error::error());
+            }
+            Some(id) => id,
+        };
+        let input_name =
+            get_device_source_string(input_device, DeviceType::INPUT).map_err(|e| {
+                cubeb_log!(
+                    "Could not get device source string for default input device. Error: {}",
+                    e
+                );
+                Error::error()
+            })?;
 
         let mut device: Box<ffi::cubeb_device> = Box::new(ffi::cubeb_device::default());
 
-        let input_name = input_name.unwrap_or_default();
         device.input_name = input_name.into_raw();
-
-        let output_name = output_name.unwrap_or_default();
         device.output_name = output_name.into_raw();
 
         Ok(unsafe { DeviceRef::from_ptr(Box::into_raw(device)) })

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -321,14 +321,14 @@ fn test_remove_listener_unknown_device() {
 fn test_get_default_device_id() {
     if test_get_default_device(Scope::Input).is_some() {
         assert_ne!(
-            audiounit_get_default_device_id(DeviceType::INPUT).unwrap(),
+            get_default_device_id(DeviceType::INPUT).unwrap(),
             kAudioObjectUnknown,
         );
     }
 
     if test_get_default_device(Scope::Output).is_some() {
         assert_ne!(
-            audiounit_get_default_device_id(DeviceType::OUTPUT).unwrap(),
+            get_default_device_id(DeviceType::OUTPUT).unwrap(),
             kAudioObjectUnknown,
         );
     }
@@ -337,13 +337,13 @@ fn test_get_default_device_id() {
 #[test]
 #[should_panic]
 fn test_get_default_device_id_with_unknown_type() {
-    assert!(audiounit_get_default_device_id(DeviceType::UNKNOWN).is_err());
+    assert!(get_default_device_id(DeviceType::UNKNOWN).is_err());
 }
 
 #[test]
 #[should_panic]
 fn test_get_default_device_id_with_inout_type() {
-    assert!(audiounit_get_default_device_id(DeviceType::INPUT | DeviceType::OUTPUT).is_err());
+    assert!(get_default_device_id(DeviceType::INPUT | DeviceType::OUTPUT).is_err());
 }
 
 // convert_channel_layout

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -2,8 +2,8 @@ use super::utils::{
     test_audiounit_get_buffer_frame_size, test_audiounit_scope_is_enabled, test_create_audiounit,
     test_device_channels_in_scope, test_device_in_scope, test_get_all_devices,
     test_get_default_audiounit, test_get_default_device, test_get_default_raw_stream,
-    test_get_default_source_name, test_get_devices_in_scope, test_get_raw_context,
-    ComponentSubType, DeviceFilter, PropertyScope, Scope,
+    test_get_devices_in_scope, test_get_raw_context, test_get_source_name, ComponentSubType,
+    DeviceFilter, PropertyScope, Scope,
 };
 use super::*;
 
@@ -976,22 +976,26 @@ fn test_convert_uint32_into_string() {
     assert_eq!(data_string, CString::new("RUST").unwrap());
 }
 
-// get_default_datasource_string
+// get_device_source_string
 // ------------------------------------
 #[test]
-fn test_get_default_device_name() {
-    test_get_default_device_name_in_scope(Scope::Input);
-    test_get_default_device_name_in_scope(Scope::Output);
+fn test_get_device_source_string() {
+    test_get_source_name_in_scope(Scope::Input);
+    test_get_source_name_in_scope(Scope::Output);
 
-    fn test_get_default_device_name_in_scope(scope: Scope) {
-        if let Some(name) = test_get_default_source_name(scope.clone()) {
-            let source = audiounit_get_default_datasource_string(scope.into())
-                .unwrap()
-                .into_string()
-                .unwrap();
-            assert_eq!(name, source);
+    fn test_get_source_name_in_scope(scope: Scope) {
+        if let Some(dev) = test_get_default_device(scope.clone()) {
+            if let Some(name) = test_get_source_name(dev, scope.clone()) {
+                let source = get_device_source_string(dev, scope.into())
+                    .unwrap()
+                    .into_string()
+                    .unwrap();
+                assert_eq!(name, source);
+            } else {
+                println!("No source name for default {:?} device ", scope);
+            }
         } else {
-            println!("No source name for {:?}", scope);
+            println!("No default {:?} device", scope);
         }
     }
 }

--- a/src/backend/tests/utils.rs
+++ b/src/backend/tests/utils.rs
@@ -188,21 +188,15 @@ fn test_enable_audiounit_in_scope(
     }
 }
 
-pub fn test_get_default_source_name(scope: Scope) -> Option<String> {
-    if let Some(source) = test_get_default_source_data(scope) {
+pub fn test_get_source_name(device: AudioObjectID, scope: Scope) -> Option<String> {
+    if let Some(source) = test_get_source_data(device, scope) {
         Some(u32_to_string(source))
     } else {
         None
     }
 }
 
-pub fn test_get_default_source_data(scope: Scope) -> Option<u32> {
-    let device = test_get_default_device(scope.clone());
-    if device.is_none() {
-        return None;
-    }
-
-    let device = device.unwrap();
+pub fn test_get_source_data(device: AudioObjectID, scope: Scope) -> Option<u32> {
     let address = AudioObjectPropertyAddress {
         mSelector: kAudioDevicePropertyDataSource,
         mScope: match scope {

--- a/todo.md
+++ b/todo.md
@@ -100,6 +100,7 @@ and create a new one. It's easier than the current implementation.
 
 ## [Cubeb Interface][cubeb-rs]
 
+- `current_device` should be the in-use device of the current stream rather than default input and output device.
 - Implement `From` trait for `enum cubeb_device_type` so we can use `devtype.into()` to get `ffi::CUBEB_DEVICE_TYPE_*`.
 - Implement `to_owned` in [`StreamParamsRef`][cubeb-rs-stmparamsref]
 - Check the passed parameters like what [cubeb.c does][cubeb-stm-check]!


### PR DESCRIPTION
 Return error for default device if it's `kAudioObjectUnknown`

The default output device on Circle CI server is `kAudioObjectUnknown`.
We should return error if we get this kind of device since all its
operations will be invalid.