### PR TITLE
Watching the alive status for all the running devices

### DIFF
--- a/run_device_tests.sh
+++ b/run_device_tests.sh
@@ -24,10 +24,8 @@ cargo test test_suspend_input_stream_by_unplugging_a_nondefault_input_device -- 
 cargo test test_destroy_input_stream_after_unplugging_a_default_input_device -- --ignored --nocapture
 cargo test test_reinit_input_stream_by_unplugging_a_default_input_device -- --ignored --nocapture
 
-# FIXME: We don't monitor the alive-status for output device currently
-# cargo test test_destroy_output_stream_after_unplugging_a_nondefault_output_device -- --ignored --nocapture
-# FIXME: We don't monitor the alive-status for output device currently
-# cargo test test_suspend_output_stream_by_unplugging_a_nondefault_output_device -- --ignored --nocapture
+cargo test test_destroy_output_stream_after_unplugging_a_nondefault_output_device -- --ignored --nocapture
+cargo test test_suspend_output_stream_by_unplugging_a_nondefault_output_device -- --ignored --nocapture
 
 cargo test test_destroy_output_stream_after_unplugging_a_default_output_device -- --ignored --nocapture
 cargo test test_reinit_output_stream_by_unplugging_a_default_output_device -- --ignored --nocapture
@@ -35,10 +33,8 @@ cargo test test_reinit_output_stream_by_unplugging_a_default_output_device -- --
 cargo test test_destroy_duplex_stream_after_unplugging_a_nondefault_input_device -- --ignored --nocapture
 cargo test test_suspend_duplex_stream_by_unplugging_a_nondefault_input_device
 
-# FIXME: We don't monitor the alive-status for output device currently
-# cargo test test_destroy_duplex_stream_after_unplugging_a_nondefault_output_device -- --ignored --nocapture
-# FIXME: We don't monitor the alive-status for output device currently
-# cargo test test_suspend_duplex_stream_by_unplugging_a_nondefault_output_device -- --ignored --nocapture
+cargo test test_destroy_duplex_stream_after_unplugging_a_nondefault_output_device -- --ignored --nocapture
+cargo test test_suspend_duplex_stream_by_unplugging_a_nondefault_output_device -- --ignored --nocapture
 
 cargo test test_destroy_duplex_stream_after_unplugging_a_default_input_device -- --ignored --nocapture
 cargo test test_reinit_duplex_stream_by_unplugging_a_default_input_device -- --ignored --nocapture

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2888,9 +2888,7 @@ impl<'ctx> CoreStreamData<'ctx> {
         // We cannot have both of them at the same time.
         assert!(
             !self.has_input()
-                || ((self.default_input_listener.is_some() != self.input_alive_listener.is_some())
-                    && (self.default_input_listener.is_some()
-                        || self.input_alive_listener.is_some()))
+                || (self.default_input_listener.is_some() != self.input_alive_listener.is_some())
         );
 
         Ok(())

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2942,8 +2942,13 @@ impl<'ctx> CoreStreamData<'ctx> {
             ));
             let rv = stm.add_device_listener(self.output_source_listener.as_ref().unwrap());
             if rv != NO_ERR {
+                cubeb_log!(
+                    "({:p}) Failed to monitor data source of output device {}. Error: {}",
+                    self.stm_ptr,
+                    self.output_source_listener.as_ref().unwrap().device,
+                    rv
+                );
                 self.output_source_listener = None;
-                cubeb_log!("AudioObjectAddPropertyListener/output/kAudioDevicePropertyDataSource rv={}, device id={}", rv, self.output_device.id);
                 return Err(Error::error());
             }
 
@@ -2965,8 +2970,12 @@ impl<'ctx> CoreStreamData<'ctx> {
             ));
             let rv = stm.add_device_listener(self.default_output_listener.as_ref().unwrap());
             if rv != NO_ERR {
+                cubeb_log!(
+                    "({:p}) Failed to monitor default output device. Error: {}",
+                    self.stm_ptr,
+                    rv
+                );
                 self.default_output_listener = None;
-                cubeb_log!("AudioObjectAddPropertyListener/output/kAudioHardwarePropertyDefaultOutputDevice rv={}", rv);
                 return Err(Error::error());
             }
         }
@@ -2992,8 +3001,13 @@ impl<'ctx> CoreStreamData<'ctx> {
             ));
             let rv = stm.add_device_listener(self.input_source_listener.as_ref().unwrap());
             if rv != NO_ERR {
+                cubeb_log!(
+                    "({:p}) Failed to monitor data source of input device {}. Error: {}",
+                    self.stm_ptr,
+                    self.input_source_listener.as_ref().unwrap().device,
+                    rv
+                );
                 self.input_source_listener = None;
-                cubeb_log!("AudioObjectAddPropertyListener/input/kAudioDevicePropertyDataSource rv={}, device id={}", rv, self.input_device.id);
                 return Err(Error::error());
             }
 
@@ -3020,8 +3034,12 @@ impl<'ctx> CoreStreamData<'ctx> {
                 ));
                 let rv = stm.add_device_listener(self.default_input_listener.as_ref().unwrap());
                 if rv != NO_ERR {
+                    cubeb_log!(
+                        "({:p}) Failed to monitor default input device. Error: {}",
+                        self.stm_ptr,
+                        rv
+                    );
                     self.default_input_listener = None;
-                    cubeb_log!("AudioObjectAddPropertyListener/input/kAudioHardwarePropertyDefaultInputDevice rv={}", rv);
                     return Err(Error::error());
                 }
             } else {
@@ -3037,8 +3055,13 @@ impl<'ctx> CoreStreamData<'ctx> {
                 ));
                 let rv = stm.add_device_listener(self.input_alive_listener.as_ref().unwrap());
                 if rv != NO_ERR {
+                    cubeb_log!(
+                        "({:p}) Failed to monitor alive status of input device {}. Error: {}",
+                        self.stm_ptr,
+                        self.input_alive_listener.as_ref().unwrap().device,
+                        rv
+                    );
                     self.input_alive_listener = None;
-                    cubeb_log!("AudioObjectAddPropertyListener/input/kAudioDevicePropertyDeviceIsAlive rv={}, device id ={}", rv, self.input_device.id);
                     return Err(Error::error());
                 }
             }
