### PR TITLE
Use a VoiceProcessingIO AudioUnit with bypass enabled instead of a regular AudioUnit on top of a drift-corrected aggregate device when in VOICE mode

### DIFF
--- a/coreaudio-sys-utils/Cargo.toml
+++ b/coreaudio-sys-utils/Cargo.toml
@@ -10,5 +10,5 @@ core-foundation-sys = { version = "0.8" }
 
 [dependencies.coreaudio-sys]
 default-features = false
-features = ["audio_unit", "core_audio"]
-version = "0.2"
+features = ["audio_unit", "core_audio", "io_kit_audio"]
+version = "0.2.14"

--- a/run_device_tests.sh
+++ b/run_device_tests.sh
@@ -31,7 +31,7 @@ cargo test test_destroy_output_stream_after_unplugging_a_default_output_device -
 cargo test test_reinit_output_stream_by_unplugging_a_default_output_device -- --ignored --nocapture
 
 cargo test test_destroy_duplex_stream_after_unplugging_a_nondefault_input_device -- --ignored --nocapture
-cargo test test_suspend_duplex_stream_by_unplugging_a_nondefault_input_device
+cargo test test_suspend_duplex_stream_by_unplugging_a_nondefault_input_device -- --ignored --nocapture
 
 cargo test test_destroy_duplex_stream_after_unplugging_a_nondefault_output_device -- --ignored --nocapture
 cargo test test_suspend_duplex_stream_by_unplugging_a_nondefault_output_device -- --ignored --nocapture

--- a/src/backend/device_property.rs
+++ b/src/backend/device_property.rs
@@ -240,6 +240,23 @@ pub fn get_stream_latency(id: AudioStreamID) -> std::result::Result<u32, OSStatu
     }
 }
 
