### PR TITLE
Ignore input streams with (explicit) unknown terminal type

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1438,6 +1438,10 @@ fn get_channel_count(
                 kAudioStreamTerminalTypeMicrophone
                 | kAudioStreamTerminalTypeHeadsetMicrophone
                 | kAudioStreamTerminalTypeReceiverMicrophone => true,
+                kAudioStreamTerminalTypeUnknown => {
+                    cubeb_log!("Unknown TerminalType for input stream. Ignoring its channels.");
+                    false
+                }
                 t if [
                     kAudioStreamTerminalTypeSpeaker,
                     kAudioStreamTerminalTypeHeadphones,


### PR DESCRIPTION
These show up on output-only devices when enabling (putting in your ear) and disabling (putting into- and closing case) AirPods.