### PR TITLE
Don't duck the VPIO output device

### DIFF
--- a/coreaudio-sys-utils/src/audio_device_extensions.rs
+++ b/coreaudio-sys-utils/src/audio_device_extensions.rs
@@ -1,0 +1,22 @@
+use coreaudio_sys::*;
+
+// See https://opensource.apple.com/source/WebCore/WebCore-7604.5.6/platform/spi/cf/CoreAudioSPI.h.auto.html
+// Per https://github.com/WebKit/WebKit/commit/7c4c851bc80f14b4cf907f76d65baee013a45eea,
+// this first appeared in MacOS 10.13 and iOS 11.0.
+extern "C" {
+    fn AudioDeviceDuck(
+        inDevice: AudioDeviceID,
+        inDuckedLevel: f32,
+        inStartTime: *const AudioTimeStamp,
+        inRampDuration: f32,
+    ) -> OSStatus;
+}
+
+pub fn audio_device_duck(
+    in_device: AudioDeviceID,
+    in_ducked_level: f32,
+    in_start_time: *const AudioTimeStamp,
+    in_ramp_duration: f32,
+) -> OSStatus {
+    unsafe { AudioDeviceDuck(in_device, in_ducked_level, in_start_time, in_ramp_duration) }
+}

--- a/coreaudio-sys-utils/src/lib.rs
+++ b/coreaudio-sys-utils/src/lib.rs
@@ -2,6 +2,7 @@ extern crate core_foundation_sys;
 extern crate coreaudio_sys;
 
 pub mod aggregate_device;
+pub mod audio_device_extensions;
 pub mod audio_object;
 pub mod audio_unit;
 pub mod cf_mutable_dict;

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -21,6 +21,7 @@ use self::aggregate_device::*;
 use self::auto_release::*;
 use self::buffer_manager::*;
 use self::coreaudio_sys_utils::aggregate_device::*;
+use self::coreaudio_sys_utils::audio_device_extensions::*;
 use self::coreaudio_sys_utils::audio_object::*;
 use self::coreaudio_sys_utils::audio_unit::*;
 use self::coreaudio_sys_utils::cf_mutable_dict::*;
@@ -3245,6 +3246,24 @@ impl<'ctx> CoreStreamData<'ctx> {
                 stream.output_device_latency_frames.fetch_add(
                     (unit_s * self.output_dev_desc.mSampleRate) as u32,
                     Ordering::SeqCst,
+                );
+            }
+        }
+
+        if using_voice_processing_unit {
+            // The VPIO AudioUnit automatically ducks other audio streams on the VPIO
+            // output device. Its ramp duration is 0.5s when ducking, so unduck similarly
+            // now.
+            // NOTE: On MacOS 14 the ducking happens on creation of the VPIO AudioUnit.
+            //       On MacOS 10.15 it happens on both creation and initialization, which
+            //       is why we defer the unducking until now.
+            let r = audio_device_duck(self.output_device.id, 1.0, ptr::null_mut(), 0.5);
+            if r != NO_ERR {
+                cubeb_log!(
+                    "({:p}) Failed to undo ducking of voiceprocessing on output device {}. Proceeding... Error: {}",
+                    self.stm_ptr,
+                    self.output_device.id,
+                    r
                 );
             }
         }


### PR DESCRIPTION
With VPIO, all output streams other than the one of the VPIO AudioUnit itself, on the VPIO output device, are ducked, i.e., their volume is statically reduced.

From manual testing it seems creation of the VPIO AudioUnit causes ducking of all output streams across all devices. After setting the output device on the VPIO AudioUnit, ducking is undone on all output streams except for those on the VPIO output device. The volume ramp-up of 1 second seems close to the ramp-up that happens automatically on other output devices.

With no control surface to control ducking, manually undo it on the VPIO output device for now.