### PR TITLE
Allow failure of current_device

### DIFF
--- a/src/backend/tests/interfaces.rs
+++ b/src/backend/tests/interfaces.rs
@@ -574,11 +574,14 @@ fn test_ops_stream_current_device() {
             println!("stream_get_current_device only works when the machine has both input and output devices");
             return;
         }
+
         let mut device: *mut ffi::cubeb_device = ptr::null_mut();
-        assert_eq!(
-            unsafe { OPS.stream_get_current_device.unwrap()(stream, &mut device) },
-            ffi::CUBEB_OK
-        );
+        if unsafe { OPS.stream_get_current_device.unwrap()(stream, &mut device) } != ffi::CUBEB_OK {
+            // It can happen when we fail to get the device source.
+            println!("stream_get_current_device fails. Skip this test.");
+            return;
+        }
+
         assert!(!device.is_null());
         // Uncomment the below to print out the results.
         // let deviceref = unsafe { DeviceRef::from_ptr(device) };


### PR DESCRIPTION
`AudioUnitStream::current_device` can fail when the default device has
no `kAudioDevicePropertyDataSource` value.