### PR TITLE
Use `get_channel_count` for `max_channel_count`

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1970,15 +1970,7 @@ impl ContextOps for AudioUnitContext {
             }
             Some(id) => id,
         };
-
-        let format = get_device_stream_format(device, DeviceType::OUTPUT).map_err(|e| {
-            cubeb_log!(
-                "Cannot get the stream format of the default output device. Error: {}",
-                e
-            );
-            Error::error()
-        })?;
-        Ok(format.mChannelsPerFrame)
+        get_channel_count(device, DeviceType::OUTPUT)
     }
     #[cfg(target_os = "ios")]
     fn min_latency(&mut self, _params: StreamParams) -> Result<u32> {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1245,14 +1245,13 @@ fn get_device_source_string(
     Ok(convert_uint32_into_string(data))
 }
 
-fn get_channel_count(devid: AudioObjectID, devtype: DeviceType) -> Result<u32> {
+fn get_channel_count(
+    devid: AudioObjectID,
+    devtype: DeviceType,
+) -> std::result::Result<u32, OSStatus> {
     assert_ne!(devid, kAudioObjectUnknown);
 
-    let buffers = get_device_stream_configuration(devid, devtype).map_err(|e| {
-        cubeb_log!("Cannot get the stream configuration. Error: {}", e);
-        Error::error()
-    })?;
-
+    let buffers = get_device_stream_configuration(devid, devtype)?;
     let mut count = 0;
     for buffer in buffers {
         count += buffer.mNumberChannels;
@@ -1415,7 +1414,10 @@ fn create_cubeb_device_info(
     devid: AudioObjectID,
     devtype: DeviceType,
 ) -> Result<ffi::cubeb_device_info> {
-    let channels = get_channel_count(devid, devtype)?;
+    let channels = get_channel_count(devid, devtype).map_err(|e| {
+        cubeb_log!("Cannot get the channel count. Error: {}", e);
+        Error::error()
+    })?;
     if channels == 0 {
         // Invalid type for this device.
         return Err(Error::error());
@@ -1970,7 +1972,10 @@ impl ContextOps for AudioUnitContext {
             }
             Some(id) => id,
         };
-        get_channel_count(device, DeviceType::OUTPUT)
+        get_channel_count(device, DeviceType::OUTPUT).map_err(|e| {
+            cubeb_log!("Cannot get the channel count. Error: {}", e);
+            Error::error()
+        })
     }
     #[cfg(target_os = "ios")]
     fn min_latency(&mut self, _params: StreamParams) -> Result<u32> {

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1050,10 +1050,7 @@ fn test_get_channel_count_of_output_for_a_input_only_deivce() {
 #[test]
 #[should_panic]
 fn test_get_channel_count_of_unknown_device() {
-    assert_eq!(
-        get_channel_count(kAudioObjectUnknown, DeviceType::OUTPUT).unwrap_err(),
-        Error::error()
-    );
+    assert!(get_channel_count(kAudioObjectUnknown, DeviceType::OUTPUT).is_err());
 }
 
 #[test]
@@ -1064,9 +1061,8 @@ fn test_get_channel_count_of_inout_type() {
     fn test_channel_count(scope: Scope) {
         if let Some(device) = test_get_default_device(scope.clone()) {
             assert_eq!(
-                // Get a kAudioHardwareUnknownPropertyError in get_channel_count actually.
                 get_channel_count(device, DeviceType::INPUT | DeviceType::OUTPUT).unwrap_err(),
-                Error::error()
+                kAudioHardwareUnknownPropertyError as OSStatus
             );
         } else {
             println!("No device for {:?}.", scope);
@@ -1082,10 +1078,7 @@ fn test_get_channel_count_of_unknwon_type() {
 
     fn test_channel_count(scope: Scope) {
         if let Some(device) = test_get_default_device(scope.clone()) {
-            assert_eq!(
-                get_channel_count(device, DeviceType::UNKNOWN).unwrap_err(),
-                Error::error()
-            );
+            assert!(get_channel_count(device, DeviceType::UNKNOWN).is_err());
         } else {
             panic!("Panic by default: No device for {:?}.", scope);
         }


### PR DESCRIPTION
We use `get_channel_count` for the max channel count in
`enumerate_devices` but we use `get_device_stream_format`'s channel info
for `max_channel_count`. We should use `get_channel_count` instead.