### PR TITLE
Monitor explicitly chosen output devices for liveness

### DIFF
--- a/run_device_tests.sh
+++ b/run_device_tests.sh
@@ -24,10 +24,8 @@ cargo test test_suspend_input_stream_by_unplugging_a_nondefault_input_device -- 
 cargo test test_destroy_input_stream_after_unplugging_a_default_input_device -- --ignored --nocapture
 cargo test test_reinit_input_stream_by_unplugging_a_default_input_device -- --ignored --nocapture
 
-# FIXME: We don't monitor the alive-status for output device currently
-# cargo test test_destroy_output_stream_after_unplugging_a_nondefault_output_device -- --ignored --nocapture
-# FIXME: We don't monitor the alive-status for output device currently
-# cargo test test_suspend_output_stream_by_unplugging_a_nondefault_output_device -- --ignored --nocapture
+cargo test test_destroy_output_stream_after_unplugging_a_nondefault_output_device -- --ignored --nocapture
+cargo test test_suspend_output_stream_by_unplugging_a_nondefault_output_device -- --ignored --nocapture
 
 cargo test test_destroy_output_stream_after_unplugging_a_default_output_device -- --ignored --nocapture
 cargo test test_reinit_output_stream_by_unplugging_a_default_output_device -- --ignored --nocapture
@@ -35,10 +33,8 @@ cargo test test_reinit_output_stream_by_unplugging_a_default_output_device -- --
 cargo test test_destroy_duplex_stream_after_unplugging_a_nondefault_input_device -- --ignored --nocapture
 cargo test test_suspend_duplex_stream_by_unplugging_a_nondefault_input_device
 
-# FIXME: We don't monitor the alive-status for output device currently
-# cargo test test_destroy_duplex_stream_after_unplugging_a_nondefault_output_device -- --ignored --nocapture
-# FIXME: We don't monitor the alive-status for output device currently
-# cargo test test_suspend_duplex_stream_by_unplugging_a_nondefault_output_device -- --ignored --nocapture
+cargo test test_destroy_duplex_stream_after_unplugging_a_nondefault_output_device -- --ignored --nocapture
+cargo test test_suspend_duplex_stream_by_unplugging_a_nondefault_output_device -- --ignored --nocapture
 
 cargo test test_destroy_duplex_stream_after_unplugging_a_default_input_device -- --ignored --nocapture
 cargo test test_reinit_duplex_stream_by_unplugging_a_default_input_device -- --ignored --nocapture

--- a/src/backend/resampler.rs
+++ b/src/backend/resampler.rs
@@ -19,15 +19,13 @@ impl Resampler {
         reclock: ffi::cubeb_resampler_reclock,
     ) -> Self {
         let raw_resampler = unsafe {
-            let in_params = if input_params.is_some() {
-                input_params.as_mut().unwrap() as *mut ffi::cubeb_stream_params
-            } else {
-                ptr::null_mut()
+            let in_params = match &mut input_params {
+                Some(p) => p,
+                None => ptr::null_mut(),
             };
-            let out_params = if output_params.is_some() {
-                output_params.as_mut().unwrap() as *mut ffi::cubeb_stream_params
-            } else {
-                ptr::null_mut()
+            let out_params = match &mut output_params {
+                Some(p) => p,
+                None => ptr::null_mut(),
             };
             ffi::cubeb_resampler_create(
                 stream,

--- a/src/backend/tests/device_change.rs
+++ b/src/backend/tests/device_change.rs
@@ -471,14 +471,12 @@ fn test_reinit_input_stream_by_unplugging_a_default_input_device() {
 
 // Unplug the non-default output device for an output stream
 // ------------------------------------------------------------------------------------------------
-// FIXME: We don't monitor the alive-status for output device currently
 #[ignore]
 #[test]
 fn test_destroy_output_stream_after_unplugging_a_nondefault_output_device() {
     test_unplug_a_device_on_an_active_stream(StreamType::OUTPUT, Scope::Output, false, 0);
 }
 
-// FIXME: We don't monitor the alive-status for output device currently
 #[ignore]
 #[test]
 fn test_suspend_output_stream_by_unplugging_a_nondefault_output_device() {
@@ -528,14 +526,12 @@ fn test_suspend_duplex_stream_by_unplugging_a_nondefault_input_device() {
 // Unplug the non-default output device for a duplex stream
 // ------------------------------------------------------------------------------------------------
 
-// FIXME: We don't monitor the alive-status for output device currently
 #[ignore]
 #[test]
 fn test_destroy_duplex_stream_after_unplugging_a_nondefault_output_device() {
     test_unplug_a_device_on_an_active_stream(StreamType::DUPLEX, Scope::Output, false, 0);
 }
 
-// FIXME: We don't monitor the alive-status for output device currently
 #[ignore]
 #[test]
 fn test_suspend_duplex_stream_by_unplugging_a_nondefault_output_device() {

--- a/src/backend/tests/utils.rs
+++ b/src/backend/tests/utils.rs
@@ -884,8 +884,9 @@ impl TestDevicePlugger {
             );
             CFRelease(device_uid as *const c_void);
 
-            // This device is private to the process creating it.
-            let private_value: i32 = 1;
+            // Make this device NOT private to the process creating it.
+            // On MacOS 14 devicechange events are not triggered when it is private.
+            let private_value: i32 = 0;
             let device_private_key = CFNumberCreate(
                 kCFAllocatorDefault,
                 i64::from(kCFNumberIntType),


### PR DESCRIPTION
This mirrors what is done for input devices, and enables the output tests. This fixes cubeb's behavior with Firefox when unplugging a device that is being played to with setSinkId and that does not affect the default device (we used to always install the default-output listener and therefore changes to the default device would trigger a reinit, which would result in an error if the device no longer exists).