### PR TITLE
Assert that stream operations are done on the queue

### DIFF
--- a/coreaudio-sys-utils/src/dispatch.rs
+++ b/coreaudio-sys-utils/src/dispatch.rs
@@ -22,6 +22,16 @@ impl Queue {
         queue
     }
 
+    #[cfg(debug_assertions)]
+    pub fn debug_assert_is_current(&self) {
+        unsafe {
+            dispatch_assert_queue(self.0);
+        }
+    }
+
+    #[cfg(not(debug_assertions))]
+    pub fn debug_assert_is_current(&self) {}
+
     pub fn run_async<F>(&self, work: F)
     where
         F: Send + FnOnce(),

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -227,10 +227,11 @@ fn test_add_listener_unknown_device() {
             ),
             callback,
         );
-        assert_eq!(
-            stream.add_device_listener(&listener),
-            kAudioHardwareBadObjectError as OSStatus
-        );
+        let mut res: OSStatus = 0;
+        stream
+            .queue
+            .run_sync(|| res = stream.add_device_listener(&listener));
+        assert_eq!(res, kAudioHardwareBadObjectError as OSStatus);
     });
 }
 
@@ -257,8 +258,15 @@ fn test_add_listener_then_remove_system_device() {
             ),
             callback,
         );
-        assert_eq!(stream.add_device_listener(&listener), NO_ERR);
-        assert_eq!(stream.remove_device_listener(&listener), NO_ERR);
+        let mut res: OSStatus = 0;
+        stream
+            .queue
+            .run_sync(|| res = stream.add_device_listener(&listener));
+        assert_eq!(res, NO_ERR);
+        stream
+            .queue
+            .run_sync(|| res = stream.remove_device_listener(&listener));
+        assert_eq!(res, NO_ERR);
     });
 }
 
@@ -283,7 +291,11 @@ fn test_remove_listener_without_adding_any_listener_before_system_device() {
             ),
             callback,
         );
-        assert_eq!(stream.remove_device_listener(&listener), NO_ERR);
+        let mut res: OSStatus = 0;
+        stream
+            .queue
+            .run_sync(|| res = stream.remove_device_listener(&listener));
+        assert_eq!(res, NO_ERR);
     });
 }
 
@@ -308,10 +320,11 @@ fn test_remove_listener_unknown_device() {
             ),
             callback,
         );
-        assert_eq!(
-            stream.remove_device_listener(&listener),
-            kAudioHardwareBadObjectError as OSStatus
-        );
+        let mut res: OSStatus = 0;
+        stream
+            .queue
+            .run_sync(|| res = stream.remove_device_listener(&listener));
+        assert_eq!(res, kAudioHardwareBadObjectError as OSStatus);
     });
 }
 


### PR DESCRIPTION
To mitigate potential race conditions in the platform, make sure all stream-specific operations are done on the stream's serial queue.