@@ -3065,6 +3088,11 @@ impl<'ctx> CoreStreamData<'ctx> {
         if self.default_input_listener.is_some() {
             let rv = stm.remove_device_listener(self.default_input_listener.as_ref().unwrap());
             if rv != NO_ERR {
+                cubeb_log!(
+                    "({:p}) Failed to cancel monitoring default input device. Error: {}",
+                    self.stm_ptr,
+                    rv
+                );
                 r = Err(Error::error());
             }
             self.default_input_listener = None;
@@ -3073,6 +3101,11 @@ impl<'ctx> CoreStreamData<'ctx> {
         if self.default_output_listener.is_some() {
             let rv = stm.remove_device_listener(self.default_output_listener.as_ref().unwrap());
             if rv != NO_ERR {
+                cubeb_log!(
+                    "({:p}) Failed to cancel monitoring default output device. Error: {}",
+                    self.stm_ptr,
+                    rv
+                );
                 r = Err(Error::error());
             }
             self.default_output_listener = None;
@@ -3081,7 +3114,12 @@ impl<'ctx> CoreStreamData<'ctx> {
         if self.output_source_listener.is_some() {
             let rv = stm.remove_device_listener(self.output_source_listener.as_ref().unwrap());
             if rv != NO_ERR {
-                cubeb_log!("AudioObjectRemovePropertyListener/output/kAudioDevicePropertyDataSource rv={}, device id={}", rv, self.output_device.id);
+                cubeb_log!(
+                    "({:p}) Failed to cancel monitoring data source of output device {}. Error: {}",
+                    self.stm_ptr,
+                    self.output_source_listener.as_ref().unwrap().device,
+                    rv
+                );
                 r = Err(Error::error());
             }
             self.output_source_listener = None;
@@ -3090,7 +3128,12 @@ impl<'ctx> CoreStreamData<'ctx> {
         if self.input_source_listener.is_some() {
             let rv = stm.remove_device_listener(self.input_source_listener.as_ref().unwrap());
             if rv != NO_ERR {
-                cubeb_log!("AudioObjectRemovePropertyListener/input/kAudioDevicePropertyDataSource rv={}, device id={}", rv, self.input_device.id);
+                cubeb_log!(
+                    "({:p}) Failed to cancel monitoring data source of input device {}. Error: {}",
+                    self.stm_ptr,
+                    self.input_source_listener.as_ref().unwrap().device,
+                    rv
+                );
                 r = Err(Error::error());
             }
             self.input_source_listener = None;
@@ -3099,7 +3142,12 @@ impl<'ctx> CoreStreamData<'ctx> {
         if self.input_alive_listener.is_some() {
             let rv = stm.remove_device_listener(self.input_alive_listener.as_ref().unwrap());
             if rv != NO_ERR {
-                cubeb_log!("AudioObjectRemovePropertyListener/input/kAudioDevicePropertyDeviceIsAlive rv={}, device id={}", rv, self.input_device.id);
+                cubeb_log!(
+                    "({:p}) Failed to cancel monitoring alive status of input device {}. Error: {}",
+                    self.stm_ptr,
+                    self.input_alive_listener.as_ref().unwrap().device,
+                    rv
+                );
                 r = Err(Error::error());
             }
             self.input_alive_listener = None;

--- a/src/backend/tests/device_change.rs
+++ b/src/backend/tests/device_change.rs
@@ -467,14 +467,12 @@ fn test_reinit_input_stream_by_unplugging_a_default_input_device() {
 
 // Unplug the non-default output device for an output stream
 // ------------------------------------------------------------------------------------------------
-// FIXME: We don't monitor the alive-status for output device currently
 #[ignore]
 #[test]
 fn test_destroy_output_stream_after_unplugging_a_nondefault_output_device() {
     test_unplug_a_device_on_an_active_stream(StreamType::OUTPUT, Scope::Output, false, 0);
 }
 
-// FIXME: We don't monitor the alive-status for output device currently
 #[ignore]
 #[test]
 fn test_suspend_output_stream_by_unplugging_a_nondefault_output_device() {
@@ -524,14 +522,12 @@ fn test_suspend_duplex_stream_by_unplugging_a_nondefault_input_device() {
 // Unplug the non-default output device for a duplex stream
 // ------------------------------------------------------------------------------------------------
 
-// FIXME: We don't monitor the alive-status for output device currently
 #[ignore]
 #[test]
 fn test_destroy_duplex_stream_after_unplugging_a_nondefault_output_device() {
     test_unplug_a_device_on_an_active_stream(StreamType::DUPLEX, Scope::Output, false, 0);
 }
 
-// FIXME: We don't monitor the alive-status for output device currently
 #[ignore]
 #[test]
 fn test_suspend_duplex_stream_by_unplugging_a_nondefault_output_device() {


### PR DESCRIPTION
We should monitor the alive status of both input and output devices in use. We used to watch input device only. With the code in this PR, we are able to watch the alive status of all the running devices when user doesn't follow the system default devices. If any user-selected device is unplugged before it's destroyed, we should fire an error callback.
