### PR TITLE
Destroying a context with collection change callbacks not removed should crash

### DIFF
--- a/src/backend/tests/device_change.rs
+++ b/src/backend/tests/device_change.rs
@@ -305,6 +305,9 @@ fn test_plug_and_unplug_device_in_scope(scope: Scope) {
             notifier.notify(counts);
         }
     }
+
+    context.register_device_collection_changed(DeviceType::OUTPUT, None, ptr::null_mut());
+    context.register_device_collection_changed(DeviceType::INPUT, None, ptr::null_mut());
 }
 
 // Switch default devices used by the active streams, to test device changed callback

--- a/src/backend/tests/interfaces.rs
+++ b/src/backend/tests/interfaces.rs
@@ -262,6 +262,18 @@ fn test_ops_context_register_device_collection_changed_twice(devtype: u32) {
             },
             ffi::CUBEB_ERROR_INVALID_PARAMETER
         );
+        // Unregister
+        assert_eq!(
+            unsafe {
+                OPS.register_device_collection_changed.unwrap()(
+                    context_ptr,
+                    devtype,
+                    None,
+                    ptr::null_mut(),
+                )
+            },
+            ffi::CUBEB_OK
+        );
     });
 }
 


### PR DESCRIPTION
https://github.com/mozilla/cubeb/blob/54217bca3f3e0cd53c073690a23dd25d83557909/test/test_duplex.cpp#L204-L223 tests this.