### PR TITLE
Enable thread sanitizer

### DIFF
--- a/run_sanitizers.sh
+++ b/run_sanitizers.sh
@@ -15,8 +15,7 @@ fi
 # - `memory`: It doesn't works with target x86_64-apple-darwin
 # - `leak`: Get some errors that are out of our control. See:
 #   https://github.com/mozilla/cubeb-coreaudio-rs/issues/45#issuecomment-591642931
-# - `thread`: It's blocked by #129
-sanitizers=("address")
+sanitizers=("address" "thread")
 for san in "${sanitizers[@]}"
 do
     San="$(tr '[:lower:]' '[:upper:]' <<< ${san:0:1})${san:1}"

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3023,14 +3023,20 @@ impl<'ctx> CoreStreamData<'ctx> {
     fn close(&mut self) {
         if !self.input_unit.is_null() {
             audio_unit_uninitialize(self.input_unit);
-            dispose_audio_unit(self.input_unit);
-            self.input_unit = ptr::null_mut();
+
+            // Cannot unset self.input_unit yet, since the output callback might be live
+            // and reading it.
         }
 
         if !self.output_unit.is_null() {
             audio_unit_uninitialize(self.output_unit);
             dispose_audio_unit(self.output_unit);
             self.output_unit = ptr::null_mut();
+        }
+
+        if !self.input_unit.is_null() {
+            dispose_audio_unit(self.input_unit);
+            self.input_unit = ptr::null_mut();
         }
 
         self.resampler.destroy();


### PR DESCRIPTION
Fixes a race between the output callback and close(), and enables TSAN.