### PR TITLE
Don't assert about input_frames / total_input_frames when input-only.

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -426,7 +426,7 @@ extern "C" fn audiounit_input_callback(
         );
         let mut total_input_frames = input_buffer_manager.available_frames() as i64;
         let input_buffer =
-            input_buffer_manager.get_linear_data(input_buffer_manager.available_samples());
+            input_buffer_manager.get_linear_data(input_buffer_manager.available_frames());
         let outframes = stm.core_stream_data.resampler.fill(
             input_buffer,
             &mut total_input_frames,
@@ -583,7 +583,6 @@ extern "C" fn audiounit_output_callback(
     let (input_buffer, mut input_frames) = if !stm.core_stream_data.input_unit.is_null() {
         let input_buffer_manager = stm.core_stream_data.input_buffer_manager.as_mut().unwrap();
         assert_ne!(stm.core_stream_data.input_dev_desc.mChannelsPerFrame, 0);
-        let input_channels = input_buffer_manager.channel_count() as usize;
         // If the output callback came first and this is a duplex stream, we need to
         // fill in some additional silence in the resampler.
         // Otherwise, if we had more than expected callbacks in a row, or we're
@@ -594,11 +593,11 @@ extern "C" fn audiounit_output_callback(
             f64::from(stm.core_stream_data.output_stream_params.rate()),
             output_frames as usize,
         );
-        let buffered_input_frames = input_buffer_manager.available_samples() / input_channels;
+        let buffered_input_frames = input_buffer_manager.available_frames();
         // Else if the input has buffered a lot already because the output started late, we
         // need to trim the input buffer
         if prev_frames_written == 0 && buffered_input_frames > input_frames_needed as usize {
-            input_buffer_manager.trim(input_frames_needed * input_channels);
+            input_buffer_manager.trim(input_frames_needed);
             let popped_frames = buffered_input_frames - input_frames_needed as usize;
             cubeb_log!("Dropping {} frames in input buffer.", popped_frames);
         }
@@ -627,10 +626,9 @@ extern "C" fn audiounit_output_callback(
             buffered_input_frames
         };
 
-        let input_samples_needed = input_frames * input_channels;
         stm.frames_read.fetch_add(input_frames, Ordering::SeqCst);
         (
-            input_buffer_manager.get_linear_data(input_samples_needed),
+            input_buffer_manager.get_linear_data(input_frames),
             input_frames as i64,
         )
     } else {


### PR DESCRIPTION
This is possible if the first branch of:

> if status == kAudioUnitErr_CannotDoInCurrentContext

is taken and there's been data before. In this case, it's possible to
have input frames, but impossible to have them, probably. I can
reproduce 100% of the time by installing BlackHole-16ch and running `./run_tests.sh` on the M1 Max.