### PR TITLE
Fix new errors reported by clippy on Nightly

### DIFF
--- a/src/backend/buffer_manager.rs
+++ b/src/backend/buffer_manager.rs
@@ -147,7 +147,7 @@ impl BufferManager {
         assert!(input_channel_count >= input_channels_to_ignore + output_channel_count);
         // 8 times the expected callback size, to handle the input callback being caled multiple
         //   times in a row correctly.
-        let buffer_element_count = output_channel_count * buffer_size_frames as usize * 8;
+        let buffer_element_count = output_channel_count * buffer_size_frames * 8;
         match format {
             SampleFormat::S16LE | SampleFormat::S16BE | SampleFormat::S16NE => {
                 let ring = RingBuffer::<i16>::new(buffer_element_count);

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -184,13 +184,6 @@ fn set_notification_runloop() {
     }
 }
 
-fn clamp_latency(latency_frames: u32) -> u32 {
-    cmp::max(
-        cmp::min(latency_frames, SAFE_MAX_LATENCY_FRAMES),
-        SAFE_MIN_LATENCY_FRAMES,
-    )
-}
-
 fn create_device_info(devid: AudioDeviceID, devtype: DeviceType) -> Option<device_info> {
     assert_ne!(devid, kAudioObjectSystemObject);
 
@@ -612,9 +605,9 @@ extern "C" fn audiounit_output_callback(
         let buffered_input_frames = input_buffer_manager.available_frames();
         // Else if the input has buffered a lot already because the output started late, we
         // need to trim the input buffer
-        if prev_frames_written == 0 && buffered_input_frames > input_frames_needed as usize {
+        if prev_frames_written == 0 && buffered_input_frames > input_frames_needed {
             input_buffer_manager.trim(input_frames_needed);
-            let popped_frames = buffered_input_frames - input_frames_needed as usize;
+            let popped_frames = buffered_input_frames - input_frames_needed;
             cubeb_alog!("Dropping {} frames in input buffer.", popped_frames);
         }
 
@@ -1815,7 +1808,7 @@ impl LatencyController {
             assert!(self.latency.is_none());
             // Silently clamp the latency down to the platform default, because we
             // synthetize the clock from the callbacks, and we want the clock to update often.
-            self.latency = Some(clamp_latency(latency));
+            self.latency = Some(latency.clamp(SAFE_MIN_LATENCY_FRAMES, SAFE_MAX_LATENCY_FRAMES));
         }
         self.latency
     }
@@ -3749,7 +3742,7 @@ impl<'ctx> StreamOps for AudioUnitStream<'ctx> {
                 Error::error()
             })?;
 
-        let mut device: Box<ffi::cubeb_device> = Box::new(ffi::cubeb_device::default());
+        let mut device: Box<ffi::cubeb_device> = Box::default();
 
         device.input_name = input_name.into_raw();
         device.output_name = output_name.into_raw();

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -885,20 +885,6 @@ fn test_create_audiounit_with_unknown_scope() {
     let _unit = create_audiounit(&device);
 }
 
-// clamp_latency
-// ------------------------------------
-#[test]
-fn test_clamp_latency() {
-    let range = 0..2 * SAFE_MAX_LATENCY_FRAMES;
-    assert!(range.start < SAFE_MIN_LATENCY_FRAMES);
-    // assert!(range.end < SAFE_MAX_LATENCY_FRAMES);
-    for latency_frames in range {
-        let clamp = clamp_latency(latency_frames);
-        assert!(clamp >= SAFE_MIN_LATENCY_FRAMES);
-        assert!(clamp <= SAFE_MAX_LATENCY_FRAMES);
-    }
-}
-
 // set_buffer_size_sync
 // ------------------------------------
 #[test]


### PR DESCRIPTION
Error log (on CI: https://github.com/mozilla/cubeb-coreaudio-rs/actions/runs/3219120272/jobs/5264095997):

<details>
<pre>
error: casting to the same type is unnecessary (`usize` -> `usize`)
   --> src/backend/buffer_manager.rs:150:59
    |
150 |         let buffer_element_count = output_channel_count * buffer_size_frames as usize * 8;
    |                                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `buffer_size_frames`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast
    = note: `-D clippy::unnecessary-cast` implied by `-D warnings`

error: clamp-like pattern without using clamp function
   --> src/backend/mod.rs:188:5
    |
188 | /     cmp::max(
189 | |         cmp::min(latency_frames, SAFE_MAX_LATENCY_FRAMES),
190 | |         SAFE_MIN_LATENCY_FRAMES,
191 | |     )
    | |_____^ help: replace with clamp: `latency_frames.clamp(SAFE_MIN_LATENCY_FRAMES, SAFE_MAX_LATENCY_FRAMES)`
    |
    = note: clamp will panic if max < min
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_clamp
    = note: `-D clippy::manual-clamp` implied by `-D warnings`

error: casting to the same type is unnecessary (`usize` -> `usize`)
   --> src/backend/mod.rs:615:64
    |
615 |         if prev_frames_written == 0 && buffered_input_frames > input_frames_needed as usize {
    |                                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `input_frames_needed`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast

error: casting to the same type is unnecessary (`usize` -> `usize`)
   --> src/backend/mod.rs:617:57
    |
617 |             let popped_frames = buffered_input_frames - input_frames_needed as usize;
    |                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `input_frames_needed`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast

error: `Box::new(_)` of default value
    --> src/backend/mod.rs:3752:50
     |
3752 |         let mut device: Box<ffi::cubeb_device> = Box::new(ffi::cubeb_device::default());
     |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = help: use `Box::default()` instead
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#box_default
     = note: `-D clippy::box-default` implied by `-D warnings`
</pre>
</details>