### PR TITLE
With VPIO configure MONO output and always enable AGC

### DIFF
--- a/src/backend/tests/manual.rs
+++ b/src/backend/tests/manual.rs
@@ -338,23 +338,6 @@ fn test_stream_tester() {
                 params.set(InputProcessingParams::ECHO_CANCELLATION, true);
                 params.set(InputProcessingParams::NOISE_SUPPRESSION, true);
             }
-            let mut agc = u32::from(false);
-            let mut size: usize = mem::size_of::<u32>();
-            assert_eq!(
-                audio_unit_get_property(
-                    stm.core_stream_data.input_unit,
-                    kAUVoiceIOProperty_VoiceProcessingEnableAGC,
-                    kAudioUnitScope_Global,
-                    AU_IN_BUS,
-                    &mut agc,
-                    &mut size,
-                ),
-                NO_ERR
-            );
-            assert_eq!(size, mem::size_of::<u32>());
-            if agc == 1 {
-                params.set(InputProcessingParams::AUTOMATIC_GAIN_CONTROL, true);
-            }
         }
         let mut done = false;
         while !done {


### PR DESCRIPTION
MONO output because VPIO will downmix to mono always, anyway.
AGC always on because it limits the signal on devices where it is too strong, like Apple Studio Display, preventing us from clipping.