### PR TITLE
Use the new async logging macros, fix various log messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["staticlib", "rlib"]
 atomic = "0.4"
 bitflags = "1.0"
 coreaudio-sys-utils = { path = "coreaudio-sys-utils" }
-cubeb-backend = "0.10"
+cubeb-backend = "0.10.1"
 float-cmp = "0.6"
 libc = "0.2"
 lazy_static = "1.2"

--- a/src/backend/buffer_manager.rs
+++ b/src/backend/buffer_manager.rs
@@ -208,7 +208,7 @@ impl BufferManager {
         };
         assert!(pushed <= to_push, "We don't support upmix");
         if pushed != to_push {
-            cubeb_log!(
+            cubeb_alog!(
                 "Input ringbuffer full, could only push {} instead of {}",
                 pushed,
                 to_push
@@ -222,6 +222,11 @@ impl BufferManager {
                     unsafe { slice::from_raw_parts_mut::<i16>(data as *mut i16, needed_samples) };
                 let read = p.pop_slice(input);
                 if read < needed_samples {
+                    cubeb_alog!(
+                        "Underrun during input data pull: (needed: {}, available: {})",
+                        needed_samples,
+                        read
+                    );
                     for i in 0..(needed_samples - read) {
                         input[read + i] = 0;
                     }
@@ -232,6 +237,11 @@ impl BufferManager {
                     unsafe { slice::from_raw_parts_mut::<f32>(data as *mut f32, needed_samples) };
                 let read = p.pop_slice(input);
                 if read < needed_samples {
+                    cubeb_alog!(
+                        "Underrun during input data pull: (needed: {}, available: {})",
+                        needed_samples,
+                        read
+                    );
                     for i in 0..(needed_samples - read) {
                         input[read + i] = 0.0;
                     }

--- a/src/backend/mixer.rs
+++ b/src/backend/mixer.rs
@@ -180,7 +180,7 @@ impl Mixer {
         assert!(out_channel_count > 0);
 
         cubeb_log!(
-            "Create a mixer with input channel count: {}, input layout: {:?}, \
+            "Creating a mixer with input channel count: {}, input layout: {:?},\
              out channel count: {}, output channels: {:?}",
             in_channel_count,
             input_layout,
@@ -189,7 +189,9 @@ impl Mixer {
         );
 
         let input_channels = if in_channel_count as u32 != input_layout.bits().count_ones() {
-            cubeb_log!("Mismatch between input channels and layout. Apply default layout instead");
+            cubeb_log!(
+                "Mismatch between input channels and layout. Applying default layout instead"
+            );
             get_default_channel_order(in_channel_count)
         } else {
             get_channel_order(input_layout)


### PR DESCRIPTION
This won't build for now, we need to bump `cubeb-backend`'s version here after merging https://github.com/mozilla/cubeb-rs/pull/70, but should be an easy rebase. It works well locally when overriding.

I took the opportunity to fix the phrasing of some logs while I was verifying what type they should be.