### PR TITLE
Explicitly ignore INPUT_UNDEFINED input channels 

### DIFF
--- a/src/backend/tests/parallel.rs
+++ b/src/backend/tests/parallel.rs
@@ -416,9 +416,9 @@ fn create_streams_in_parallel_with_different_latency<F>(
         return;
     }
 
-    let context = AudioUnitContext::new();
+    let mut context = AudioUnitContext::new();
 
-    let context_ptr_value = &context as *const AudioUnitContext as usize;
+    let context_ptr_value = &mut context as *mut AudioUnitContext as usize;
 
     let mut join_handles = vec![];
     for i in 0..amount {


### PR DESCRIPTION
Instead of allowing only explicitly recognized terminal types, this
patch makes INPUT_UNDEFINED explicitly ignored and everything else
allowed. Unrecognized terminal types will still be logged as before.

Background for this change is https://bugzilla.mozilla.org/show_bug.cgi?id=1870678