### PR TITLE
In get_channel_count enumerate streams directly

### DIFF
--- a/src/backend/device_property.rs
+++ b/src/backend/device_property.rs
@@ -268,13 +268,13 @@ pub fn get_device_stream_configuration(
     Ok(buffers.to_vec())
 }
 
-pub fn get_stream_latency(
-    id: AudioStreamID,
-    devtype: DeviceType,
-) -> std::result::Result<u32, OSStatus> {
+pub fn get_stream_latency(id: AudioStreamID) -> std::result::Result<u32, OSStatus> {
     assert_ne!(id, kAudioObjectUnknown);
 
-    let address = get_property_address(Property::StreamLatency, devtype);
+    let address = get_property_address(
+        Property::StreamLatency,
+        DeviceType::INPUT | DeviceType::OUTPUT,
+    );
     let mut size = mem::size_of::<u32>();
     let mut latency: u32 = 0;
     let err = audio_object_get_property_data(id, &address, &mut size, &mut latency);

--- a/src/backend/device_property.rs
+++ b/src/backend/device_property.rs
@@ -223,51 +223,6 @@ pub fn get_ranges_of_device_sample_rate(
     }
 }
 
-pub fn get_device_stream_format(
-    id: AudioDeviceID,
-    devtype: DeviceType,
-) -> std::result::Result<AudioStreamBasicDescription, OSStatus> {
-    assert_ne!(id, kAudioObjectUnknown);
-
-    let address = get_property_address(Property::DeviceStreamFormat, devtype);
-    let mut size = mem::size_of::<AudioStreamBasicDescription>();
-    let mut format = AudioStreamBasicDescription::default();
-    let err = audio_object_get_property_data(id, &address, &mut size, &mut format);
-    if err == NO_ERR {
-        Ok(format)
-    } else {
-        Err(err)
-    }
-}
-
-#[allow(clippy::cast_ptr_alignment)] // Allow casting *mut u8 to *mut AudioBufferList
-pub fn get_device_stream_configuration(
-    id: AudioDeviceID,
-    devtype: DeviceType,
-) -> std::result::Result<Vec<AudioBuffer>, OSStatus> {
-    assert_ne!(id, kAudioObjectUnknown);
-
-    let address = get_property_address(Property::DeviceStreamConfiguration, devtype);
-    let mut size: usize = 0;
-    let err = audio_object_get_property_data_size(id, &address, &mut size);
-    if err != NO_ERR {
-        return Err(err);
-    }
-
-    let mut data: Vec<u8> = allocate_array_by_size(size);
-    let ptr = data.as_mut_ptr() as *mut AudioBufferList;
-    let err = audio_object_get_property_data(id, &address, &mut size, ptr);
-    if err != NO_ERR {
-        return Err(err);
-    }
-
-    let list = unsafe { &(*ptr) };
-    let ptr = list.mBuffers.as_ptr();
-    let len = list.mNumberBuffers as usize;
-    let buffers = unsafe { slice::from_raw_parts(ptr, len) };
-    Ok(buffers.to_vec())
-}
-
 pub fn get_stream_latency(id: AudioStreamID) -> std::result::Result<u32, OSStatus> {
     assert_ne!(id, kAudioObjectUnknown);
 
@@ -280,6 +235,25 @@ pub fn get_stream_latency(id: AudioStreamID) -> std::result::Result<u32, OSStatu
     let err = audio_object_get_property_data(id, &address, &mut size, &mut latency);
     if err == NO_ERR {
         Ok(latency)
+    } else {
+        Err(err)
+    }
+}
+
+pub fn get_stream_virtual_format(
+    id: AudioStreamID,
+) -> std::result::Result<AudioStreamBasicDescription, OSStatus> {
+    assert_ne!(id, kAudioObjectUnknown);
+
+    let address = get_property_address(
+        Property::StreamVirtualFormat,
+        DeviceType::INPUT | DeviceType::OUTPUT,
+    );
+    let mut size = mem::size_of::<AudioStreamBasicDescription>();
+    let mut format = AudioStreamBasicDescription::default();
+    let err = audio_object_get_property_data(id, &address, &mut size, &mut format);
+    if err == NO_ERR {
+        Ok(format)
     } else {
         Err(err)
     }
@@ -312,8 +286,6 @@ pub enum Property {
     DeviceSampleRates,
     DeviceSource,
     DeviceSourceName,
-    DeviceStreamConfiguration,
-    DeviceStreamFormat,
     DeviceStreams,
     DeviceUID,
     HardwareDefaultInputDevice,
@@ -321,6 +293,7 @@ pub enum Property {
     HardwareDevices,
     ModelUID,
     StreamLatency,
+    StreamVirtualFormat,
     TransportType,
     ClockDomain,
 }
@@ -337,8 +310,6 @@ impl From<Property> for AudioObjectPropertySelector {
             Property::DeviceSampleRates => kAudioDevicePropertyAvailableNominalSampleRates,
             Property::DeviceSource => kAudioDevicePropertyDataSource,
             Property::DeviceSourceName => kAudioDevicePropertyDataSourceNameForIDCFString,
-            Property::DeviceStreamConfiguration => kAudioDevicePropertyStreamConfiguration,
-            Property::DeviceStreamFormat => kAudioDevicePropertyStreamFormat,
             Property::DeviceStreams => kAudioDevicePropertyStreams,
             Property::DeviceUID => kAudioDevicePropertyDeviceUID,
             Property::HardwareDefaultInputDevice => kAudioHardwarePropertyDefaultInputDevice,
@@ -346,6 +317,7 @@ impl From<Property> for AudioObjectPropertySelector {
             Property::HardwareDevices => kAudioHardwarePropertyDevices,
             Property::ModelUID => kAudioDevicePropertyModelUID,
             Property::StreamLatency => kAudioStreamPropertyLatency,
+            Property::StreamVirtualFormat => kAudioStreamPropertyVirtualFormat,
             Property::TransportType => kAudioDevicePropertyTransportType,
             Property::ClockDomain => kAudioDevicePropertyClockDomain,
         }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1342,7 +1342,7 @@ fn get_fixed_latency(devid: AudioObjectID, devtype: DeviceType) -> u32 {
             );
             Ok(0) // default stream latency
         } else {
-            get_stream_latency(streams[0], devtype)
+            get_stream_latency(streams[0])
         }
     }).map_err(|e| {
         cubeb_log!(

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1060,8 +1060,12 @@ fn test_get_channel_count_of_inout_type() {
     fn test_channel_count(scope: Scope) {
         if let Some(device) = test_get_default_device(scope.clone()) {
             assert_eq!(
-                get_channel_count(device, DeviceType::INPUT | DeviceType::OUTPUT).unwrap_err(),
-                kAudioHardwareUnknownPropertyError as OSStatus
+                get_channel_count(device, DeviceType::INPUT | DeviceType::OUTPUT),
+                get_channel_count(device, DeviceType::INPUT).map(|c| c + get_channel_count(
+                    device,
+                    DeviceType::OUTPUT
+                )
+                .unwrap_or(0))
             );
         } else {
             println!("No device for {:?}.", scope);
@@ -1379,7 +1383,6 @@ fn test_create_device_info_by_unknown_device() {
 }
 
 #[test]
-#[should_panic]
 fn test_create_device_info_with_unknown_type() {
     test_create_device_info_with_unknown_type_by_scope(Scope::Input);
     test_create_device_info_with_unknown_type_by_scope(Scope::Output);
@@ -1387,8 +1390,6 @@ fn test_create_device_info_with_unknown_type() {
     fn test_create_device_info_with_unknown_type_by_scope(scope: Scope) {
         if let Some(device) = test_get_default_device(scope.clone()) {
             assert!(create_cubeb_device_info(device, DeviceType::UNKNOWN).is_err());
-        } else {
-            panic!("Panic by default: No device for {:?}.", scope);
         }
     }
 }

--- a/src/backend/tests/device_property.rs
+++ b/src/backend/tests/device_property.rs
@@ -282,6 +282,7 @@ fn test_get_device_streams() {
     if let Some(device) = test_get_default_device(Scope::Input) {
         let streams = get_device_streams(device, DeviceType::INPUT).unwrap();
         println!("streams on the input device: {:?}", streams);
+        assert!(!streams.is_empty());
     } else {
         println!("No input device.");
     }
@@ -289,6 +290,7 @@ fn test_get_device_streams() {
     if let Some(device) = test_get_default_device(Scope::Output) {
         let streams = get_device_streams(device, DeviceType::OUTPUT).unwrap();
         println!("streams on the output device: {:?}", streams);
+        assert!(!streams.is_empty());
     } else {
         println!("No output device.");
     }

--- a/src/backend/tests/device_property.rs
+++ b/src/backend/tests/device_property.rs
@@ -352,56 +352,6 @@ fn test_get_ranges_of_device_sample_rate_by_unknown_device() {
     assert!(get_ranges_of_device_sample_rate(kAudioObjectUnknown, DeviceType::INPUT).is_err());
 }
 
-// get_device_stream_format
-// ------------------------------------
-#[test]
-fn test_get_device_stream_format() {
-    if let Some(device) = test_get_default_device(Scope::Input) {
-        let format = get_device_stream_format(device, DeviceType::INPUT).unwrap();
-        println!("input stream format: {:?}", format);
-    } else {
-        println!("No input device.");
-    }
-
-    if let Some(device) = test_get_default_device(Scope::Output) {
-        let format = get_device_stream_format(device, DeviceType::OUTPUT).unwrap();
-        println!("output stream format: {:?}", format);
-    } else {
-        println!("No output device.");
-    }
-}
-
-#[test]
-#[should_panic]
-fn test_get_device_stream_format_by_unknown_device() {
-    assert!(get_device_stream_format(kAudioObjectUnknown, DeviceType::INPUT).is_err());
-}
-
-// get_device_stream_configuration
-// ------------------------------------
-#[test]
-fn test_get_device_stream_configuration() {
-    if let Some(device) = test_get_default_device(Scope::Input) {
-        let buffers = get_device_stream_configuration(device, DeviceType::INPUT).unwrap();
-        println!("input stream config: {:?}", buffers);
-    } else {
-        println!("No input device.");
-    }
-
-    if let Some(device) = test_get_default_device(Scope::Output) {
-        let buffers = get_device_stream_configuration(device, DeviceType::OUTPUT).unwrap();
-        println!("output stream config: {:?}", buffers);
-    } else {
-        println!("No output device.");
-    }
-}
-
-#[test]
-#[should_panic]
-fn test_get_device_stream_configuration_by_unknown_device() {
-    assert!(get_device_stream_configuration(kAudioObjectUnknown, DeviceType::INPUT).is_err());
-}
-
 // get_stream_latency
 // ------------------------------------
 #[test]
@@ -431,4 +381,39 @@ fn test_get_stream_latency() {
 #[should_panic]
 fn test_get_stream_latency_by_unknown_device() {
     assert!(get_stream_latency(kAudioObjectUnknown).is_err());
+}
+
+// get_stream_virtual_format
+// ------------------------------------
+#[test]
+fn test_get_stream_virtual_format() {
+    if let Some(device) = test_get_default_device(Scope::Input) {
+        let streams = get_device_streams(device, DeviceType::INPUT).unwrap();
+        let formats = streams
+            .iter()
+            .map(|s| get_stream_virtual_format(*s))
+            .collect::<Vec<std::result::Result<AudioStreamBasicDescription, OSStatus>>>();
+        println!("input stream formats: {:?}", formats);
+        assert!(!formats.is_empty());
+    } else {
+        println!("No input device.");
+    }
+
+    if let Some(device) = test_get_default_device(Scope::Output) {
+        let streams = get_device_streams(device, DeviceType::OUTPUT).unwrap();
+        let formats = streams
+            .iter()
+            .map(|s| get_stream_virtual_format(*s))
+            .collect::<Vec<std::result::Result<AudioStreamBasicDescription, OSStatus>>>();
+        println!("output stream formats: {:?}", formats);
+        assert!(!formats.is_empty());
+    } else {
+        println!("No output device.");
+    }
+}
+
+#[test]
+#[should_panic]
+fn test_get_stream_virtual_format_by_unknown_stream() {
+    assert!(get_stream_virtual_format(kAudioObjectUnknown).is_err());
 }

--- a/src/backend/tests/device_property.rs
+++ b/src/backend/tests/device_property.rs
@@ -409,7 +409,7 @@ fn test_get_stream_latency() {
     if let Some(device) = test_get_default_device(Scope::Input) {
         let streams = get_device_streams(device, DeviceType::INPUT).unwrap();
         for stream in streams {
-            let latency = get_stream_latency(stream, DeviceType::INPUT).unwrap();
+            let latency = get_stream_latency(stream).unwrap();
             println!("latency of the input stream {} is {}", stream, latency);
         }
     } else {
@@ -419,7 +419,7 @@ fn test_get_stream_latency() {
     if let Some(device) = test_get_default_device(Scope::Output) {
         let streams = get_device_streams(device, DeviceType::OUTPUT).unwrap();
         for stream in streams {
-            let latency = get_stream_latency(stream, DeviceType::OUTPUT).unwrap();
+            let latency = get_stream_latency(stream).unwrap();
             println!("latency of the output stream {} is {}", stream, latency);
         }
     } else {
@@ -430,5 +430,5 @@ fn test_get_stream_latency() {
 #[test]
 #[should_panic]
 fn test_get_stream_latency_by_unknown_device() {
-    assert!(get_stream_latency(kAudioObjectUnknown, DeviceType::INPUT).is_err());
+    assert!(get_stream_latency(kAudioObjectUnknown).is_err());
 }


### PR DESCRIPTION
This commit does not change behavior of get_channel_count. But it changes it from counting channels on a device's stream configuration, which is essentially a list of stream descriptions, to counting channels by enumerating streams and querying them for their format. This will help filter out Tap input streams from output devices in a future commit.