+pub fn get_stream_terminal_type(id: AudioStreamID) -> std::result::Result<u32, OSStatus> {
+    assert_ne!(id, kAudioObjectUnknown);
+
+    let address = get_property_address(
+        Property::StreamTerminalType,
+        DeviceType::INPUT | DeviceType::OUTPUT,
+    );
+    let mut size = mem::size_of::<u32>();
+    let mut terminal_type: u32 = 0;
+    let err = audio_object_get_property_data(id, &address, &mut size, &mut terminal_type);
+    if err == NO_ERR {
+        Ok(terminal_type)
+    } else {
+        Err(err)
+    }
+}
+
 pub fn get_stream_virtual_format(
     id: AudioStreamID,
 ) -> std::result::Result<AudioStreamBasicDescription, OSStatus> {
@@ -293,6 +310,7 @@ pub enum Property {
     HardwareDevices,
     ModelUID,
     StreamLatency,
+    StreamTerminalType,
     StreamVirtualFormat,
     TransportType,
     ClockDomain,
@@ -317,6 +335,7 @@ impl From<Property> for AudioObjectPropertySelector {
             Property::HardwareDevices => kAudioHardwarePropertyDevices,
             Property::ModelUID => kAudioDevicePropertyModelUID,
             Property::StreamLatency => kAudioStreamPropertyLatency,
+            Property::StreamTerminalType => kAudioStreamPropertyTerminalType,
             Property::StreamVirtualFormat => kAudioStreamPropertyVirtualFormat,
             Property::TransportType => kAudioDevicePropertyTransportType,
             Property::ClockDomain => kAudioDevicePropertyClockDomain,

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2851,7 +2851,9 @@ impl<'ctx> CoreStreamData<'ctx> {
                 self.stm_ptr,
                 input_hw_desc
             );
-            assert!(input_hw_desc.mChannelsPerFrame >= device_channel_count);
+            // In some cases with VPIO the stream format's mChannelsPerFrame is higher than
+            // expected. Use get_channel_count as source of truth.
+            input_hw_desc.mChannelsPerFrame = device_channel_count;
             // Notice: when we are using aggregate device, the input_hw_desc.mChannelsPerFrame is
             // the total of all the input channel count of the devices added in the aggregate device.
             // Due to our aggregate device settings, the data captured by the output device's input
@@ -3028,6 +3030,10 @@ impl<'ctx> CoreStreamData<'ctx> {
                 self.stm_ptr,
                 output_hw_desc
             );
+
+            // In some cases with VPIO the stream format's mChannelsPerFrame is higher than
+            // expected. Use get_channel_count as source of truth.
+            output_hw_desc.mChannelsPerFrame = device_channel_count;
 
             // This has been observed in the wild.
             if output_hw_desc.mChannelsPerFrame == 0 {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2134,6 +2134,16 @@ impl ContextOps for AudioUnitContext {
             return Err(Error::invalid_parameter());
         }
 
+        if input_stream_params.is_none() && output_stream_params.is_none() {
+            cubeb_log!("Cannot init a stream without any stream params");
+            return Err(Error::invalid_parameter());
+        }
+
+        if data_callback.is_none() {
+            cubeb_log!("Cannot init a stream without a data callback");
+            return Err(Error::invalid_parameter());
+        }
+
         // Latency cannot change if another stream is operating in parallel. In this case
         // latency is set to the other stream value.
         let global_latency_frames = self

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1711,19 +1711,6 @@ fn create_cubeb_device_info(
     Ok(dev_info)
 }
 
-fn is_aggregate_device(device_info: &ffi::cubeb_device_info) -> bool {
-    assert!(!device_info.friendly_name.is_null());
-    let private_name =
-        CString::new(PRIVATE_AGGREGATE_DEVICE_NAME).expect("Fail to create a private name");
-    unsafe {
-        libc::strncmp(
-            device_info.friendly_name,
-            private_name.as_ptr(),
-            private_name.as_bytes().len(),
-        ) == 0
-    }
-}
-
 fn destroy_cubeb_device_info(device: &mut ffi::cubeb_device_info) {
     // This should be mapped to the memory allocation in `create_cubeb_device_info`.
     // The `device_id`, `group_id`, `vendor_name` can be null pointer if the queries
@@ -2189,9 +2176,7 @@ impl ContextOps for AudioUnitContext {
             let devices = audiounit_get_devices_of_type(*dev_type);
             for device in devices {
                 if let Ok(info) = create_cubeb_device_info(device, *dev_type) {
-                    if !is_aggregate_device(&info) {
-                        device_infos.push(info);
-                    }
+                    device_infos.push(info);
                 }
             }
         }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2124,9 +2124,13 @@ impl ContextOps for AudioUnitContext {
         state_callback: ffi::cubeb_state_callback,
         user_ptr: *mut c_void,
     ) -> Result<Stream> {
-        if (!input_device.is_null() && input_stream_params.is_none())
-            || (!output_device.is_null() && output_stream_params.is_none())
-        {
+        if !input_device.is_null() && input_stream_params.is_none() {
+            cubeb_log!("Cannot init an input device without input stream params");
+            return Err(Error::invalid_parameter());
+        }
+
+        if !output_device.is_null() && output_stream_params.is_none() {
+            cubeb_log!("Cannot init an output device without output stream params");
             return Err(Error::invalid_parameter());
         }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -971,36 +971,41 @@ fn create_audiounit(device: &device_info) -> Result<AudioUnit> {
 
     if device.flags.contains(device_flags::DEV_INPUT) {
         // Input only.
-        enable_audiounit_scope(unit, DeviceType::INPUT, true).map_err(|e| {
-            cubeb_log!("Fail to enable audiounit input scope. Error: {}", e);
-            Error::error()
-        })?;
-        enable_audiounit_scope(unit, DeviceType::OUTPUT, false).map_err(|e| {
-            cubeb_log!("Fail to disable audiounit output scope. Error: {}", e);
-            Error::error()
-        })?;
+        if let Err(e) = enable_audiounit_scope(unit, DeviceType::INPUT, true) {
+            cubeb_log!("Failed to enable audiounit input scope. Error: {}", e);
+            dispose_audio_unit(unit);
+            return Err(Error::error());
+        }
+        if let Err(e) = enable_audiounit_scope(unit, DeviceType::OUTPUT, false) {
+            cubeb_log!("Failed to disable audiounit output scope. Error: {}", e);
+            dispose_audio_unit(unit);
+            return Err(Error::error());
+        }
     }
 
     if device.flags.contains(device_flags::DEV_OUTPUT) {
         // Output only.
-        enable_audiounit_scope(unit, DeviceType::OUTPUT, true).map_err(|e| {
-            cubeb_log!("Fail to enable audiounit output scope. Error: {}", e);
-            Error::error()
-        })?;
-        enable_audiounit_scope(unit, DeviceType::INPUT, false).map_err(|e| {
-            cubeb_log!("Fail to disable audiounit input scope. Error: {}", e);
-            Error::error()
-        })?;
+        if let Err(e) = enable_audiounit_scope(unit, DeviceType::OUTPUT, true) {
+            cubeb_log!("Failed to enable audiounit output scope. Error: {}", e);
+            dispose_audio_unit(unit);
+            return Err(Error::error());
+        }
+        if let Err(e) = enable_audiounit_scope(unit, DeviceType::INPUT, false) {
+            cubeb_log!("Failed to disable audiounit input scope. Error: {}", e);
+            dispose_audio_unit(unit);
+            return Err(Error::error());
+        }
     }
 
-    set_device_to_audiounit(unit, device.id).map_err(|e| {
+    if let Err(e) = set_device_to_audiounit(unit, device.id) {
         cubeb_log!(
             "Failed to set device {} to the created audiounit. Error: {}",
             device.id,
             e
         );
-        Error::error()
-    })?;
+        dispose_audio_unit(unit);
+        return Err(Error::error());
+    }
 
     Ok(unit)
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -42,7 +42,7 @@ use std::cmp;
 use std::ffi::{CStr, CString};
 use std::fmt;
 use std::mem;
-use std::os::raw::c_void;
+use std::os::raw::{c_uint, c_void};
 use std::ptr;
 use std::slice;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering};
@@ -55,6 +55,7 @@ const AU_IN_BUS: AudioUnitElement = 1;
 
 const DISPATCH_QUEUE_LABEL: &str = "org.mozilla.cubeb";
 const PRIVATE_AGGREGATE_DEVICE_NAME: &str = "CubebAggregateDevice";
+const VOICEPROCESSING_AGGREGATE_DEVICE_NAME: &str = "VPAUAggregateAudioDevice";
 
 // Testing empirically, some headsets report a minimal latency that is very low,
 // but this does not work in practice. Lie and say the minimum is 128 frames.
@@ -464,8 +465,11 @@ extern "C" fn audiounit_input_callback(
     };
 
     // If the input (input-only stream) or the output is drained (duplex stream),
-    // cancel this callback.
-    if stm.draining.load(Ordering::SeqCst) {
+    // cancel this callback. Note that for voice processing cases (a single unit),
+    // the output callback handles stopping the unit and notifying of state.
+    if stm.core_stream_data.input_unit != stm.core_stream_data.output_unit
+        && stm.draining.load(Ordering::SeqCst)
+    {
         let r = stop_audiounit(stm.core_stream_data.input_unit);
         assert!(r.is_ok());
         // Only fire state-changed callback for input-only stream.
@@ -968,6 +972,7 @@ fn create_audiounit(device: &device_info) -> Result<AudioUnit> {
         .contains(device_flags::DEV_INPUT | device_flags::DEV_OUTPUT));
 
     let unit = create_blank_audiounit()?;
+    let mut bus = AU_OUT_BUS;
 
     if device.flags.contains(device_flags::DEV_INPUT) {
         // Input only.
@@ -981,6 +986,7 @@ fn create_audiounit(device: &device_info) -> Result<AudioUnit> {
             dispose_audio_unit(unit);
             return Err(Error::error());
         }
+        bus = AU_IN_BUS;
     }
 
     if device.flags.contains(device_flags::DEV_OUTPUT) {
@@ -995,14 +1001,64 @@ fn create_audiounit(device: &device_info) -> Result<AudioUnit> {
             dispose_audio_unit(unit);
             return Err(Error::error());
         }
+        bus = AU_OUT_BUS;
     }
 
-    if let Err(e) = set_device_to_audiounit(unit, device.id) {
+    if let Err(e) = set_device_to_audiounit(unit, device.id, bus) {
         cubeb_log!(
             "Failed to set device {} to the created audiounit. Error: {}",
             device.id,
             e
         );
+        dispose_audio_unit(unit);
+        return Err(Error::error());
+    }
+
+    Ok(unit)
+}
+
+fn create_voiceprocessing_audiounit(
+    in_device: &device_info,
+    out_device: &device_info,
+) -> Result<AudioUnit> {
+    assert!(in_device.flags.contains(device_flags::DEV_INPUT));
+    assert!(!in_device.flags.contains(device_flags::DEV_OUTPUT));
+    assert!(!out_device.flags.contains(device_flags::DEV_INPUT));
+    assert!(out_device.flags.contains(device_flags::DEV_OUTPUT));
+
+    let unit = create_typed_audiounit(kAudioUnitSubType_VoiceProcessingIO)?;
+
+    if let Err(e) = set_device_to_audiounit(unit, in_device.id, AU_IN_BUS) {
+        cubeb_log!(
+            "Failed to set in device {} to the created audiounit. Error: {}",
+            in_device.id,
+            e
+        );
+        dispose_audio_unit(unit);
+        return Err(Error::error());
+    }
+
+    if let Err(e) = set_device_to_audiounit(unit, out_device.id, AU_OUT_BUS) {
+        cubeb_log!(
+            "Failed to set out device {} to the created audiounit. Error: {}",
+            out_device.id,
+            e
+        );
+        dispose_audio_unit(unit);
+        return Err(Error::error());
+    }
+
+    let bypass = u32::from(true);
+    let r = audio_unit_set_property(
+        unit,
+        kAudioUnitProperty_BypassEffect,
+        kAudioUnitScope_Global,
+        AU_IN_BUS,
+        &bypass,
+        mem::size_of::<u32>(),
+    );
+    if r != NO_ERR {
+        cubeb_log!("Failed to enable bypass of voiceprocessing. Error: {}", r);
         dispose_audio_unit(unit);
         return Err(Error::error());
     }
@@ -1044,6 +1100,7 @@ fn enable_audiounit_scope(
 fn set_device_to_audiounit(
     unit: AudioUnit,
     device_id: AudioObjectID,
+    bus: AudioUnitElement,
 ) -> std::result::Result<(), OSStatus> {
     assert!(!unit.is_null());
 
@@ -1051,7 +1108,7 @@ fn set_device_to_audiounit(
         unit,
         kAudioOutputUnitProperty_CurrentDevice,
         kAudioUnitScope_Global,
-        0,
+        bus,
         &device_id,
         mem::size_of::<AudioDeviceID>(),
     );
@@ -1062,13 +1119,10 @@ fn set_device_to_audiounit(
     }
 }
 
-fn create_blank_audiounit() -> Result<AudioUnit> {
+fn create_typed_audiounit(sub_type: c_uint) -> Result<AudioUnit> {
     let desc = AudioComponentDescription {
         componentType: kAudioUnitType_Output,
-        #[cfg(not(target_os = "ios"))]
-        componentSubType: kAudioUnitSubType_HALOutput,
-        #[cfg(target_os = "ios")]
-        componentSubType: kAudioUnitSubType_RemoteIO,
+        componentSubType: sub_type,
         componentManufacturer: kAudioUnitManufacturer_Apple,
         componentFlags: 0,
         componentFlagsMask: 0,
@@ -1088,6 +1142,13 @@ fn create_blank_audiounit() -> Result<AudioUnit> {
         cubeb_log!("Fail to get a new AudioUnit. Error: {}", status);
         Err(Error::error())
     }
+}
+
+fn create_blank_audiounit() -> Result<AudioUnit> {
+    #[cfg(not(target_os = "ios"))]
+    return create_typed_audiounit(kAudioUnitSubType_HALOutput);
+    #[cfg(target_os = "ios")]
+    return create_typed_audiounit(kAudioUnitSubType_RemoteIO);
 }
 
 fn get_buffer_size(unit: AudioUnit, devtype: DeviceType) -> std::result::Result<u32, OSStatus> {
@@ -1681,6 +1742,7 @@ fn audiounit_get_devices_of_type(devtype: DeviceType) -> Vec<AudioObjectID> {
         } else if let Ok(uid) = get_device_global_uid(device) {
             let uid = uid.into_string();
             !uid.contains(PRIVATE_AGGREGATE_DEVICE_NAME)
+                && !uid.contains(VOICEPROCESSING_AGGREGATE_DEVICE_NAME)
         } else {
             // Fail to get device uid.
             true
@@ -2440,6 +2502,10 @@ impl<'ctx> CoreStreamData<'ctx> {
         if !self.input_unit.is_null() {
             start_audiounit(self.input_unit)?;
         }
+        if self.using_voice_processing_unit() {
+            // Handle the VoiceProcessIO case where there is a single unit.
+            return Ok(());
+        }
         if !self.output_unit.is_null() {
             start_audiounit(self.output_unit)?;
         }
@@ -2451,6 +2517,10 @@ impl<'ctx> CoreStreamData<'ctx> {
         if !self.input_unit.is_null() {
             let r = stop_audiounit(self.input_unit);
             assert!(r.is_ok());
+        }
+        if self.using_voice_processing_unit() {
+            // Handle the VoiceProcessIO case where there is a single unit.
+            return;
         }
         if !self.output_unit.is_null() {
             let r = stop_audiounit(self.output_unit);
@@ -2466,43 +2536,8 @@ impl<'ctx> CoreStreamData<'ctx> {
         self.output_stream_params.rate() > 0
     }
 
-    fn should_use_aggregate_device(&self) -> bool {
-        self.debug_assert_is_on_stream_queue();
-        // It's impossible to create an aggregate device from an aggregate device, and it's
-        // unnecessary to create an aggregate device when opening the same device input/output. In
-        // all other cases, use an aggregate device.
-        let mut either_already_aggregate = false;
-        if self.has_input() {
-            let input_is_aggregate =
-                get_device_transport_type(self.input_device.id, DeviceType::INPUT).unwrap_or(0)
-                    == kAudioDeviceTransportTypeAggregate;
-            if input_is_aggregate {
-                either_already_aggregate = true;
-            }
-            cubeb_log!(
-                "Input device ID: {} (aggregate: {:?})",
-                self.input_device.id,
-                input_is_aggregate
-            );
-        }
-        if self.has_output() {
-            let output_is_aggregate =
-                get_device_transport_type(self.output_device.id, DeviceType::OUTPUT).unwrap_or(0)
-                    == kAudioDeviceTransportTypeAggregate;
-            if output_is_aggregate {
-                either_already_aggregate = true;
-            }
-            cubeb_log!(
-                "Output device ID: {} (aggregate: {:?})",
-                self.input_device.id,
-                output_is_aggregate
-            );
-        }
-        // Only use an aggregate device when the device are different.
-        self.has_input()
-            && self.has_output()
-            && self.input_device.id != self.output_device.id
-            && !either_already_aggregate
+    fn using_voice_processing_unit(&self) -> bool {
+        !self.input_unit.is_null() && self.input_unit == self.output_unit
     }
 
     fn same_clock_domain(&self) -> bool {
@@ -2530,6 +2565,165 @@ impl<'ctx> CoreStreamData<'ctx> {
         input_domain == output_domain
     }
 
+    fn create_audiounits(&mut self) -> Result<(device_info, device_info)> {
+        self.debug_assert_is_on_stream_queue();
+        let should_use_voice_processing_unit = self.has_input() && self.has_output();
+
+        let should_use_aggregate_device = {
+            // It's impossible to create an aggregate device from an aggregate device, and it's
+            // unnecessary to create an aggregate device when opening the same device input/output. In
+            // all other cases, use an aggregate device.
+            let mut either_already_aggregate = false;
+            if self.has_input() {
+                let input_is_aggregate =
+                    get_device_transport_type(self.input_device.id, DeviceType::INPUT).unwrap_or(0)
+                        == kAudioDeviceTransportTypeAggregate;
+                if input_is_aggregate {
+                    either_already_aggregate = true;
+                }
+                cubeb_log!(
+                    "Input device ID: {} (aggregate: {:?})",
+                    self.input_device.id,
+                    input_is_aggregate
+                );
+            }
+            if self.has_output() {
+                let output_is_aggregate =
+                    get_device_transport_type(self.output_device.id, DeviceType::OUTPUT)
+                        .unwrap_or(0)
+                        == kAudioDeviceTransportTypeAggregate;
+                if output_is_aggregate {
+                    either_already_aggregate = true;
+                }
+                cubeb_log!(
+                    "Output device ID: {} (aggregate: {:?})",
+                    self.input_device.id,
+                    output_is_aggregate
+                );
+            }
+            // Only use an aggregate device when the device are different.
+            self.has_input()
+                && self.has_output()
+                && self.input_device.id != self.output_device.id
+                && !either_already_aggregate
+        };
+
+        // Create an AudioUnit:
+        // - If we're eligible to use voice processing, try creating a VoiceProcessingIO AudioUnit.
+        // - If we should use an aggregate device, try creating one and input and output AudioUnits next.
+        // - As last resort, create regular AudioUnits. This is also the normal non-duplex path.
+
+        if should_use_voice_processing_unit {
+            if let Ok(au) =
+                create_voiceprocessing_audiounit(&self.input_device, &self.output_device)
+            {
+                cubeb_log!("({:p}) Using VoiceProcessingIO AudioUnit", self.stm_ptr);
+                self.input_unit = au;
+                self.output_unit = au;
+                return Ok((self.input_device.clone(), self.output_device.clone()));
+            }
+            cubeb_log!(
+                "({:p}) Failed to create VoiceProcessingIO AudioUnit. Trying a regular one.",
+                self.stm_ptr
+            );
+        }
+
+        if should_use_aggregate_device {
+            if let Ok(device) = AggregateDevice::new(self.input_device.id, self.output_device.id) {
+                let in_dev_info = {
+                    device_info {
+                        id: device.get_device_id(),
+                        ..self.input_device
+                    }
+                };
+                let out_dev_info = {
+                    device_info {
+                        id: device.get_device_id(),
+                        ..self.output_device
+                    }
+                };
+
+                match (
+                    create_audiounit(&in_dev_info),
+                    create_audiounit(&out_dev_info),
+                ) {
+                    (Ok(in_au), Ok(out_au)) => {
+                        cubeb_log!(
+                            "({:p}) Using an aggregate device {} for input and output.",
+                            self.stm_ptr,
+                            device.get_device_id()
+                        );
+                        self.aggregate_device = Some(device);
+                        self.input_unit = in_au;
+                        self.output_unit = out_au;
+                        return Ok((in_dev_info, out_dev_info));
+                    }
+                    (Err(e), Ok(au)) => {
+                        cubeb_log!(
+                            "({:p}) Failed to create input AudioUnit for aggregate device. Error: {}.",
+                            self.stm_ptr,
+                            e
+                        );
+                        dispose_audio_unit(au);
+                    }
+                    (Ok(au), Err(e)) => {
+                        cubeb_log!(
+                            "({:p}) Failed to create output AudioUnit for aggregate device. Error: {}.",
+                            self.stm_ptr,
+                            e
+                        );
+                        dispose_audio_unit(au);
+                    }
+                    (Err(e), _) => {
+                        cubeb_log!(
+                            "({:p}) Failed to create AudioUnits for aggregate device. Error: {}.",
+                            self.stm_ptr,
+                            e
+                        );
+                    }
+                }
+            }
+            cubeb_log!(
+                "({:p}) Failed to set up aggregate device. Using regular AudioUnits.",
+                self.stm_ptr
+            );
+        }
+
+        if self.has_input() {
+            match create_audiounit(&self.input_device) {
+                Ok(in_au) => self.input_unit = in_au,
+                Err(e) => {
+                    cubeb_log!(
+                        "({:p}) Failed to create regular AudioUnit for input. Error: {}",
+                        self.stm_ptr,
+                        e
+                    );
+                    return Err(e);
+                }
+            }
+        }
+
+        if self.has_output() {
+            match create_audiounit(&self.output_device) {
+                Ok(out_au) => self.output_unit = out_au,
+                Err(e) => {
+                    cubeb_log!(
+                        "({:p}) Failed to create regular AudioUnit for output. Error: {}",
+                        self.stm_ptr,
+                        e
+                    );
+                    if !self.input_unit.is_null() {
+                        dispose_audio_unit(self.input_unit);
+                        self.input_unit = ptr::null_mut();
+                    }
+                    return Err(e);
+                }
+            }
+        }
+
+        Ok((self.input_device.clone(), self.output_device.clone()))
+    }
+
     #[allow(clippy::cognitive_complexity)] // TODO: Refactoring.
     fn setup(&mut self) -> Result<()> {
         self.debug_assert_is_on_stream_queue();
@@ -2546,42 +2740,17 @@ impl<'ctx> CoreStreamData<'ctx> {
             return Err(Error::not_supported());
         }
 
-        let mut in_dev_info = self.input_device.clone();
-        let mut out_dev_info = self.output_device.clone();
         let same_clock_domain = self.same_clock_domain();
-
-        if self.should_use_aggregate_device() {
-            match AggregateDevice::new(in_dev_info.id, out_dev_info.id) {
-                Ok(device) => {
-                    in_dev_info.id = device.get_device_id();
-                    out_dev_info.id = device.get_device_id();
-                    in_dev_info.flags = device_flags::DEV_INPUT;
-                    out_dev_info.flags = device_flags::DEV_OUTPUT;
-                    self.aggregate_device = Some(device);
-                    cubeb_log!(
-                        "({:p}) Using an aggregate device {} for input and output.",
-                        self.stm_ptr,
-                        self.aggregate_device.as_ref().unwrap().get_device_id()
-                    );
-                }
-                Err(e) => {
-                    cubeb_log!(
-                        "({:p}) Creation of aggregate devices failed. Error: {}.\
-                         Using assigned devices directly instead.",
-                        self.stm_ptr,
-                        e
-                    );
-                }
-            }
-        } else {
-            cubeb_log!("Not using an aggregate device");
-        }
+        let (in_dev_info, out_dev_info) = self.create_audiounits()?;
+        let using_voice_processing_unit = self.using_voice_processing_unit();
 
         assert!(!self.stm_ptr.is_null());
         let stream = unsafe { &(*self.stm_ptr) };
 
         // Configure I/O stream
         if self.has_input() {
+            assert!(!self.input_unit.is_null());
+
             cubeb_log!(
                 "({:p}) Initializing input by device info: {:?}",
                 self.stm_ptr,
@@ -2600,20 +2769,16 @@ impl<'ctx> CoreStreamData<'ctx> {
                 return Err(Error::invalid_parameter());
             }
 
-            self.input_unit = create_audiounit(&in_dev_info).map_err(|e| {
-                cubeb_log!("({:p}) AudioUnit creation for input failed.", self.stm_ptr);
-                e
-            })?;
-
             cubeb_log!(
-                "({:p}) Opening input side: rate {}, channels {}, format {:?}, layout {:?}, prefs {:?}, latency in frames {}.",
+                "({:p}) Opening input side: rate {}, channels {}, format {:?}, layout {:?}, prefs {:?}, latency in frames {}, voice processing {}.",
                 self.stm_ptr,
                 self.input_stream_params.rate(),
                 self.input_stream_params.channels(),
                 self.input_stream_params.format(),
                 self.input_stream_params.layout(),
                 self.input_stream_params.prefs(),
-                stream.latency_frames
+                stream.latency_frames,
+                using_voice_processing_unit
             );
 
             // Get input device hardware information.
@@ -2649,7 +2814,13 @@ impl<'ctx> CoreStreamData<'ctx> {
             // channels to the audio callback.
             let params = unsafe {
                 let mut p = *self.input_stream_params.as_ptr();
-                p.channels = input_hw_desc.mChannelsPerFrame;
+                p.channels = if using_voice_processing_unit {
+                    // With VPIO, stereo input devices configured for stereo have been observed to
+                    // spit out only a single mono channel.
+                    1
+                } else {
+                    input_hw_desc.mChannelsPerFrame
+                };
                 // Input AudioUnit must be configured with device's sample rate.
                 // we will resample inside input callback.
                 p.rate = input_hw_desc.mSampleRate as _;
@@ -2718,7 +2889,9 @@ impl<'ctx> CoreStreamData<'ctx> {
                 self.input_stream_params.format(),
                 SAFE_MAX_LATENCY_FRAMES as usize,
                 self.input_dev_desc.mChannelsPerFrame as usize,
-                (self.input_dev_desc.mChannelsPerFrame - device_channel_count) as usize,
+                self.input_dev_desc
+                    .mChannelsPerFrame
+                    .saturating_sub(device_channel_count) as usize,
                 self.input_stream_params.channels() as usize,
             ));
 
@@ -2753,6 +2926,8 @@ impl<'ctx> CoreStreamData<'ctx> {
         }
 
         if self.has_output() {
+            assert!(!self.output_unit.is_null());
+
             cubeb_log!(
                 "({:p}) Initialize output by device info: {:?}",
                 self.stm_ptr,
@@ -2771,20 +2946,16 @@ impl<'ctx> CoreStreamData<'ctx> {
                 return Err(Error::invalid_parameter());
             }
 
-            self.output_unit = create_audiounit(&out_dev_info).map_err(|e| {
-                cubeb_log!("({:p}) AudioUnit creation for output failed.", self.stm_ptr);
-                e
-            })?;
-
             cubeb_log!(
-                "({:p}) Opening output side: rate {}, channels {}, format {:?}, layout {:?}, prefs {:?}, latency in frames {}.",
+                "({:p}) Opening output side: rate {}, channels {}, format {:?}, layout {:?}, prefs {:?}, latency in frames {}, voice processing {}.",
                 self.stm_ptr,
                 self.output_stream_params.rate(),
                 self.output_stream_params.channels(),
                 self.output_stream_params.format(),
                 self.output_stream_params.layout(),
                 self.output_stream_params.prefs(),
-                stream.latency_frames
+                stream.latency_frames,
+                using_voice_processing_unit
             );
 
             // Get output device hardware information.
@@ -2827,6 +2998,11 @@ impl<'ctx> CoreStreamData<'ctx> {
             let params = unsafe {
                 let mut p = *self.output_stream_params.as_ptr();
                 p.channels = output_hw_desc.mChannelsPerFrame;
+                if using_voice_processing_unit {
+                    // VPIO will always use the sample rate of the input hw for both input and output,
+                    // as reported to us. (We can override it but we cannot improve quality this way).
+                    p.rate = output_hw_desc.mSampleRate as _;
+                }
                 StreamParams::from(p)
             };
 
@@ -2838,7 +3014,20 @@ impl<'ctx> CoreStreamData<'ctx> {
                 e
             })?;
 
-            let device_layout = audiounit_get_current_channel_layout(self.output_unit);
+            // XXX
+            let device_layout = if using_voice_processing_unit {
+                let mut channels = Vec::with_capacity(output_hw_desc.mChannelsPerFrame as usize);
+                match output_hw_desc.mChannelsPerFrame {
+                    1 => channels.push(mixer::Channel::FrontCenter),
+                    _ => {
+                        channels.push(mixer::Channel::FrontLeft);
+                        channels.push(mixer::Channel::FrontRight);
+                    }
+                }
+                channels
+            } else {
+                audiounit_get_current_channel_layout(self.output_unit)
+            };
 
             // The mixer will be set up when
             // 1. using aggregate device whose input device has output channels
@@ -2951,14 +3140,19 @@ impl<'ctx> CoreStreamData<'ctx> {
             None
         };
         let resampler_output_params = if self.has_output() {
-            Some(unsafe { *(self.output_stream_params.as_ptr()) })
+            let mut p = unsafe { *(self.output_stream_params.as_ptr()) };
+            p.rate = self.output_dev_desc.mSampleRate as u32;
+            Some(p)
         } else {
             None
         };
 
         // Only reclock if there is an input and we couldn't use an aggregate device, and the
         // devices are not part of the same clock domain.
-        let reclock_policy = if self.aggregate_device.is_none() && !same_clock_domain {
+        let reclock_policy = if self.aggregate_device.is_none()
+            && !using_voice_processing_unit
+            && !same_clock_domain
+        {
             cubeb_log!(
                 "Reclocking duplex steam using_aggregate_device={} same_clock_domain={}",
                 self.aggregate_device.is_some(),
@@ -3001,10 +3195,12 @@ impl<'ctx> CoreStreamData<'ctx> {
         }
 
         if !self.output_unit.is_null() {
-            let r = audio_unit_initialize(self.output_unit);
-            if r != NO_ERR {
-                cubeb_log!("AudioUnitInitialize/output rv={}", r);
-                return Err(Error::error());
+            if self.input_unit != self.output_unit {
+                let r = audio_unit_initialize(self.output_unit);
+                if r != NO_ERR {
+                    cubeb_log!("AudioUnitInitialize/output rv={}", r);
+                    return Err(Error::error());
+                }
             }
 
             stream.output_device_latency_frames.store(
@@ -3072,6 +3268,10 @@ impl<'ctx> CoreStreamData<'ctx> {
         self.debug_assert_is_on_stream_queue();
         if !self.input_unit.is_null() {
             audio_unit_uninitialize(self.input_unit);
+            if self.using_voice_processing_unit() {
+                // Handle the VoiceProcessIO case where there is a single unit.
+                self.output_unit = ptr::null_mut();
+            }
 
             // Cannot unset self.input_unit yet, since the output callback might be live
             // and reading it.

--- a/src/backend/tests/aggregate_device.rs
+++ b/src/backend/tests/aggregate_device.rs
@@ -42,7 +42,7 @@ fn test_aggregate_set_sub_devices_for_unknown_devices() {
 // application and print out the sub devices of them!
 #[test]
 fn test_aggregate_get_sub_devices() {
-    let devices = test_get_all_devices(DeviceFilter::ExcludeCubebAggregate);
+    let devices = test_get_all_devices(DeviceFilter::ExcludeCubebAggregateAndVPIO);
     for device in devices {
         // `AggregateDevice::get_sub_devices(device)` will return a single-element vector
         // containing `device` itself if it's not an aggregate device. This test assumes devices
@@ -108,7 +108,7 @@ fn test_aggregate_create_blank_device() {
     // TODO: Test this when there is no available devices.
     let plugin = AggregateDevice::get_system_plugin_id().unwrap();
     let device = AggregateDevice::create_blank_device_sync(plugin).unwrap();
-    let devices = test_get_all_devices(DeviceFilter::IncludeCubebAggregate);
+    let devices = test_get_all_devices(DeviceFilter::IncludeAll);
     let device = devices.into_iter().find(|dev| dev == &device).unwrap();
     let uid = get_device_global_uid(device).unwrap().into_string();
     assert!(uid.contains(PRIVATE_AGGREGATE_DEVICE_NAME));

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1434,23 +1434,6 @@ fn test_create_device_from_hwdev_with_inout_type() {
     }
 }
 
-// is_aggregate_device
-// ------------------------------------
-#[test]
-fn test_is_aggregate_device() {
-    let mut aggregate_name = String::from(PRIVATE_AGGREGATE_DEVICE_NAME);
-    aggregate_name.push_str("_something");
-    let aggregate_name_cstring = CString::new(aggregate_name).unwrap();
-
-    let mut info = ffi::cubeb_device_info::default();
-    info.friendly_name = aggregate_name_cstring.as_ptr();
-    assert!(is_aggregate_device(&info));
-
-    let non_aggregate_name_cstring = CString::new("Hello World!").unwrap();
-    info.friendly_name = non_aggregate_name_cstring.as_ptr();
-    assert!(!is_aggregate_device(&info));
-}
-
 // get_devices_of_type
 // ------------------------------------
 #[test]

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1457,7 +1457,7 @@ fn test_get_devices_of_type() {
     let input_devices = audiounit_get_devices_of_type(DeviceType::INPUT);
     let output_devices = audiounit_get_devices_of_type(DeviceType::OUTPUT);
 
-    let mut expected_all = test_get_all_devices(DeviceFilter::ExcludeCubebAggregate);
+    let mut expected_all = test_get_all_devices(DeviceFilter::ExcludeCubebAggregateAndVPIO);
     expected_all.sort();
     assert_eq!(all_devices, expected_all);
     for device in all_devices.iter() {

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -713,7 +713,7 @@ fn test_convert_channel_layout() {
         }
         let layout_ref = unsafe { &(*(&layout as *const TestLayout as *const AudioChannelLayout)) };
         assert_eq!(
-            &audiounit_convert_channel_layout(layout_ref),
+            &audiounit_convert_channel_layout(layout_ref).unwrap(),
             expected_layout
         );
     }
@@ -724,7 +724,9 @@ fn test_convert_channel_layout() {
 #[test]
 fn test_get_preferred_channel_layout_output() {
     match test_get_default_audiounit(Scope::Output) {
-        Some(unit) => assert!(!audiounit_get_preferred_channel_layout(unit.get_inner()).is_empty()),
+        Some(unit) => assert!(!audiounit_get_preferred_channel_layout(unit.get_inner())
+            .unwrap()
+            .is_empty()),
         None => println!("No output audiounit for test."),
     }
 }
@@ -734,7 +736,9 @@ fn test_get_preferred_channel_layout_output() {
 #[test]
 fn test_get_current_channel_layout_output() {
     match test_get_default_audiounit(Scope::Output) {
-        Some(unit) => assert!(!audiounit_get_current_channel_layout(unit.get_inner()).is_empty()),
+        Some(unit) => assert!(!audiounit_get_current_channel_layout(unit.get_inner())
+            .unwrap()
+            .is_empty()),
         None => println!("No output audiounit for test."),
     }
 }

--- a/src/backend/tests/device_property.rs
+++ b/src/backend/tests/device_property.rs
@@ -417,3 +417,57 @@ fn test_get_stream_virtual_format() {
 fn test_get_stream_virtual_format_by_unknown_stream() {
     assert!(get_stream_virtual_format(kAudioObjectUnknown).is_err());
 }
+
+// get_stream_terminal_type
+// ------------------------------------
+
+#[test]
+fn test_get_stream_terminal_type() {
+    fn terminal_type_to_device_type(terminal_type: u32) -> Option<DeviceType> {
+        #[allow(non_upper_case_globals)]
+        match terminal_type {
+            kAudioStreamTerminalTypeMicrophone
+            | kAudioStreamTerminalTypeHeadsetMicrophone
+            | kAudioStreamTerminalTypeReceiverMicrophone => Some(DeviceType::INPUT),
+            kAudioStreamTerminalTypeSpeaker
+            | kAudioStreamTerminalTypeHeadphones
+            | kAudioStreamTerminalTypeLFESpeaker
+            | kAudioStreamTerminalTypeReceiverSpeaker => Some(DeviceType::OUTPUT),
+            t if t > INPUT_UNDEFINED && t < OUTPUT_UNDEFINED => Some(DeviceType::INPUT),
+            t if t > OUTPUT_UNDEFINED && t < BIDIRECTIONAL_UNDEFINED => Some(DeviceType::OUTPUT),
+            t => {
+                println!("UNKNOWN TerminalType {:#06x}", t);
+                None
+            }
+        }
+    }
+    if let Some(device) = test_get_default_device(Scope::Input) {
+        let streams = get_device_streams(device, DeviceType::INPUT).unwrap();
+        for stream in streams {
+            assert_eq!(
+                terminal_type_to_device_type(get_stream_terminal_type(stream).unwrap()),
+                Some(DeviceType::INPUT)
+            );
+        }
+    } else {
+        println!("No input device.");
+    }
+
+    if let Some(device) = test_get_default_device(Scope::Output) {
+        let streams = get_device_streams(device, DeviceType::OUTPUT).unwrap();
+        for stream in streams {
+            assert_eq!(
+                terminal_type_to_device_type(get_stream_terminal_type(stream).unwrap()),
+                Some(DeviceType::OUTPUT)
+            );
+        }
+    } else {
+        println!("No output device.");
+    }
+}
+
+#[test]
+#[should_panic]
+fn test_get_stream_terminal_type_by_unknown_stream() {
+    assert!(get_stream_terminal_type(kAudioObjectUnknown).is_err());
+}

--- a/src/backend/tests/parallel.rs
+++ b/src/backend/tests/parallel.rs
@@ -1,6 +1,6 @@
 use super::utils::{
-    test_audiounit_get_buffer_frame_size, test_get_default_audiounit, test_get_default_device,
-    test_ops_context_operation, PropertyScope, Scope,
+    noop_data_callback, test_audiounit_get_buffer_frame_size, test_get_default_audiounit,
+    test_get_default_device, test_ops_context_operation, PropertyScope, Scope,
 };
 use super::*;
 use std::thread;
@@ -232,7 +232,7 @@ fn create_streams_by_ops_in_parallel_with_different_latency<F>(
                                         ptr::null_mut()
                                     },
                                     latency_frames,
-                                    None,            // No data callback.
+                                    Some(noop_data_callback),
                                     None,            // No state callback.
                                     ptr::null_mut(), // No user data pointer.
                                 )
@@ -468,7 +468,7 @@ fn create_streams_in_parallel_with_different_latency<F>(
                                 None
                             },
                             latency_frames,
-                            None,            // No data callback.
+                            Some(noop_data_callback),
                             None,            // No state callback.
                             ptr::null_mut(), // No user data pointer.
                         )

--- a/src/backend/tests/utils.rs
+++ b/src/backend/tests/utils.rs
@@ -257,8 +257,8 @@ fn u32_to_string(data: u32) -> String {
 }
 
 pub enum DeviceFilter {
-    ExcludeCubebAggregate,
-    IncludeCubebAggregate,
+    ExcludeCubebAggregateAndVPIO,
+    IncludeAll,
 }
 pub fn test_get_all_devices(filter: DeviceFilter) -> Vec<AudioObjectID> {
     let mut devices = Vec::new();
@@ -303,11 +303,12 @@ pub fn test_get_all_devices(filter: DeviceFilter) -> Vec<AudioObjectID> {
     }
 
     match filter {
-        DeviceFilter::ExcludeCubebAggregate => {
+        DeviceFilter::ExcludeCubebAggregateAndVPIO => {
             devices.retain(|&device| {
                 if let Ok(uid) = get_device_global_uid(device) {
                     let uid = uid.into_string();
                     !uid.contains(PRIVATE_AGGREGATE_DEVICE_NAME)
+                        && !uid.contains(VOICEPROCESSING_AGGREGATE_DEVICE_NAME)
                 } else {
                     true
                 }
@@ -320,7 +321,7 @@ pub fn test_get_all_devices(filter: DeviceFilter) -> Vec<AudioObjectID> {
 }
 
 pub fn test_get_devices_in_scope(scope: Scope) -> Vec<AudioObjectID> {
-    let mut devices = test_get_all_devices(DeviceFilter::ExcludeCubebAggregate);
+    let mut devices = test_get_all_devices(DeviceFilter::ExcludeCubebAggregateAndVPIO);
     devices.retain(|device| test_device_in_scope(*device, scope.clone()));
     devices
 }


### PR DESCRIPTION
The drift corrected aggregate device is resulting in distortions due to drift, and we do not really understand why.
The VoiceProcessingIO AudioUnit handles drift properly.

This is the workaround fix for https://bugzilla.mozilla.org/show_bug.cgi?id=1670633.

Note that the VoiceProcessingIO AudioUnit enables system wide ducking on other output streams while running.
We set it to bypass mode for now since there is not yet an API to toggle processing features dynamically, as would be needed by Firefox through MediaStreamTrack.applyConstraints.