### PR TITLE
Querying kAudioUnitProperty_StreamFormat can return a channel count of 0

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2670,6 +2670,16 @@ impl<'ctx> CoreStreamData<'ctx> {
                 self.stm_ptr,
                 output_hw_desc
             );
+
+            // This has been observed in the wild.
+            if output_hw_desc.mChannelsPerFrame == 0 {
+                cubeb_log!(
+                    "({:p}) Output hardware description channel count is zero",
+                    self.stm_ptr
+                );
+                return Err(Error::error());
+            }
+
             // Notice: when we are using aggregate device, the output_hw_desc.mChannelsPerFrame is
             // the total of all the output channel count of the devices added in the aggregate device.
             // Due to our aggregate device settings, the data recorded by the input device's output


### PR DESCRIPTION
Only one crash so far though: https://crash-stats.mozilla.org/signature/?product=Firefox&version=101.0a1&platform=Mac%20OS%20X&build_id=%3E%3D20220414092955&signature=cubeb_coreaudio%3A%3Abackend%3A%3ACoreStreamData%3A%3Asetup&date=%3E%3D2022-03-20T00%3A00%3A00.000Z&date=%3C2022-04-20T23%3A59%3A00.000Z&_columns=date&_columns=product&_columns=version&_columns=build_id&_columns=platform&_columns=reason&_columns=address&_columns=install_time&_columns=startup_crash&_sort=-date&page=1