### PR TITLE
Serialize all operations talking to the platform, and other fixes

### DIFF
--- a/coreaudio-sys-utils/src/audio_device_extensions.rs
+++ b/coreaudio-sys-utils/src/audio_device_extensions.rs
@@ -1,3 +1,4 @@
+use crate::dispatch::*;
 use coreaudio_sys::*;
 
 // See https://opensource.apple.com/source/WebCore/WebCore-7604.5.6/platform/spi/cf/CoreAudioSPI.h.auto.html
@@ -18,5 +19,6 @@ pub fn audio_device_duck(
     in_start_time: *const AudioTimeStamp,
     in_ramp_duration: f32,
 ) -> OSStatus {
+    debug_assert_running_serially();
     unsafe { AudioDeviceDuck(in_device, in_ducked_level, in_start_time, in_ramp_duration) }
 }

--- a/coreaudio-sys-utils/src/audio_object.rs
+++ b/coreaudio-sys-utils/src/audio_object.rs
@@ -1,3 +1,4 @@
+use crate::dispatch::*;
 use coreaudio_sys::*;
 use std::fmt;
 use std::os::raw::c_void;
@@ -77,6 +78,7 @@ pub fn audio_object_set_property_data<T>(
     size: usize,
     data: *const T,
 ) -> OSStatus {
+    debug_assert_running_serially();
     unsafe {
         AudioObjectSetPropertyData(
             id,
@@ -99,6 +101,7 @@ pub fn audio_object_add_property_listener<T>(
     listener: audio_object_property_listener_proc,
     data: *mut T,
 ) -> OSStatus {
+    debug_assert_running_serially();
     unsafe { AudioObjectAddPropertyListener(id, address, Some(listener), data as *mut c_void) }
 }
 
@@ -108,6 +111,7 @@ pub fn audio_object_remove_property_listener<T>(
     listener: audio_object_property_listener_proc,
     data: *mut T,
 ) -> OSStatus {
+    debug_assert_running_serially();
     unsafe { AudioObjectRemovePropertyListener(id, address, Some(listener), data as *mut c_void) }
 }
 

--- a/coreaudio-sys-utils/src/audio_unit.rs
+++ b/coreaudio-sys-utils/src/audio_unit.rs
@@ -1,3 +1,4 @@
+use crate::dispatch::debug_assert_running_serially;
 use coreaudio_sys::*;
 use std::convert::TryFrom;
 use std::os::raw::c_void;
@@ -13,6 +14,7 @@ pub fn audio_unit_get_property_info(
 ) -> OSStatus {
     assert!(!unit.is_null());
     assert!(UInt32::try_from(*size).is_ok()); // Check if `size` can be converted to a UInt32.
+    debug_assert_running_serially();
     unsafe {
         AudioUnitGetPropertyInfo(
             unit,
@@ -35,6 +37,7 @@ pub fn audio_unit_get_property<T>(
 ) -> OSStatus {
     assert!(!unit.is_null());
     assert!(UInt32::try_from(*size).is_ok()); // Check if `size` can be converted to a UInt32.
+    debug_assert_running_serially();
     unsafe {
         AudioUnitGetProperty(
             unit,
@@ -56,6 +59,7 @@ pub fn audio_unit_set_property<T>(
     size: usize,
 ) -> OSStatus {
     assert!(!unit.is_null());
+    debug_assert_running_serially();
     unsafe {
         AudioUnitSetProperty(
             unit,
@@ -76,6 +80,7 @@ pub fn audio_unit_get_parameter(
     value: &mut AudioUnitParameterValue,
 ) -> OSStatus {
     assert!(!unit.is_null());
+    debug_assert_running_serially();
     unsafe {
         AudioUnitGetParameter(
             unit,
@@ -96,30 +101,36 @@ pub fn audio_unit_set_parameter(
     buffer_offset_in_frames: UInt32,
 ) -> OSStatus {
     assert!(!unit.is_null());
+    debug_assert_running_serially();
     unsafe { AudioUnitSetParameter(unit, id, scope, element, value, buffer_offset_in_frames) }
 }
 
 pub fn audio_unit_initialize(unit: AudioUnit) -> OSStatus {
     assert!(!unit.is_null());
+    debug_assert_running_serially();
     unsafe { AudioUnitInitialize(unit) }
 }
 
 pub fn audio_unit_uninitialize(unit: AudioUnit) -> OSStatus {
     assert!(!unit.is_null());
+    debug_assert_running_serially();
     unsafe { AudioUnitUninitialize(unit) }
 }
 
 pub fn dispose_audio_unit(unit: AudioUnit) -> OSStatus {
+    debug_assert_running_serially();
     unsafe { AudioComponentInstanceDispose(unit) }
 }
 
 pub fn audio_output_unit_start(unit: AudioUnit) -> OSStatus {
     assert!(!unit.is_null());
+    debug_assert_running_serially();
     unsafe { AudioOutputUnitStart(unit) }
 }
 
 pub fn audio_output_unit_stop(unit: AudioUnit) -> OSStatus {
     assert!(!unit.is_null());
+    debug_assert_running_serially();
     unsafe { AudioOutputUnitStop(unit) }
 }
 
@@ -155,6 +166,7 @@ pub fn audio_unit_add_property_listener<T>(
     data: *mut T,
 ) -> OSStatus {
     assert!(!unit.is_null());
+    debug_assert_running_serially();
     unsafe { AudioUnitAddPropertyListener(unit, id, Some(listener), data as *mut c_void) }
 }
 
@@ -165,6 +177,7 @@ pub fn audio_unit_remove_property_listener_with_user_data<T>(
     data: *mut T,
 ) -> OSStatus {
     assert!(!unit.is_null());
+    debug_assert_running_serially();
     unsafe {
         AudioUnitRemovePropertyListenerWithUserData(unit, id, Some(listener), data as *mut c_void)
     }

--- a/coreaudio-sys-utils/src/dispatch.rs
+++ b/coreaudio-sys-utils/src/dispatch.rs
@@ -5,6 +5,14 @@ use std::mem;
 use std::os::raw::c_void;
 use std::ptr;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::OnceLock;
+
+pub const DISPATCH_QUEUE_LABEL: &str = "org.mozilla.cubeb";
+
+pub fn get_serial_queue_singleton() -> &'static Queue {
+    static SERIAL_QUEUE: OnceLock<Queue> = OnceLock::new();
+    SERIAL_QUEUE.get_or_init(|| Queue::new(DISPATCH_QUEUE_LABEL))
+}
 
 // Queue: A wrapper around `dispatch_queue_t` that is always serial.
 // ------------------------------------------------------------------------------------------------
@@ -196,6 +204,9 @@ impl Clone for Queue {
         }
     }
 }
+
+unsafe impl Send for Queue {}
+unsafe impl Sync for Queue {}
 
 #[test]
 fn run_tasks_in_order() {

--- a/coreaudio-sys-utils/src/dispatch.rs
+++ b/coreaudio-sys-utils/src/dispatch.rs
@@ -19,6 +19,10 @@ pub fn debug_assert_running_serially() {
     get_serial_queue_singleton().debug_assert_is_current();
 }
 
+pub fn debug_assert_not_running_serially() {
+    get_serial_queue_singleton().debug_assert_is_not_current();
+}
+
 pub fn run_serially<F, B>(work: F) -> B
 where
     F: FnOnce() -> B,
@@ -80,6 +84,16 @@ impl Queue {
 
     #[cfg(not(debug_assertions))]
     pub fn debug_assert_is_current(&self) {}
+
+    #[cfg(debug_assertions)]
+    pub fn debug_assert_is_not_current(&self) {
+        unsafe {
+            dispatch_assert_queue_not(self.queue);
+        }
+    }
+
+    #[cfg(not(debug_assertions))]
+    pub fn debug_assert_is_not_current(&self) {}
 
     pub fn run_async<F>(&self, work: F)
     where

--- a/coreaudio-sys-utils/src/dispatch.rs
+++ b/coreaudio-sys-utils/src/dispatch.rs
@@ -77,7 +77,7 @@ impl Queue {
 
     pub fn run_sync<F, B>(&self, work: F) -> Option<B>
     where
-        F: Send + FnOnce() -> B,
+        F: FnOnce() -> B,
     {
         let mut res: Option<B> = None;
         let should_cancel = self.get_should_cancel();
@@ -95,7 +95,7 @@ impl Queue {
 
     pub fn run_final<F, B>(&self, work: F) -> Option<B>
     where
-        F: Send + FnOnce() -> B,
+        F: FnOnce() -> B,
     {
         assert!(self.owned, "Doesn't make sense to finalize global queue");
         let mut res: Option<B> = None;

--- a/coreaudio-sys-utils/src/dispatch.rs
+++ b/coreaudio-sys-utils/src/dispatch.rs
@@ -69,6 +69,10 @@ impl Queue {
         F: Send + FnOnce(),
     {
         let should_cancel = self.get_should_cancel();
+        debug_assert!(
+            should_cancel.is_some(),
+            "dispatch context should be allocated!"
+        );
         let (closure, executor) = Self::create_closure_and_executor(|| {
             work();
             should_cancel

--- a/run_device_tests.sh
+++ b/run_device_tests.sh
@@ -15,8 +15,6 @@ cargo test test_plug_and_unplug_device -- --ignored --nocapture
 cargo test test_register_device_changed_callback_to_check_default_device_changed_input -- --ignored --nocapture
 cargo test test_register_device_changed_callback_to_check_default_device_changed_output -- --ignored --nocapture
 cargo test test_register_device_changed_callback_to_check_default_device_changed_duplex -- --ignored --nocapture
-cargo test test_register_device_changed_callback_to_check_input_alive_changed_input -- --ignored --nocapture
-cargo test test_register_device_changed_callback_to_check_input_alive_changed_duplex -- --ignored --nocapture
 
 cargo test test_destroy_input_stream_after_unplugging_a_nondefault_input_device -- --ignored --nocapture
 cargo test test_suspend_input_stream_by_unplugging_a_nondefault_input_device -- --ignored --nocapture

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -39,7 +39,6 @@ cargo clippy -- -D warnings
 
 # Regular Tests
 cargo test --verbose
-cargo test test_configure_output -- --ignored
 
 # Parallel Tests
 cargo test test_parallel -- --ignored --nocapture --test-threads=1

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -40,7 +40,6 @@ cargo clippy -- -D warnings
 # Regular Tests
 cargo test --verbose
 cargo test test_configure_output -- --ignored
-cargo test test_aggregate -- --ignored --test-threads=1
 
 # Parallel Tests
 cargo test test_parallel -- --ignored --nocapture --test-threads=1

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -40,6 +40,9 @@ cargo clippy -- -D warnings
 # Regular Tests
 cargo test --verbose
 
+# Timing sensitive tests must run serially so they cannot be impacted by other tasks on the queue
+cargo test test_ops_timing_sensitive -- --ignored --test-threads=1
+
 # Parallel Tests
 cargo test test_parallel -- --ignored --nocapture --test-threads=1
 

--- a/src/backend/aggregate_device.rs
+++ b/src/backend/aggregate_device.rs
@@ -69,6 +69,7 @@ impl AggregateDevice {
         input_id: AudioObjectID,
         output_id: AudioObjectID,
     ) -> std::result::Result<Self, Error> {
+        debug_assert_running_serially();
         let plugin_id = Self::get_system_plugin_id()?;
         let device_id = Self::create_blank_device_sync(plugin_id)?;
 
@@ -671,6 +672,7 @@ impl Default for AggregateDevice {
 
 impl Drop for AggregateDevice {
     fn drop(&mut self) {
+        debug_assert_running_serially();
         if self.plugin_id != kAudioObjectUnknown && self.device_id != kAudioObjectUnknown {
             if let Err(r) = Self::destroy_device(self.plugin_id, self.device_id) {
                 cubeb_log!(

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2509,10 +2509,10 @@ impl ContextOps for AudioUnitContext {
 
 impl Drop for AudioUnitContext {
     fn drop(&mut self) {
-        let devices = self.devices.lock().unwrap();
-        assert!(
+        assert!({
+            let devices = self.devices.lock().unwrap();
             devices.input.changed_callback.is_none() && devices.output.changed_callback.is_none()
-        );
+        });
 
         {
             let controller = self.latency_controller.lock().unwrap();

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -54,7 +54,6 @@ const NO_ERR: OSStatus = 0;
 const AU_OUT_BUS: AudioUnitElement = 0;
 const AU_IN_BUS: AudioUnitElement = 1;
 
-const DISPATCH_QUEUE_LABEL: &str = "org.mozilla.cubeb";
 const PRIVATE_AGGREGATE_DEVICE_NAME: &str = "CubebAggregateDevice";
 const VOICEPROCESSING_AGGREGATE_DEVICE_NAME: &str = "VPAUAggregateAudioDevice";
 

--- a/src/backend/tests/aggregate_device.rs
+++ b/src/backend/tests/aggregate_device.rs
@@ -3,6 +3,7 @@ use super::utils::{
     test_get_drift_compensations, test_get_master_device, DeviceFilter, Scope,
 };
 use super::*;
+use std::panic;
 
 // AggregateDevice::set_sub_devices
 // ------------------------------------
@@ -19,21 +20,27 @@ fn test_aggregate_set_sub_devices_for_an_unknown_aggregate_device() {
     let default_input = default_input.unwrap();
     let default_output = default_output.unwrap();
     assert!(
-        AggregateDevice::set_sub_devices(kAudioObjectUnknown, default_input, default_output)
-            .is_err()
+        run_serially_forward_panics(|| AggregateDevice::set_sub_devices(
+            kAudioObjectUnknown,
+            default_input,
+            default_output
+        ))
+        .is_err()
     );
 }
 
 #[test]
 #[should_panic]
 fn test_aggregate_set_sub_devices_for_unknown_devices() {
-    // If aggregate device id is kAudioObjectUnknown, we are unable to set device list.
-    assert!(AggregateDevice::set_sub_devices(
-        kAudioObjectUnknown,
-        kAudioObjectUnknown,
-        kAudioObjectUnknown
-    )
-    .is_err());
+    run_serially_forward_panics(|| {
+        // If aggregate device id is kAudioObjectUnknown, we are unable to set device list.
+        assert!(AggregateDevice::set_sub_devices(
+            kAudioObjectUnknown,
+            kAudioObjectUnknown,
+            kAudioObjectUnknown
+        )
+        .is_err());
+    });
 }
 
 // AggregateDevice::get_sub_devices
@@ -48,7 +55,13 @@ fn test_aggregate_get_sub_devices() {
         // containing `device` itself if it's not an aggregate device. This test assumes devices
         // is not an empty aggregate device (Test will panic when calling get_sub_devices with
         // an empty aggregate device).
-        let sub_devices = AggregateDevice::get_sub_devices(device).unwrap();
+        println!(
+            "get_sub_devices({}={})",
+            device,
+            run_serially_forward_panics(|| get_device_uid(device))
+        );
+        let sub_devices =
+            run_serially_forward_panics(|| AggregateDevice::get_sub_devices(device).unwrap());
         // TODO: If the device is a blank aggregate device, then the assertion fails!
         assert!(!sub_devices.is_empty());
     }
@@ -57,8 +70,10 @@ fn test_aggregate_get_sub_devices() {
 #[test]
 #[should_panic]
 fn test_aggregate_get_sub_devices_for_a_unknown_device() {
-    let devices = AggregateDevice::get_sub_devices(kAudioObjectUnknown).unwrap();
-    assert!(devices.is_empty());
+    run_serially_forward_panics(|| {
+        let devices = AggregateDevice::get_sub_devices(kAudioObjectUnknown).unwrap();
+        assert!(devices.is_empty());
+    });
 }
 
 // AggregateDevice::set_master_device
@@ -66,7 +81,11 @@ fn test_aggregate_get_sub_devices_for_a_unknown_device() {
 #[test]
 #[should_panic]
 fn test_aggregate_set_master_device_for_an_unknown_aggregate_device() {
-    assert!(AggregateDevice::set_master_device(kAudioObjectUnknown, kAudioObjectUnknown).is_err());
+    run_serially_forward_panics(|| {
+        assert!(
+            AggregateDevice::set_master_device(kAudioObjectUnknown, kAudioObjectUnknown).is_err()
+        );
+    });
 }
 
 // AggregateDevice::activate_clock_drift_compensation
@@ -74,7 +93,9 @@ fn test_aggregate_set_master_device_for_an_unknown_aggregate_device() {
 #[test]
 #[should_panic]
 fn test_aggregate_activate_clock_drift_compensation_for_an_unknown_aggregate_device() {
-    assert!(AggregateDevice::activate_clock_drift_compensation(kAudioObjectUnknown).is_err());
+    run_serially_forward_panics(|| {
+        assert!(AggregateDevice::activate_clock_drift_compensation(kAudioObjectUnknown).is_err());
+    });
 }
 
 // AggregateDevice::destroy_device
@@ -82,60 +103,55 @@ fn test_aggregate_activate_clock_drift_compensation_for_an_unknown_aggregate_dev
 #[test]
 #[should_panic]
 fn test_aggregate_destroy_device_for_unknown_plugin_and_aggregate_devices() {
-    assert!(AggregateDevice::destroy_device(kAudioObjectUnknown, kAudioObjectUnknown).is_err())
+    run_serially_forward_panics(|| {
+        assert!(AggregateDevice::destroy_device(kAudioObjectUnknown, kAudioObjectUnknown).is_err())
+    });
 }
 
 #[test]
 #[should_panic]
 fn test_aggregate_destroy_aggregate_device_for_a_unknown_aggregate_device() {
-    let plugin = AggregateDevice::get_system_plugin_id().unwrap();
-    assert!(AggregateDevice::destroy_device(plugin, kAudioObjectUnknown).is_err());
+    run_serially_forward_panics(|| {
+        let plugin = AggregateDevice::get_system_plugin_id().unwrap();
+        assert!(AggregateDevice::destroy_device(plugin, kAudioObjectUnknown).is_err());
+    });
 }
-
-// Default Ignored Tests
-// ================================================================================================
-// The following tests that calls `AggregateDevice::create_blank_device` are marked `ignore` by
-// default since the device-collection-changed callbacks will be fired upon
-// `AggregateDevice::create_blank_device` is called (it will plug a new device in system!).
-// Some tests rely on the device-collection-changed callbacks in a certain way. The callbacks
-// fired from a unexpected `AggregateDevice::create_blank_device` will break those tests.
 
 // AggregateDevice::create_blank_device_sync
 // ------------------------------------
 #[test]
-#[ignore]
 fn test_aggregate_create_blank_device() {
     // TODO: Test this when there is no available devices.
-    let plugin = AggregateDevice::get_system_plugin_id().unwrap();
-    let device = AggregateDevice::create_blank_device_sync(plugin).unwrap();
+    let plugin = run_serially(|| AggregateDevice::get_system_plugin_id()).unwrap();
+    let device = run_serially(|| AggregateDevice::create_blank_device_sync(plugin)).unwrap();
     let devices = test_get_all_devices(DeviceFilter::IncludeAll);
     let device = devices.into_iter().find(|dev| dev == &device).unwrap();
-    let uid = get_device_global_uid(device).unwrap().into_string();
+    let uid = run_serially(|| get_device_global_uid(device).unwrap().into_string());
     assert!(uid.contains(PRIVATE_AGGREGATE_DEVICE_NAME));
-    assert!(AggregateDevice::destroy_device(plugin, device).is_ok());
+    assert!(run_serially(|| AggregateDevice::destroy_device(plugin, device)).is_ok());
 }
 
 // AggregateDevice::get_sub_devices
 // ------------------------------------
 #[test]
-#[ignore]
 #[should_panic]
 fn test_aggregate_get_sub_devices_for_blank_aggregate_devices() {
-    // TODO: Test this when there is no available devices.
-    let plugin = AggregateDevice::get_system_plugin_id().unwrap();
-    let device = AggregateDevice::create_blank_device_sync(plugin).unwrap();
-    // There is no sub device in a blank aggregate device!
-    // AggregateDevice::get_sub_devices guarantees returning a non-empty devices vector, so
-    // the following call will panic!
-    let sub_devices = AggregateDevice::get_sub_devices(device).unwrap();
-    assert!(sub_devices.is_empty());
-    assert!(AggregateDevice::destroy_device(plugin, device).is_ok());
+    run_serially_forward_panics(|| {
+        // TODO: Test this when there is no available devices.
+        let plugin = AggregateDevice::get_system_plugin_id().unwrap();
+        let device = AggregateDevice::create_blank_device_sync(plugin).unwrap();
+        // There is no sub device in a blank aggregate device!
+        // AggregateDevice::get_sub_devices guarantees returning a non-empty devices vector, so
+        // the following call will panic!
+        let sub_devices = AggregateDevice::get_sub_devices(device).unwrap();
+        assert!(sub_devices.is_empty());
+        assert!(AggregateDevice::destroy_device(plugin, device).is_ok());
+    });
 }
 
 // AggregateDevice::set_sub_devices_sync
 // ------------------------------------
 #[test]
-#[ignore]
 fn test_aggregate_set_sub_devices() {
     let input_device = test_get_default_device(Scope::Input);
     let output_device = test_get_default_device(Scope::Output);
@@ -147,13 +163,20 @@ fn test_aggregate_set_sub_devices() {
     let input_device = input_device.unwrap();
     let output_device = output_device.unwrap();
 
-    let plugin = AggregateDevice::get_system_plugin_id().unwrap();
-    let device = AggregateDevice::create_blank_device_sync(plugin).unwrap();
-    assert!(AggregateDevice::set_sub_devices_sync(device, input_device, output_device).is_ok());
+    let plugin = run_serially(|| AggregateDevice::get_system_plugin_id()).unwrap();
+    let device = run_serially(|| AggregateDevice::create_blank_device_sync(plugin)).unwrap();
+    assert!(run_serially(|| AggregateDevice::set_sub_devices_sync(
+        device,
+        input_device,
+        output_device
+    ))
+    .is_ok());
 
-    let sub_devices = AggregateDevice::get_sub_devices(device).unwrap();
-    let input_sub_devices = AggregateDevice::get_sub_devices(input_device).unwrap();
-    let output_sub_devices = AggregateDevice::get_sub_devices(output_device).unwrap();
+    let sub_devices = run_serially(|| AggregateDevice::get_sub_devices(device)).unwrap();
+    let input_sub_devices =
+        run_serially(|| AggregateDevice::get_sub_devices(input_device)).unwrap();
+    let output_sub_devices =
+        run_serially(|| AggregateDevice::get_sub_devices(output_device)).unwrap();
 
     // TODO: There may be overlapping devices between input_sub_devices and output_sub_devices,
     //       but now AggregateDevice::set_sub_devices will add them directly.
@@ -168,10 +191,10 @@ fn test_aggregate_set_sub_devices() {
         assert!(sub_devices.contains(dev));
     }
 
-    let onwed_devices = test_get_all_onwed_devices(device);
-    let onwed_device_uids = get_device_uids(&onwed_devices);
-    let input_sub_device_uids = get_device_uids(&input_sub_devices);
-    let output_sub_device_uids = get_device_uids(&output_sub_devices);
+    let onwed_devices = run_serially(|| test_get_all_onwed_devices(device));
+    let onwed_device_uids = run_serially(|| get_device_uids(&onwed_devices));
+    let input_sub_device_uids = run_serially(|| get_device_uids(&input_sub_devices));
+    let output_sub_device_uids = run_serially(|| get_device_uids(&output_sub_devices));
     for uid in &input_sub_device_uids {
         assert!(onwed_device_uids.contains(uid));
     }
@@ -179,11 +202,10 @@ fn test_aggregate_set_sub_devices() {
         assert!(onwed_device_uids.contains(uid));
     }
 
-    assert!(AggregateDevice::destroy_device(plugin, device).is_ok());
+    assert!(run_serially(|| AggregateDevice::destroy_device(plugin, device)).is_ok());
 }
 
 #[test]
-#[ignore]
 #[should_panic]
 fn test_aggregate_set_sub_devices_for_unknown_input_devices() {
     let output_device = test_get_default_device(Scope::Output);
@@ -192,16 +214,19 @@ fn test_aggregate_set_sub_devices_for_unknown_input_devices() {
     }
     let output_device = output_device.unwrap();
 
-    let plugin = AggregateDevice::get_system_plugin_id().unwrap();
-    let device = AggregateDevice::create_blank_device_sync(plugin).unwrap();
+    run_serially_forward_panics(|| {
+        let plugin = AggregateDevice::get_system_plugin_id().unwrap();
+        let device = AggregateDevice::create_blank_device_sync(plugin).unwrap();
 
-    assert!(AggregateDevice::set_sub_devices(device, kAudioObjectUnknown, output_device).is_err());
+        assert!(
+            AggregateDevice::set_sub_devices(device, kAudioObjectUnknown, output_device).is_err()
+        );
 
-    assert!(AggregateDevice::destroy_device(plugin, device).is_ok());
+        assert!(AggregateDevice::destroy_device(plugin, device).is_ok());
+    });
 }
 
 #[test]
-#[ignore]
 #[should_panic]
 fn test_aggregate_set_sub_devices_for_unknown_output_devices() {
     let input_device = test_get_default_device(Scope::Input);
@@ -210,12 +235,16 @@ fn test_aggregate_set_sub_devices_for_unknown_output_devices() {
     }
     let input_device = input_device.unwrap();
 
-    let plugin = AggregateDevice::get_system_plugin_id().unwrap();
-    let device = AggregateDevice::create_blank_device_sync(plugin).unwrap();
+    run_serially_forward_panics(|| {
+        let plugin = AggregateDevice::get_system_plugin_id().unwrap();
+        let device = AggregateDevice::create_blank_device_sync(plugin).unwrap();
 
-    assert!(AggregateDevice::set_sub_devices(device, input_device, kAudioObjectUnknown).is_err());
+        assert!(
+            AggregateDevice::set_sub_devices(device, input_device, kAudioObjectUnknown).is_err()
+        );
 
-    assert!(AggregateDevice::destroy_device(plugin, device).is_ok());
+        assert!(AggregateDevice::destroy_device(plugin, device).is_ok());
+    });
 }
 
 fn get_device_uids(devices: &Vec<AudioObjectID>) -> Vec<String> {
@@ -228,7 +257,6 @@ fn get_device_uids(devices: &Vec<AudioObjectID>) -> Vec<String> {
 // AggregateDevice::set_master_device
 // ------------------------------------
 #[test]
-#[ignore]
 fn test_aggregate_set_master_device() {
     let input_device = test_get_default_device(Scope::Input);
     let output_device = test_get_default_device(Scope::Output);
@@ -240,22 +268,26 @@ fn test_aggregate_set_master_device() {
     let input_device = input_device.unwrap();
     let output_device = output_device.unwrap();
 
-    let plugin = AggregateDevice::get_system_plugin_id().unwrap();
-    let device = AggregateDevice::create_blank_device_sync(plugin).unwrap();
-    assert!(AggregateDevice::set_sub_devices_sync(device, input_device, output_device).is_ok());
-    assert!(AggregateDevice::set_master_device(device, output_device).is_ok());
+    let plugin = run_serially(|| AggregateDevice::get_system_plugin_id()).unwrap();
+    let device = run_serially(|| AggregateDevice::create_blank_device_sync(plugin)).unwrap();
+    assert!(run_serially(|| AggregateDevice::set_sub_devices_sync(
+        device,
+        input_device,
+        output_device
+    ))
+    .is_ok());
+    assert!(run_serially(|| AggregateDevice::set_master_device(device, output_device)).is_ok());
 
     // Check if master is set to the first sub device of the default output device.
     let first_output_sub_device_uid =
-        get_device_uid(AggregateDevice::get_sub_devices(device).unwrap()[0]);
-    let master_device_uid = test_get_master_device(device);
+        run_serially(|| get_device_uid(AggregateDevice::get_sub_devices(device).unwrap()[0]));
+    let master_device_uid = run_serially(|| test_get_master_device(device));
     assert_eq!(first_output_sub_device_uid, master_device_uid);
 
-    assert!(AggregateDevice::destroy_device(plugin, device).is_ok());
+    assert!(run_serially(|| AggregateDevice::destroy_device(plugin, device)).is_ok());
 }
 
 #[test]
-#[ignore]
 fn test_aggregate_set_master_device_for_a_blank_aggregate_device() {
     let output_device = test_get_default_device(Scope::Output);
     if output_device.is_none() {
@@ -263,9 +295,11 @@ fn test_aggregate_set_master_device_for_a_blank_aggregate_device() {
         return;
     }
 
-    let plugin = AggregateDevice::get_system_plugin_id().unwrap();
-    let device = AggregateDevice::create_blank_device_sync(plugin).unwrap();
-    assert!(AggregateDevice::set_master_device(device, output_device.unwrap()).is_ok());
+    let plugin = run_serially(|| AggregateDevice::get_system_plugin_id()).unwrap();
+    let device = run_serially(|| AggregateDevice::create_blank_device_sync(plugin)).unwrap();
+    assert!(
+        run_serially(|| AggregateDevice::set_master_device(device, output_device.unwrap())).is_ok()
+    );
 
     // TODO: it's really weird the aggregate device actually own nothing
     //       but its master device can be set successfully!
@@ -275,17 +309,16 @@ fn test_aggregate_set_master_device_for_a_blank_aggregate_device() {
     // The CFStringRef of the master device returned from `test_get_master_device` is actually
     // non-null.
 
-    assert!(AggregateDevice::destroy_device(plugin, device).is_ok());
+    assert!(run_serially(|| AggregateDevice::destroy_device(plugin, device)).is_ok());
 }
 
 fn get_device_uid(id: AudioObjectID) -> String {
-    get_device_global_uid(id).unwrap().into_string()
+    get_device_global_uid(id).map_or(String::new(), |uid| uid.into_string())
 }
 
 // AggregateDevice::activate_clock_drift_compensation
 // ------------------------------------
 #[test]
-#[ignore]
 fn test_aggregate_activate_clock_drift_compensation() {
     let input_device = test_get_default_device(Scope::Input);
     let output_device = test_get_default_device(Scope::Output);
@@ -297,15 +330,20 @@ fn test_aggregate_activate_clock_drift_compensation() {
     let input_device = input_device.unwrap();
     let output_device = output_device.unwrap();
 
-    let plugin = AggregateDevice::get_system_plugin_id().unwrap();
-    let device = AggregateDevice::create_blank_device_sync(plugin).unwrap();
-    assert!(AggregateDevice::set_sub_devices_sync(device, input_device, output_device).is_ok());
-    assert!(AggregateDevice::set_master_device(device, output_device).is_ok());
-    assert!(AggregateDevice::activate_clock_drift_compensation(device).is_ok());
+    let plugin = run_serially(|| AggregateDevice::get_system_plugin_id()).unwrap();
+    let device = run_serially(|| AggregateDevice::create_blank_device_sync(plugin)).unwrap();
+    assert!(run_serially(|| AggregateDevice::set_sub_devices_sync(
+        device,
+        input_device,
+        output_device
+    ))
+    .is_ok());
+    assert!(run_serially(|| AggregateDevice::set_master_device(device, output_device)).is_ok());
+    assert!(run_serially(|| AggregateDevice::activate_clock_drift_compensation(device)).is_ok());
 
     // Check the compensations.
-    let devices = test_get_all_onwed_devices(device);
-    let compensations = get_drift_compensations(&devices);
+    let devices = run_serially(|| test_get_all_onwed_devices(device));
+    let compensations = run_serially(|| get_drift_compensations(&devices));
     assert!(!compensations.is_empty());
     assert_eq!(devices.len(), compensations.len());
 
@@ -313,11 +351,10 @@ fn test_aggregate_activate_clock_drift_compensation() {
         assert_eq!(*compensation, if i == 0 { 0 } else { DRIFT_COMPENSATION });
     }
 
-    assert!(AggregateDevice::destroy_device(plugin, device).is_ok());
+    assert!(run_serially(|| AggregateDevice::destroy_device(plugin, device)).is_ok());
 }
 
 #[test]
-#[ignore]
 fn test_aggregate_activate_clock_drift_compensation_for_an_aggregate_device_without_master_device()
 {
     let input_device = test_get_default_device(Scope::Input);
@@ -330,25 +367,31 @@ fn test_aggregate_activate_clock_drift_compensation_for_an_aggregate_device_with
     let input_device = input_device.unwrap();
     let output_device = output_device.unwrap();
 
-    let plugin = AggregateDevice::get_system_plugin_id().unwrap();
-    let device = AggregateDevice::create_blank_device_sync(plugin).unwrap();
-    assert!(AggregateDevice::set_sub_devices_sync(device, input_device, output_device).is_ok());
+    let plugin = run_serially(|| AggregateDevice::get_system_plugin_id()).unwrap();
+    let device = run_serially(|| AggregateDevice::create_blank_device_sync(plugin)).unwrap();
+    assert!(run_serially(|| AggregateDevice::set_sub_devices_sync(
+        device,
+        input_device,
+        output_device
+    ))
+    .is_ok());
 
     // TODO: Is the master device the first output sub device by default if we
     //       don't set that ? Is it because we add the output sub device list
     //       before the input's one ? (See implementation of
     //       AggregateDevice::set_sub_devices).
-    let first_output_sub_device_uid =
-        get_device_uid(AggregateDevice::get_sub_devices(output_device).unwrap()[0]);
-    let master_device_uid = test_get_master_device(device);
+    let first_output_sub_device_uid = run_serially(|| {
+        get_device_uid(AggregateDevice::get_sub_devices(output_device).unwrap()[0])
+    });
+    let master_device_uid = run_serially(|| test_get_master_device(device));
     assert_eq!(first_output_sub_device_uid, master_device_uid);
 
     // Compensate the drift directly without setting master device.
-    assert!(AggregateDevice::activate_clock_drift_compensation(device).is_ok());
+    assert!(run_serially(|| AggregateDevice::activate_clock_drift_compensation(device)).is_ok());
 
     // Check the compensations.
-    let devices = test_get_all_onwed_devices(device);
-    let compensations = get_drift_compensations(&devices);
+    let devices = run_serially(|| test_get_all_onwed_devices(device));
+    let compensations = run_serially(|| get_drift_compensations(&devices));
     assert!(!compensations.is_empty());
     assert_eq!(devices.len(), compensations.len());
 
@@ -356,25 +399,26 @@ fn test_aggregate_activate_clock_drift_compensation_for_an_aggregate_device_with
         assert_eq!(*compensation, if i == 0 { 0 } else { DRIFT_COMPENSATION });
     }
 
-    assert!(AggregateDevice::destroy_device(plugin, device).is_ok());
+    assert!(run_serially(|| AggregateDevice::destroy_device(plugin, device)).is_ok());
 }
 
 #[test]
 #[should_panic]
-#[ignore]
 fn test_aggregate_activate_clock_drift_compensation_for_a_blank_aggregate_device() {
-    let plugin = AggregateDevice::get_system_plugin_id().unwrap();
-    let device = AggregateDevice::create_blank_device_sync(plugin).unwrap();
+    run_serially_forward_panics(|| {
+        let plugin = AggregateDevice::get_system_plugin_id().unwrap();
+        let device = AggregateDevice::create_blank_device_sync(plugin).unwrap();
 
-    let sub_devices = AggregateDevice::get_sub_devices(device).unwrap();
-    assert!(sub_devices.is_empty());
-    let onwed_devices = test_get_all_onwed_devices(device);
-    assert!(onwed_devices.is_empty());
+        let sub_devices = AggregateDevice::get_sub_devices(device).unwrap();
+        assert!(sub_devices.is_empty());
+        let onwed_devices = test_get_all_onwed_devices(device);
+        assert!(onwed_devices.is_empty());
 
-    // Get a panic since no sub devices to be set compensation.
-    assert!(AggregateDevice::activate_clock_drift_compensation(device).is_err());
+        // Get a panic since no sub devices to be set compensation.
+        assert!(AggregateDevice::activate_clock_drift_compensation(device).is_err());
 
-    assert!(AggregateDevice::destroy_device(plugin, device).is_ok());
+        assert!(AggregateDevice::destroy_device(plugin, device).is_ok());
+    });
 }
 
 fn get_drift_compensations(devices: &Vec<AudioObjectID>) -> Vec<u32> {
@@ -391,10 +435,11 @@ fn get_drift_compensations(devices: &Vec<AudioObjectID>) -> Vec<u32> {
 // AggregateDevice::destroy_device
 // ------------------------------------
 #[test]
-#[ignore]
 #[should_panic]
 fn test_aggregate_destroy_aggregate_device_for_a_unknown_plugin_device() {
-    let plugin = AggregateDevice::get_system_plugin_id().unwrap();
-    let device = AggregateDevice::create_blank_device_sync(plugin).unwrap();
-    assert!(AggregateDevice::destroy_device(kAudioObjectUnknown, device).is_err());
+    run_serially_forward_panics(|| {
+        let plugin = AggregateDevice::get_system_plugin_id().unwrap();
+        let device = AggregateDevice::create_blank_device_sync(plugin).unwrap();
+        assert!(AggregateDevice::destroy_device(kAudioObjectUnknown, device).is_err());
+    });
 }

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -227,10 +227,10 @@ fn test_add_listener_unknown_device() {
             ),
             callback,
         );
-        let mut res: OSStatus = 0;
-        stream
+        let res = stream
             .queue
-            .run_sync(|| res = stream.add_device_listener(&listener));
+            .run_sync(|| stream.add_device_listener(&listener))
+            .unwrap();
         assert_eq!(res, kAudioHardwareBadObjectError as OSStatus);
     });
 }
@@ -258,14 +258,15 @@ fn test_add_listener_then_remove_system_device() {
             ),
             callback,
         );
-        let mut res: OSStatus = 0;
-        stream
+        let res = stream
             .queue
-            .run_sync(|| res = stream.add_device_listener(&listener));
+            .run_sync(|| stream.add_device_listener(&listener))
+            .unwrap();
         assert_eq!(res, NO_ERR);
-        stream
+        let res = stream
             .queue
-            .run_sync(|| res = stream.remove_device_listener(&listener));
+            .run_sync(|| stream.remove_device_listener(&listener))
+            .unwrap();
         assert_eq!(res, NO_ERR);
     });
 }
@@ -291,10 +292,10 @@ fn test_remove_listener_without_adding_any_listener_before_system_device() {
             ),
             callback,
         );
-        let mut res: OSStatus = 0;
-        stream
+        let res = stream
             .queue
-            .run_sync(|| res = stream.remove_device_listener(&listener));
+            .run_sync(|| stream.remove_device_listener(&listener))
+            .unwrap();
         assert_eq!(res, NO_ERR);
     });
 }
@@ -320,10 +321,10 @@ fn test_remove_listener_unknown_device() {
             ),
             callback,
         );
-        let mut res: OSStatus = 0;
-        stream
+        let res = stream
             .queue
-            .run_sync(|| res = stream.remove_device_listener(&listener));
+            .run_sync(|| stream.remove_device_listener(&listener))
+            .unwrap();
         assert_eq!(res, kAudioHardwareBadObjectError as OSStatus);
     });
 }

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1770,6 +1770,17 @@ fn test_shared_voice_processing_unit() {
 }
 
 #[test]
+fn test_shared_voice_processing_unit_after_priming() {
+    let queue = Queue::new_with_target(
+        "test_shared_voice_processing_unit_after_priming",
+        get_serial_queue_singleton(),
+    );
+    let mut shared = SharedVoiceProcessingUnit::new(queue.clone());
+    shared.prime();
+    assert!(queue.run_sync(|| shared.take()).unwrap().is_ok());
+}
+
+#[test]
 #[should_panic]
 fn test_shared_voice_processing_unit_bad_release_order() {
     let queue = Queue::new_with_target(

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -149,7 +149,8 @@ fn test_minimum_resampling_input_frames_equal_input_output_rate() {
 #[test]
 fn test_create_device_info_from_unknown_input_device() {
     if let Some(default_device_id) = test_get_default_device(Scope::Input) {
-        let default_device = create_device_info(kAudioObjectUnknown, DeviceType::INPUT).unwrap();
+        let default_device =
+            run_serially(|| create_device_info(kAudioObjectUnknown, DeviceType::INPUT).unwrap());
         assert_eq!(default_device.id, default_device_id);
         assert_eq!(
             default_device.flags,
@@ -163,7 +164,8 @@ fn test_create_device_info_from_unknown_input_device() {
 #[test]
 fn test_create_device_info_from_unknown_output_device() {
     if let Some(default_device_id) = test_get_default_device(Scope::Output) {
-        let default_device = create_device_info(kAudioObjectUnknown, DeviceType::OUTPUT).unwrap();
+        let default_device =
+            run_serially(|| create_device_info(kAudioObjectUnknown, DeviceType::OUTPUT)).unwrap();
         assert_eq!(default_device.id, default_device_id);
         assert_eq!(
             default_device.flags,
@@ -177,7 +179,9 @@ fn test_create_device_info_from_unknown_output_device() {
 #[test]
 #[should_panic]
 fn test_set_device_info_to_system_input_device() {
-    let _device = create_device_info(kAudioObjectSystemObject, DeviceType::INPUT);
+    let _device = run_serially_forward_panics(|| {
+        create_device_info(kAudioObjectSystemObject, DeviceType::INPUT)
+    });
 }
 
 #[test]
@@ -335,14 +339,14 @@ fn test_remove_listener_unknown_device() {
 fn test_get_default_device_id() {
     if test_get_default_device(Scope::Input).is_some() {
         assert_ne!(
-            get_default_device_id(DeviceType::INPUT).unwrap(),
+            run_serially(|| get_default_device_id(DeviceType::INPUT)).unwrap(),
             kAudioObjectUnknown,
         );
     }
 
     if test_get_default_device(Scope::Output).is_some() {
         assert_ne!(
-            get_default_device_id(DeviceType::OUTPUT).unwrap(),
+            run_serially(|| get_default_device_id(DeviceType::OUTPUT)).unwrap(),
             kAudioObjectUnknown,
         );
     }
@@ -351,13 +355,16 @@ fn test_get_default_device_id() {
 #[test]
 #[should_panic]
 fn test_get_default_device_id_with_unknown_type() {
-    assert!(get_default_device_id(DeviceType::UNKNOWN).is_err());
+    assert!(run_serially_forward_panics(|| get_default_device_id(DeviceType::UNKNOWN)).is_err());
 }
 
 #[test]
 #[should_panic]
 fn test_get_default_device_id_with_inout_type() {
-    assert!(get_default_device_id(DeviceType::INPUT | DeviceType::OUTPUT).is_err());
+    assert!(run_serially_forward_panics(|| get_default_device_id(
+        DeviceType::INPUT | DeviceType::OUTPUT
+    ))
+    .is_err());
 }
 
 // convert_channel_layout
@@ -725,9 +732,11 @@ fn test_convert_channel_layout() {
 #[test]
 fn test_get_preferred_channel_layout_output() {
     match test_get_default_audiounit(Scope::Output) {
-        Some(unit) => assert!(!audiounit_get_preferred_channel_layout(unit.get_inner())
-            .unwrap()
-            .is_empty()),
+        Some(unit) => assert!(!run_serially(|| audiounit_get_preferred_channel_layout(
+            unit.get_inner()
+        ))
+        .unwrap()
+        .is_empty()),
         None => println!("No output audiounit for test."),
     }
 }
@@ -737,9 +746,15 @@ fn test_get_preferred_channel_layout_output() {
 #[test]
 fn test_get_current_channel_layout_output() {
     match test_get_default_audiounit(Scope::Output) {
-        Some(unit) => assert!(!audiounit_get_current_channel_layout(unit.get_inner())
-            .unwrap()
-            .is_empty()),
+        Some(unit) => {
+            assert!(
+                !run_serially_forward_panics(|| audiounit_get_current_channel_layout(
+                    unit.get_inner()
+                ))
+                .unwrap()
+                .is_empty()
+            )
+        }
         None => println!("No output audiounit for test."),
     }
 }
@@ -815,10 +830,30 @@ fn test_enable_audiounit_scope() {
     // for the unit whose subtype is kAudioUnitSubType_HALOutput
     // even when there is no available input or output devices.
     if let Some(unit) = test_create_audiounit(ComponentSubType::HALOutput) {
-        assert!(enable_audiounit_scope(unit.get_inner(), DeviceType::OUTPUT, true).is_ok());
-        assert!(enable_audiounit_scope(unit.get_inner(), DeviceType::OUTPUT, false).is_ok());
-        assert!(enable_audiounit_scope(unit.get_inner(), DeviceType::INPUT, true).is_ok());
-        assert!(enable_audiounit_scope(unit.get_inner(), DeviceType::INPUT, false).is_ok());
+        assert!(run_serially_forward_panics(|| enable_audiounit_scope(
+            unit.get_inner(),
+            DeviceType::OUTPUT,
+            true
+        ))
+        .is_ok());
+        assert!(run_serially_forward_panics(|| enable_audiounit_scope(
+            unit.get_inner(),
+            DeviceType::OUTPUT,
+            false
+        ))
+        .is_ok());
+        assert!(run_serially_forward_panics(|| enable_audiounit_scope(
+            unit.get_inner(),
+            DeviceType::INPUT,
+            true
+        ))
+        .is_ok());
+        assert!(run_serially_forward_panics(|| enable_audiounit_scope(
+            unit.get_inner(),
+            DeviceType::INPUT,
+            false
+        ))
+        .is_ok());
     } else {
         println!("No audiounit to perform test.");
     }
@@ -828,19 +863,23 @@ fn test_enable_audiounit_scope() {
 fn test_enable_audiounit_scope_for_default_output_unit() {
     if let Some(unit) = test_create_audiounit(ComponentSubType::DefaultOutput) {
         assert_eq!(
-            enable_audiounit_scope(unit.get_inner(), DeviceType::OUTPUT, true).unwrap_err(),
+            run_serially(|| enable_audiounit_scope(unit.get_inner(), DeviceType::OUTPUT, true))
+                .unwrap_err(),
             kAudioUnitErr_InvalidProperty
         );
         assert_eq!(
-            enable_audiounit_scope(unit.get_inner(), DeviceType::OUTPUT, false).unwrap_err(),
+            run_serially(|| enable_audiounit_scope(unit.get_inner(), DeviceType::OUTPUT, false))
+                .unwrap_err(),
             kAudioUnitErr_InvalidProperty
         );
         assert_eq!(
-            enable_audiounit_scope(unit.get_inner(), DeviceType::INPUT, true).unwrap_err(),
+            run_serially(|| enable_audiounit_scope(unit.get_inner(), DeviceType::INPUT, true))
+                .unwrap_err(),
             kAudioUnitErr_InvalidProperty
         );
         assert_eq!(
-            enable_audiounit_scope(unit.get_inner(), DeviceType::INPUT, false).unwrap_err(),
+            run_serially(|| enable_audiounit_scope(unit.get_inner(), DeviceType::INPUT, false))
+                .unwrap_err(),
             kAudioUnitErr_InvalidProperty
         );
     }
@@ -850,7 +889,10 @@ fn test_enable_audiounit_scope_for_default_output_unit() {
 #[should_panic]
 fn test_enable_audiounit_scope_with_null_unit() {
     let unit: AudioUnit = ptr::null_mut();
-    assert!(enable_audiounit_scope(unit, DeviceType::INPUT, false).is_err());
+    assert!(
+        run_serially_forward_panics(|| enable_audiounit_scope(unit, DeviceType::INPUT, false))
+            .is_err()
+    );
 }
 
 // create_audiounit
@@ -900,7 +942,7 @@ fn test_for_create_audiounit() {
 #[should_panic]
 fn test_create_audiounit_with_unknown_scope() {
     let device = device_info::default();
-    let _unit = create_audiounit(&device);
+    let _unit = run_serially_forward_panics(|| create_audiounit(&device));
 }
 
 // set_buffer_size_sync
@@ -928,9 +970,12 @@ fn test_set_buffer_size_sync() {
         .unwrap();
         assert_ne!(buffer_frames, 0);
         buffer_frames *= 2;
-        assert!(
-            set_buffer_size_sync(unit.get_inner(), scope.clone().into(), buffer_frames).is_ok()
-        );
+        assert!(run_serially(|| set_buffer_size_sync(
+            unit.get_inner(),
+            scope.clone().into(),
+            buffer_frames
+        ))
+        .is_ok());
         let new_buffer_frames =
             test_audiounit_get_buffer_frame_size(unit.get_inner(), scope.clone(), prop_scope)
                 .unwrap();
@@ -952,7 +997,9 @@ fn test_set_buffer_size_sync_for_output_with_null_output_unit() {
 
 fn test_set_buffer_size_sync_by_scope_with_null_unit(scope: Scope) {
     let unit: AudioUnit = ptr::null_mut();
-    assert!(set_buffer_size_sync(unit, scope.into(), 2048).is_err());
+    assert!(
+        run_serially_forward_panics(|| set_buffer_size_sync(unit, scope.into(), 2048)).is_err()
+    );
 }
 
 // get_volume, set_volume
@@ -961,8 +1008,11 @@ fn test_set_buffer_size_sync_by_scope_with_null_unit(scope: Scope) {
 fn test_stream_get_volume() {
     if let Some(unit) = test_get_default_audiounit(Scope::Output) {
         let expected_volume: f32 = 0.5;
-        set_volume(unit.get_inner(), expected_volume);
-        assert_eq!(expected_volume, get_volume(unit.get_inner()).unwrap());
+        run_serially(|| set_volume(unit.get_inner(), expected_volume));
+        assert_eq!(
+            expected_volume,
+            run_serially(|| get_volume(unit.get_inner()).unwrap())
+        );
     } else {
         println!("No output audiounit.");
     }
@@ -989,7 +1039,9 @@ fn test_get_channel_count() {
 
     fn test_channel_count(scope: Scope) {
         if let Some(device) = test_get_default_device(scope.clone()) {
-            let channels = get_channel_count(device, DeviceType::from(scope.clone())).unwrap();
+            let channels =
+                run_serially(|| get_channel_count(device, DeviceType::from(scope.clone())))
+                    .unwrap();
             assert!(channels > 0);
             assert_eq!(
                 channels,
@@ -1009,7 +1061,7 @@ fn test_get_channel_count_of_input_for_a_output_only_deivce() {
         if test_device_in_scope(device, Scope::Input) {
             continue;
         }
-        let count = get_channel_count(device, DeviceType::INPUT).unwrap();
+        let count = run_serially(|| get_channel_count(device, DeviceType::INPUT)).unwrap();
         assert_eq!(count, 0);
     }
 }
@@ -1022,7 +1074,7 @@ fn test_get_channel_count_of_output_for_a_input_only_deivce() {
         if test_device_in_scope(device, Scope::Output) {
             continue;
         }
-        let count = get_channel_count(device, DeviceType::OUTPUT).unwrap();
+        let count = run_serially(|| get_channel_count(device, DeviceType::OUTPUT)).unwrap();
         assert_eq!(count, 0);
     }
 }
@@ -1030,7 +1082,11 @@ fn test_get_channel_count_of_output_for_a_input_only_deivce() {
 #[test]
 #[should_panic]
 fn test_get_channel_count_of_unknown_device() {
-    assert!(get_channel_count(kAudioObjectUnknown, DeviceType::OUTPUT).is_err());
+    assert!(run_serially_forward_panics(|| get_channel_count(
+        kAudioObjectUnknown,
+        DeviceType::OUTPUT
+    ))
+    .is_err());
 }
 
 #[test]
@@ -1040,14 +1096,16 @@ fn test_get_channel_count_of_inout_type() {
 
     fn test_channel_count(scope: Scope) {
         if let Some(device) = test_get_default_device(scope.clone()) {
-            assert_eq!(
-                get_channel_count(device, DeviceType::INPUT | DeviceType::OUTPUT),
-                get_channel_count(device, DeviceType::INPUT).map(|c| c + get_channel_count(
-                    device,
-                    DeviceType::OUTPUT
-                )
-                .unwrap_or(0))
-            );
+            run_serially_forward_panics(|| {
+                assert_eq!(
+                    get_channel_count(device, DeviceType::INPUT | DeviceType::OUTPUT),
+                    get_channel_count(device, DeviceType::INPUT).map(|c| c + get_channel_count(
+                        device,
+                        DeviceType::OUTPUT
+                    )
+                    .unwrap_or(0))
+                );
+            });
         } else {
             println!("No device for {:?}.", scope);
         }
@@ -1096,7 +1154,9 @@ fn test_get_range_of_sample_rates() {
         ];
         let mut ranges = Vec::new();
         for scope in scopes.iter() {
-            ranges.push(get_range_of_sample_rates(id, *scope).unwrap());
+            ranges.push(
+                run_serially_forward_panics(|| get_range_of_sample_rates(id, *scope)).unwrap(),
+            );
         }
         ranges
     }
@@ -1118,7 +1178,7 @@ fn test_get_device_presentation_latency() {
     fn test_get_device_presentation_latencies_in_scope(scope: Scope) {
         if let Some(device) = test_get_default_device(scope.clone()) {
             // TODO: The latencies very from devices to devices. Check nothing here.
-            let latency = get_fixed_latency(device, scope.clone().into());
+            let latency = run_serially(|| get_fixed_latency(device, scope.clone().into()));
             println!(
                 "present latency on the device {} in scope {:?}: {}",
                 device, scope, latency
@@ -1134,7 +1194,7 @@ fn test_get_device_presentation_latency() {
 #[test]
 fn test_get_device_group_id() {
     if let Some(device) = test_get_default_device(Scope::Input) {
-        match get_device_group_id(device, DeviceType::INPUT) {
+        match run_serially(|| get_device_group_id(device, DeviceType::INPUT)) {
             Ok(id) => println!("input group id: {:?}", id),
             Err(e) => println!("No input group id. Error: {}", e),
         }
@@ -1143,7 +1203,7 @@ fn test_get_device_group_id() {
     }
 
     if let Some(device) = test_get_default_device(Scope::Output) {
-        match get_device_group_id(device, DeviceType::OUTPUT) {
+        match run_serially(|| get_device_group_id(device, DeviceType::OUTPUT)) {
             Ok(id) => println!("output group id: {:?}", id),
             Err(e) => println!("No output group id. Error: {}", e),
         }
@@ -1166,8 +1226,8 @@ fn test_get_same_group_id_for_builtin_device_pairs() {
     let mut input_group_ids = HashMap::<u32, String>::new();
     let input_devices = test_get_devices_in_scope(Scope::Input);
     for device in input_devices.iter() {
-        match get_device_source(*device, DeviceType::INPUT) {
-            Ok(source) => match get_device_group_id(*device, DeviceType::INPUT) {
+        match run_serially(|| get_device_source(*device, DeviceType::INPUT)) {
+            Ok(source) => match run_serially(|| get_device_group_id(*device, DeviceType::INPUT)) {
                 Ok(id) => assert!(input_group_ids
                     .insert(source, id.into_string().unwrap())
                     .is_none()),
@@ -1182,8 +1242,8 @@ fn test_get_same_group_id_for_builtin_device_pairs() {
     let mut output_group_ids = HashMap::<u32, String>::new();
     let output_devices = test_get_devices_in_scope(Scope::Output);
     for device in output_devices.iter() {
-        match get_device_source(*device, DeviceType::OUTPUT) {
-            Ok(source) => match get_device_group_id(*device, DeviceType::OUTPUT) {
+        match run_serially(|| get_device_source(*device, DeviceType::OUTPUT)) {
+            Ok(source) => match run_serially(|| get_device_group_id(*device, DeviceType::OUTPUT)) {
                 Ok(id) => assert!(output_group_ids
                     .insert(source, id.into_string().unwrap())
                     .is_none()),
@@ -1211,7 +1271,11 @@ fn test_get_same_group_id_for_builtin_device_pairs() {
 #[test]
 #[should_panic]
 fn test_get_device_group_id_by_unknown_device() {
-    assert!(get_device_group_id(kAudioObjectUnknown, DeviceType::INPUT).is_err());
+    assert!(run_serially_forward_panics(|| get_device_group_id(
+        kAudioObjectUnknown,
+        DeviceType::INPUT
+    ))
+    .is_err());
 }
 
 // get_device_label
@@ -1219,14 +1283,14 @@ fn test_get_device_group_id_by_unknown_device() {
 #[test]
 fn test_get_device_label() {
     if let Some(device) = test_get_default_device(Scope::Input) {
-        let name = get_device_label(device, DeviceType::INPUT).unwrap();
+        let name = run_serially(|| get_device_label(device, DeviceType::INPUT)).unwrap();
         println!("input device label: {}", name.into_string());
     } else {
         println!("No input device.");
     }
 
     if let Some(device) = test_get_default_device(Scope::Output) {
-        let name = get_device_label(device, DeviceType::OUTPUT).unwrap();
+        let name = run_serially(|| get_device_label(device, DeviceType::OUTPUT)).unwrap();
         println!("output device label: {}", name.into_string());
     } else {
         println!("No output device.");
@@ -1236,7 +1300,11 @@ fn test_get_device_label() {
 #[test]
 #[should_panic]
 fn test_get_device_label_by_unknown_device() {
-    assert!(get_device_label(kAudioObjectUnknown, DeviceType::INPUT).is_err());
+    assert!(run_serially_forward_panics(|| get_device_label(
+        kAudioObjectUnknown,
+        DeviceType::INPUT
+    ))
+    .is_err());
 }
 
 // get_device_global_uid
@@ -1245,14 +1313,14 @@ fn test_get_device_label_by_unknown_device() {
 fn test_get_device_global_uid() {
     // Input device.
     if let Some(input) = test_get_default_device(Scope::Input) {
-        let uid = get_device_global_uid(input).unwrap();
+        let uid = run_serially(|| get_device_global_uid(input)).unwrap();
         let uid = uid.into_string();
         assert!(!uid.is_empty());
     }
 
     // Output device.
     if let Some(output) = test_get_default_device(Scope::Output) {
-        let uid = get_device_global_uid(output).unwrap();
+        let uid = run_serially(|| get_device_global_uid(output)).unwrap();
         let uid = uid.into_string();
         assert!(!uid.is_empty());
     }
@@ -1286,7 +1354,7 @@ fn test_create_cubeb_device_info() {
             if is_input {
                 let mut input_device_info = input_result.unwrap();
                 check_device_info_by_device(&input_device_info, device, Scope::Input);
-                destroy_cubeb_device_info(&mut input_device_info);
+                run_serially(|| destroy_cubeb_device_info(&mut input_device_info));
             } else {
                 assert_eq!(input_result.unwrap_err(), Error::error());
             }
@@ -1295,7 +1363,7 @@ fn test_create_cubeb_device_info() {
             if is_output {
                 let mut output_device_info = output_result.unwrap();
                 check_device_info_by_device(&output_device_info, device, Scope::Output);
-                destroy_cubeb_device_info(&mut output_device_info);
+                run_serially(|| destroy_cubeb_device_info(&mut output_device_info));
             } else {
                 assert_eq!(output_result.unwrap_err(), Error::error());
             }
@@ -1310,7 +1378,7 @@ fn test_create_cubeb_device_info() {
         let dev_types = [DeviceType::INPUT, DeviceType::OUTPUT];
         let mut results = VecDeque::new();
         for dev_type in dev_types.iter() {
-            results.push_back(create_cubeb_device_info(id, *dev_type));
+            results.push_back(run_serially(|| create_cubeb_device_info(id, *dev_type)));
         }
         results
     }
@@ -1370,7 +1438,9 @@ fn test_create_device_info_with_unknown_type() {
 
     fn test_create_device_info_with_unknown_type_by_scope(scope: Scope) {
         if let Some(device) = test_get_default_device(scope.clone()) {
-            assert!(create_cubeb_device_info(device, DeviceType::UNKNOWN).is_err());
+            assert!(
+                run_serially(|| create_cubeb_device_info(device, DeviceType::UNKNOWN)).is_err()
+            );
         }
     }
 }
@@ -1402,9 +1472,11 @@ fn test_create_device_from_hwdev_with_inout_type() {
     fn test_create_device_from_hwdev_with_inout_type_by_scope(scope: Scope) {
         if let Some(device) = test_get_default_device(scope.clone()) {
             // Get a kAudioHardwareUnknownPropertyError in get_channel_count actually.
-            assert!(
-                create_cubeb_device_info(device, DeviceType::INPUT | DeviceType::OUTPUT).is_err()
-            );
+            assert!(run_serially(|| create_cubeb_device_info(
+                device,
+                DeviceType::INPUT | DeviceType::OUTPUT
+            ))
+            .is_err());
         } else {
             println!("No device for {:?}.", scope);
         }
@@ -1417,9 +1489,10 @@ fn test_create_device_from_hwdev_with_inout_type() {
 fn test_get_devices_of_type() {
     use std::collections::HashSet;
 
-    let all_devices = audiounit_get_devices_of_type(DeviceType::INPUT | DeviceType::OUTPUT);
-    let input_devices = audiounit_get_devices_of_type(DeviceType::INPUT);
-    let output_devices = audiounit_get_devices_of_type(DeviceType::OUTPUT);
+    let all_devices =
+        run_serially(|| audiounit_get_devices_of_type(DeviceType::INPUT | DeviceType::OUTPUT));
+    let input_devices = run_serially(|| audiounit_get_devices_of_type(DeviceType::INPUT));
+    let output_devices = run_serially(|| audiounit_get_devices_of_type(DeviceType::OUTPUT));
 
     let mut expected_all = test_get_all_devices(DeviceFilter::ExcludeCubebAggregateAndVPIO);
     expected_all.sort();
@@ -1444,8 +1517,10 @@ fn test_get_devices_of_type() {
 #[test]
 #[should_panic]
 fn test_get_devices_of_type_unknown() {
-    let no_devs = audiounit_get_devices_of_type(DeviceType::UNKNOWN);
-    assert!(no_devs.is_empty());
+    run_serially_forward_panics(|| {
+        let no_devs = audiounit_get_devices_of_type(DeviceType::UNKNOWN);
+        assert!(no_devs.is_empty());
+    });
 }
 
 // add_devices_changed_listener
@@ -1469,9 +1544,10 @@ fn test_add_devices_changed_listener() {
             assert!(get_devices_changed_callback(context, Scope::Output).is_none());
 
             // Register a callback within a specific scope.
-            assert!(context
-                .add_devices_changed_listener(*devtype, Some(*callback), ptr::null_mut())
-                .is_ok());
+            assert!(run_serially(|| {
+                context.add_devices_changed_listener(*devtype, Some(*callback), ptr::null_mut())
+            })
+            .is_ok());
 
             if devtype.contains(DeviceType::INPUT) {
                 let cb = get_devices_changed_callback(context, Scope::Input);
@@ -1492,9 +1568,10 @@ fn test_add_devices_changed_listener() {
             }
 
             // Unregister the callbacks within all scopes.
-            assert!(context
-                .remove_devices_changed_listener(DeviceType::INPUT | DeviceType::OUTPUT)
-                .is_ok());
+            assert!(run_serially(|| {
+                context.remove_devices_changed_listener(DeviceType::INPUT | DeviceType::OUTPUT)
+            })
+            .is_ok());
 
             assert!(get_devices_changed_callback(context, Scope::Input).is_none());
             assert!(get_devices_changed_callback(context, Scope::Output).is_none());
@@ -1548,9 +1625,12 @@ fn test_remove_devices_changed_listener() {
 
             // Register callbacks within all scopes.
             for (scope, listener) in map.iter() {
-                assert!(context
-                    .add_devices_changed_listener(*scope, Some(*listener), ptr::null_mut())
-                    .is_ok());
+                assert!(run_serially(|| context.add_devices_changed_listener(
+                    *scope,
+                    Some(*listener),
+                    ptr::null_mut()
+                ))
+                .is_ok());
             }
 
             let input_callback = get_devices_changed_callback(context, Scope::Input);
@@ -1567,7 +1647,7 @@ fn test_remove_devices_changed_listener() {
             );
 
             // Unregister the callbacks within one specific scopes.
-            assert!(context.remove_devices_changed_listener(*devtype).is_ok());
+            assert!(run_serially(|| context.remove_devices_changed_listener(*devtype)).is_ok());
 
             if devtype.contains(DeviceType::INPUT) {
                 let cb = get_devices_changed_callback(context, Scope::Input);
@@ -1588,9 +1668,10 @@ fn test_remove_devices_changed_listener() {
             }
 
             // Unregister the callbacks within all scopes.
-            assert!(context
-                .remove_devices_changed_listener(DeviceType::INPUT | DeviceType::OUTPUT)
-                .is_ok());
+            assert!(run_serially(
+                || context.remove_devices_changed_listener(DeviceType::INPUT | DeviceType::OUTPUT)
+            )
+            .is_ok());
         }
     });
 }
@@ -1603,7 +1684,7 @@ fn test_remove_devices_changed_listener_without_adding_listeners() {
             DeviceType::OUTPUT,
             DeviceType::INPUT | DeviceType::OUTPUT,
         ] {
-            assert!(context.remove_devices_changed_listener(*devtype).is_ok());
+            assert!(run_serially(|| context.remove_devices_changed_listener(*devtype)).is_ok());
         }
     });
 }
@@ -1626,9 +1707,12 @@ fn test_remove_devices_changed_listener_within_all_scopes() {
             assert!(get_devices_changed_callback(context, Scope::Input).is_none());
             assert!(get_devices_changed_callback(context, Scope::Output).is_none());
 
-            assert!(context
-                .add_devices_changed_listener(*devtype, Some(*callback), ptr::null_mut())
-                .is_ok());
+            assert!(run_serially(|| context.add_devices_changed_listener(
+                *devtype,
+                Some(*callback),
+                ptr::null_mut()
+            ))
+            .is_ok());
 
             if devtype.contains(DeviceType::INPUT) {
                 let cb = get_devices_changed_callback(context, Scope::Input);
@@ -1642,9 +1726,10 @@ fn test_remove_devices_changed_listener_within_all_scopes() {
                 assert_eq!(cb.unwrap(), *callback);
             }
 
-            assert!(context
-                .remove_devices_changed_listener(DeviceType::INPUT | DeviceType::OUTPUT)
-                .is_ok());
+            assert!(run_serially(
+                || context.remove_devices_changed_listener(DeviceType::INPUT | DeviceType::OUTPUT)
+            )
+            .is_ok());
 
             assert!(get_devices_changed_callback(context, Scope::Input).is_none());
             assert!(get_devices_changed_callback(context, Scope::Output).is_none());

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -869,29 +869,29 @@ fn test_for_create_audiounit() {
         // Check the output scope is enabled.
         if device.flags.contains(device_flags::DEV_OUTPUT) && default_output.is_some() {
             device.id = default_output.unwrap();
-            let unit = create_audiounit(&device).unwrap();
+            let unit = run_serially(|| create_audiounit(&device).unwrap());
             assert!(!unit.is_null());
             assert!(test_audiounit_scope_is_enabled(unit, Scope::Output));
 
             // Destroy the AudioUnit.
-            unsafe {
+            run_serially(|| unsafe {
                 AudioUnitUninitialize(unit);
                 AudioComponentInstanceDispose(unit);
-            }
+            });
         }
 
         // Check the input scope is enabled.
         if device.flags.contains(device_flags::DEV_INPUT) && default_input.is_some() {
             let device_id = default_input.unwrap();
             device.id = device_id;
-            let unit = create_audiounit(&device).unwrap();
+            let unit = run_serially(|| create_audiounit(&device).unwrap());
             assert!(!unit.is_null());
             assert!(test_audiounit_scope_is_enabled(unit, Scope::Input));
             // Destroy the AudioUnit.
-            unsafe {
+            run_serially(|| unsafe {
                 AudioUnitUninitialize(unit);
                 AudioComponentInstanceDispose(unit);
-            }
+            });
         }
     }
 }

--- a/src/backend/tests/device_change.rs
+++ b/src/backend/tests/device_change.rs
@@ -711,7 +711,7 @@ fn test_unplug_a_device_on_an_active_stream(
         state_callback,
         device_changed_callback,
         |stream| {
-            stream.start();
+            assert_eq!(stream.start(), Ok(()));
 
             let changed_watcher = Watcher::new(&notifier);
             let mut data_guard = notifier.lock().unwrap();

--- a/src/backend/tests/device_change.rs
+++ b/src/backend/tests/device_change.rs
@@ -49,13 +49,15 @@ fn test_switch_device_in_scope(scope: Scope) {
 
     let notifier = Arc::new(Notifier::new(0));
     let also_notifier = notifier.clone();
-    let listener = test_create_device_change_listener(scope.clone(), move |_addresses| {
-        let mut cnt = notifier.lock().unwrap();
-        *cnt += 1;
-        notifier.notify(cnt);
-        NO_ERR
+    let listener = run_serially(|| {
+        test_create_device_change_listener(scope.clone(), move |_addresses| {
+            let mut cnt = notifier.lock().unwrap();
+            *cnt += 1;
+            notifier.notify(cnt);
+            NO_ERR
+        })
     });
-    listener.start();
+    run_serially(|| listener.start());
 
     let changed_watcher = Watcher::new(&also_notifier);
     test_get_started_stream_in_scope(scope.clone(), move |_stream| loop {

--- a/src/backend/tests/device_property.rs
+++ b/src/backend/tests/device_property.rs
@@ -7,14 +7,14 @@ use super::*;
 fn test_get_device_uid() {
     // Input device.
     if let Some(input) = test_get_default_device(Scope::Input) {
-        let uid = get_device_uid(input, DeviceType::INPUT).unwrap();
+        let uid = run_serially(|| get_device_uid(input, DeviceType::INPUT)).unwrap();
         let uid = uid.into_string();
         assert!(!uid.is_empty());
     }
 
     // Output device.
     if let Some(output) = test_get_default_device(Scope::Output) {
-        let uid = get_device_uid(output, DeviceType::OUTPUT).unwrap();
+        let uid = run_serially(|| get_device_uid(output, DeviceType::OUTPUT)).unwrap();
         let uid = uid.into_string();
         assert!(!uid.is_empty());
     }
@@ -24,7 +24,10 @@ fn test_get_device_uid() {
 #[should_panic]
 fn test_get_device_uid_by_unknwon_device() {
     // Unknown device.
-    assert!(get_device_uid(kAudioObjectUnknown, DeviceType::INPUT).is_err());
+    assert!(
+        run_serially_forward_panics(|| get_device_uid(kAudioObjectUnknown, DeviceType::INPUT))
+            .is_err()
+    );
 }
 
 // get_device_model_uid
@@ -33,7 +36,7 @@ fn test_get_device_uid_by_unknwon_device() {
 #[test]
 fn test_get_device_model_uid() {
     if let Some(device) = test_get_default_device(Scope::Input) {
-        match get_device_model_uid(device, DeviceType::INPUT) {
+        match run_serially(|| get_device_model_uid(device, DeviceType::INPUT)) {
             Ok(uid) => println!("input model uid: {}", uid.into_string()),
             Err(e) => println!("No input model uid. Error: {}", e),
         }
@@ -42,7 +45,7 @@ fn test_get_device_model_uid() {
     }
 
     if let Some(device) = test_get_default_device(Scope::Output) {
-        match get_device_model_uid(device, DeviceType::OUTPUT) {
+        match run_serially(|| get_device_model_uid(device, DeviceType::OUTPUT)) {
             Ok(uid) => println!("output model uid: {}", uid.into_string()),
             Err(e) => println!("No output model uid. Error: {}", e),
         }
@@ -54,7 +57,11 @@ fn test_get_device_model_uid() {
 #[test]
 #[should_panic]
 fn test_get_device_model_uid_by_unknown_device() {
-    assert!(get_device_model_uid(kAudioObjectUnknown, DeviceType::INPUT).is_err());
+    assert!(run_serially_forward_panics(|| get_device_model_uid(
+        kAudioObjectUnknown,
+        DeviceType::INPUT
+    ))
+    .is_err());
 }
 
 // get_device_transport_type
@@ -62,7 +69,7 @@ fn test_get_device_model_uid_by_unknown_device() {
 #[test]
 fn test_get_device_transport_type() {
     if let Some(device) = test_get_default_device(Scope::Input) {
-        match get_device_transport_type(device, DeviceType::INPUT) {
+        match run_serially(|| get_device_transport_type(device, DeviceType::INPUT)) {
             Ok(trans_type) => println!(
                 "input transport type: {:X}, {:?}",
                 trans_type,
@@ -75,7 +82,7 @@ fn test_get_device_transport_type() {
     }
 
     if let Some(device) = test_get_default_device(Scope::Output) {
-        match get_device_transport_type(device, DeviceType::OUTPUT) {
+        match run_serially(|| get_device_transport_type(device, DeviceType::OUTPUT)) {
             Ok(trans_type) => println!(
                 "output transport type: {:X}, {:?}",
                 trans_type,
@@ -91,7 +98,11 @@ fn test_get_device_transport_type() {
 #[test]
 #[should_panic]
 fn test_get_device_transport_type_by_unknown_device() {
-    assert!(get_device_transport_type(kAudioObjectUnknown, DeviceType::INPUT).is_err());
+    assert!(run_serially_forward_panics(|| get_device_transport_type(
+        kAudioObjectUnknown,
+        DeviceType::INPUT
+    ))
+    .is_err());
 }
 
 // get_device_source
@@ -100,7 +111,7 @@ fn test_get_device_transport_type_by_unknown_device() {
 #[test]
 fn test_get_device_source() {
     if let Some(device) = test_get_default_device(Scope::Input) {
-        match get_device_source(device, DeviceType::INPUT) {
+        match run_serially(|| get_device_source(device, DeviceType::INPUT)) {
             Ok(source) => println!(
                 "input source: {:X}, {:?}",
                 source,
@@ -113,7 +124,7 @@ fn test_get_device_source() {
     }
 
     if let Some(device) = test_get_default_device(Scope::Output) {
-        match get_device_source(device, DeviceType::OUTPUT) {
+        match run_serially(|| get_device_source(device, DeviceType::OUTPUT)) {
             Ok(source) => println!(
                 "output source: {:X}, {:?}",
                 source,
@@ -129,7 +140,11 @@ fn test_get_device_source() {
 #[test]
 #[should_panic]
 fn test_get_device_source_by_unknown_device() {
-    assert!(get_device_source(kAudioObjectUnknown, DeviceType::INPUT).is_err());
+    assert!(run_serially_forward_panics(|| get_device_source(
+        kAudioObjectUnknown,
+        DeviceType::INPUT
+    ))
+    .is_err());
 }
 
 // get_device_source_name
@@ -137,7 +152,7 @@ fn test_get_device_source_by_unknown_device() {
 #[test]
 fn test_get_device_source_name() {
     if let Some(device) = test_get_default_device(Scope::Input) {
-        match get_device_source_name(device, DeviceType::INPUT) {
+        match run_serially(|| get_device_source_name(device, DeviceType::INPUT)) {
             Ok(name) => println!("input: {}", name.into_string()),
             Err(e) => println!("No input data source name. Error: {}", e),
         }
@@ -146,7 +161,7 @@ fn test_get_device_source_name() {
     }
 
     if let Some(device) = test_get_default_device(Scope::Output) {
-        match get_device_source_name(device, DeviceType::OUTPUT) {
+        match run_serially(|| get_device_source_name(device, DeviceType::OUTPUT)) {
             Ok(name) => println!("output: {}", name.into_string()),
             Err(e) => println!("No output data source name. Error: {}", e),
         }
@@ -158,7 +173,11 @@ fn test_get_device_source_name() {
 #[test]
 #[should_panic]
 fn test_get_device_source_name_by_unknown_device() {
-    assert!(get_device_source_name(kAudioObjectUnknown, DeviceType::INPUT).is_err());
+    assert!(run_serially_forward_panics(|| get_device_source_name(
+        kAudioObjectUnknown,
+        DeviceType::INPUT
+    ))
+    .is_err());
 }
 
 // get_device_name
@@ -166,14 +185,14 @@ fn test_get_device_source_name_by_unknown_device() {
 #[test]
 fn test_get_device_name() {
     if let Some(device) = test_get_default_device(Scope::Input) {
-        let name = get_device_name(device, DeviceType::INPUT).unwrap();
+        let name = run_serially(|| get_device_name(device, DeviceType::INPUT)).unwrap();
         println!("input device name: {}", name.into_string());
     } else {
         println!("No input device.");
     }
 
     if let Some(device) = test_get_default_device(Scope::Output) {
-        let name = get_device_name(device, DeviceType::OUTPUT).unwrap();
+        let name = run_serially(|| get_device_name(device, DeviceType::OUTPUT).unwrap());
         println!("output device name: {}", name.into_string());
     } else {
         println!("No output device.");
@@ -183,7 +202,11 @@ fn test_get_device_name() {
 #[test]
 #[should_panic]
 fn test_get_device_name_by_unknown_device() {
-    assert!(get_device_name(kAudioObjectUnknown, DeviceType::INPUT).is_err());
+    assert!(run_serially_forward_panics(|| get_device_name(
+        kAudioObjectUnknown,
+        DeviceType::INPUT
+    ))
+    .is_err());
 }
 
 // get_device_manufacturer
@@ -193,7 +216,7 @@ fn test_get_device_manufacturer() {
     if let Some(device) = test_get_default_device(Scope::Input) {
         // Some devices like AirPods cannot get the vendor info so we print the error directly.
         // TODO: Replace `map` and `unwrap_or_else` by `map_or_else`
-        let name = get_device_manufacturer(device, DeviceType::INPUT)
+        let name = run_serially(|| get_device_manufacturer(device, DeviceType::INPUT))
             .map(|name| name.into_string())
             .unwrap_or_else(|e| format!("Error: {}", e));
         println!("input device vendor: {}", name);
@@ -204,9 +227,10 @@ fn test_get_device_manufacturer() {
     if let Some(device) = test_get_default_device(Scope::Output) {
         // Some devices like AirPods cannot get the vendor info so we print the error directly.
         // TODO: Replace `map` and `unwrap_or_else` by `map_or_else`
-        let name = get_device_manufacturer(device, DeviceType::OUTPUT)
-            .map(|name| name.into_string())
-            .unwrap_or_else(|e| format!("Error: {}", e));
+        let name =
+            run_serially_forward_panics(|| get_device_manufacturer(device, DeviceType::OUTPUT))
+                .map(|name| name.into_string())
+                .unwrap_or_else(|e| format!("Error: {}", e));
         println!("output device vendor: {}", name);
     } else {
         println!("No output device.");
@@ -216,7 +240,11 @@ fn test_get_device_manufacturer() {
 #[test]
 #[should_panic]
 fn test_get_device_manufacturer_by_unknown_device() {
-    assert!(get_device_manufacturer(kAudioObjectUnknown, DeviceType::INPUT).is_err());
+    assert!(run_serially_forward_panics(|| get_device_manufacturer(
+        kAudioObjectUnknown,
+        DeviceType::INPUT
+    ))
+    .is_err());
 }
 
 // get_device_buffer_frame_size_range
@@ -224,7 +252,8 @@ fn test_get_device_manufacturer_by_unknown_device() {
 #[test]
 fn test_get_device_buffer_frame_size_range() {
     if let Some(device) = test_get_default_device(Scope::Input) {
-        let range = get_device_buffer_frame_size_range(device, DeviceType::INPUT).unwrap();
+        let range =
+            run_serially(|| get_device_buffer_frame_size_range(device, DeviceType::INPUT)).unwrap();
         println!(
             "range of input buffer frame size: {}-{}",
             range.mMinimum, range.mMaximum
@@ -234,7 +263,8 @@ fn test_get_device_buffer_frame_size_range() {
     }
 
     if let Some(device) = test_get_default_device(Scope::Output) {
-        let range = get_device_buffer_frame_size_range(device, DeviceType::OUTPUT).unwrap();
+        let range = run_serially(|| get_device_buffer_frame_size_range(device, DeviceType::OUTPUT))
+            .unwrap();
         println!(
             "range of output buffer frame size: {}-{}",
             range.mMinimum, range.mMaximum
@@ -247,7 +277,13 @@ fn test_get_device_buffer_frame_size_range() {
 #[test]
 #[should_panic]
 fn test_get_device_buffer_frame_size_range_by_unknown_device() {
-    assert!(get_device_buffer_frame_size_range(kAudioObjectUnknown, DeviceType::INPUT).is_err());
+    assert!(
+        run_serially_forward_panics(|| get_device_buffer_frame_size_range(
+            kAudioObjectUnknown,
+            DeviceType::INPUT
+        ))
+        .is_err()
+    );
 }
 
 // get_device_latency
@@ -255,14 +291,14 @@ fn test_get_device_buffer_frame_size_range_by_unknown_device() {
 #[test]
 fn test_get_device_latency() {
     if let Some(device) = test_get_default_device(Scope::Input) {
-        let latency = get_device_latency(device, DeviceType::INPUT).unwrap();
+        let latency = run_serially(|| get_device_latency(device, DeviceType::INPUT)).unwrap();
         println!("latency of input device: {}", latency);
     } else {
         println!("No input device.");
     }
 
     if let Some(device) = test_get_default_device(Scope::Output) {
-        let latency = get_device_latency(device, DeviceType::OUTPUT).unwrap();
+        let latency = run_serially(|| get_device_latency(device, DeviceType::OUTPUT)).unwrap();
         println!("latency of output device: {}", latency);
     } else {
         println!("No output device.");
@@ -272,7 +308,11 @@ fn test_get_device_latency() {
 #[test]
 #[should_panic]
 fn test_get_device_latency_by_unknown_device() {
-    assert!(get_device_latency(kAudioObjectUnknown, DeviceType::INPUT).is_err());
+    assert!(run_serially_forward_panics(|| get_device_latency(
+        kAudioObjectUnknown,
+        DeviceType::INPUT
+    ))
+    .is_err());
 }
 
 // get_device_streams
@@ -280,7 +320,7 @@ fn test_get_device_latency_by_unknown_device() {
 #[test]
 fn test_get_device_streams() {
     if let Some(device) = test_get_default_device(Scope::Input) {
-        let streams = get_device_streams(device, DeviceType::INPUT).unwrap();
+        let streams = run_serially(|| get_device_streams(device, DeviceType::INPUT)).unwrap();
         println!("streams on the input device: {:?}", streams);
         assert!(!streams.is_empty());
     } else {
@@ -288,7 +328,7 @@ fn test_get_device_streams() {
     }
 
     if let Some(device) = test_get_default_device(Scope::Output) {
-        let streams = get_device_streams(device, DeviceType::OUTPUT).unwrap();
+        let streams = run_serially(|| get_device_streams(device, DeviceType::OUTPUT)).unwrap();
         println!("streams on the output device: {:?}", streams);
         assert!(!streams.is_empty());
     } else {
@@ -299,7 +339,11 @@ fn test_get_device_streams() {
 #[test]
 #[should_panic]
 fn test_get_device_streams_by_unknown_device() {
-    assert!(get_device_streams(kAudioObjectUnknown, DeviceType::INPUT).is_err());
+    assert!(run_serially_forward_panics(|| get_device_streams(
+        kAudioObjectUnknown,
+        DeviceType::INPUT
+    ))
+    .is_err());
 }
 
 // get_device_sample_rate
@@ -307,14 +351,14 @@ fn test_get_device_streams_by_unknown_device() {
 #[test]
 fn test_get_device_sample_rate() {
     if let Some(device) = test_get_default_device(Scope::Input) {
-        let rate = get_device_sample_rate(device, DeviceType::INPUT).unwrap();
+        let rate = run_serially(|| get_device_sample_rate(device, DeviceType::INPUT)).unwrap();
         println!("input sample rate: {}", rate);
     } else {
         println!("No input device.");
     }
 
     if let Some(device) = test_get_default_device(Scope::Output) {
-        let rate = get_device_sample_rate(device, DeviceType::OUTPUT).unwrap();
+        let rate = run_serially(|| get_device_sample_rate(device, DeviceType::OUTPUT).unwrap());
         println!("output sample rate: {}", rate);
     } else {
         println!("No output device.");
@@ -324,7 +368,11 @@ fn test_get_device_sample_rate() {
 #[test]
 #[should_panic]
 fn test_get_device_sample_rate_by_unknown_device() {
-    assert!(get_device_sample_rate(kAudioObjectUnknown, DeviceType::INPUT).is_err());
+    assert!(run_serially_forward_panics(|| get_device_sample_rate(
+        kAudioObjectUnknown,
+        DeviceType::INPUT
+    ))
+    .is_err());
 }
 
 // get_ranges_of_device_sample_rate
@@ -332,14 +380,16 @@ fn test_get_device_sample_rate_by_unknown_device() {
 #[test]
 fn test_get_ranges_of_device_sample_rate() {
     if let Some(device) = test_get_default_device(Scope::Input) {
-        let ranges = get_ranges_of_device_sample_rate(device, DeviceType::INPUT).unwrap();
+        let ranges =
+            run_serially(|| get_ranges_of_device_sample_rate(device, DeviceType::INPUT)).unwrap();
         println!("ranges of input sample rate: {:?}", ranges);
     } else {
         println!("No input device.");
     }
 
     if let Some(device) = test_get_default_device(Scope::Output) {
-        let ranges = get_ranges_of_device_sample_rate(device, DeviceType::OUTPUT).unwrap();
+        let ranges =
+            run_serially(|| get_ranges_of_device_sample_rate(device, DeviceType::OUTPUT)).unwrap();
         println!("ranges of output sample rate: {:?}", ranges);
     } else {
         println!("No output device.");
@@ -349,7 +399,13 @@ fn test_get_ranges_of_device_sample_rate() {
 #[test]
 #[should_panic]
 fn test_get_ranges_of_device_sample_rate_by_unknown_device() {
-    assert!(get_ranges_of_device_sample_rate(kAudioObjectUnknown, DeviceType::INPUT).is_err());
+    assert!(
+        run_serially_forward_panics(|| get_ranges_of_device_sample_rate(
+            kAudioObjectUnknown,
+            DeviceType::INPUT
+        ))
+        .is_err()
+    );
 }
 
 // get_stream_latency
@@ -357,9 +413,9 @@ fn test_get_ranges_of_device_sample_rate_by_unknown_device() {
 #[test]
 fn test_get_stream_latency() {
     if let Some(device) = test_get_default_device(Scope::Input) {
-        let streams = get_device_streams(device, DeviceType::INPUT).unwrap();
+        let streams = run_serially(|| get_device_streams(device, DeviceType::INPUT)).unwrap();
         for stream in streams {
-            let latency = get_stream_latency(stream).unwrap();
+            let latency = run_serially(|| get_stream_latency(stream)).unwrap();
             println!("latency of the input stream {} is {}", stream, latency);
         }
     } else {
@@ -367,9 +423,9 @@ fn test_get_stream_latency() {
     }
 
     if let Some(device) = test_get_default_device(Scope::Output) {
-        let streams = get_device_streams(device, DeviceType::OUTPUT).unwrap();
+        let streams = run_serially(|| get_device_streams(device, DeviceType::OUTPUT)).unwrap();
         for stream in streams {
-            let latency = get_stream_latency(stream).unwrap();
+            let latency = run_serially(|| get_stream_latency(stream)).unwrap();
             println!("latency of the output stream {} is {}", stream, latency);
         }
     } else {
@@ -388,10 +444,10 @@ fn test_get_stream_latency_by_unknown_device() {
 #[test]
 fn test_get_stream_virtual_format() {
     if let Some(device) = test_get_default_device(Scope::Input) {
-        let streams = get_device_streams(device, DeviceType::INPUT).unwrap();
+        let streams = run_serially(|| get_device_streams(device, DeviceType::INPUT)).unwrap();
         let formats = streams
             .iter()
-            .map(|s| get_stream_virtual_format(*s))
+            .map(|s| run_serially(|| get_stream_virtual_format(*s)))
             .collect::<Vec<std::result::Result<AudioStreamBasicDescription, OSStatus>>>();
         println!("input stream formats: {:?}", formats);
         assert!(!formats.is_empty());
@@ -400,10 +456,10 @@ fn test_get_stream_virtual_format() {
     }
 
     if let Some(device) = test_get_default_device(Scope::Output) {
-        let streams = get_device_streams(device, DeviceType::OUTPUT).unwrap();
+        let streams = run_serially(|| get_device_streams(device, DeviceType::OUTPUT)).unwrap();
         let formats = streams
             .iter()
-            .map(|s| get_stream_virtual_format(*s))
+            .map(|s| run_serially(|| get_stream_virtual_format(*s)))
             .collect::<Vec<std::result::Result<AudioStreamBasicDescription, OSStatus>>>();
         println!("output stream formats: {:?}", formats);
         assert!(!formats.is_empty());
@@ -415,7 +471,9 @@ fn test_get_stream_virtual_format() {
 #[test]
 #[should_panic]
 fn test_get_stream_virtual_format_by_unknown_stream() {
-    assert!(get_stream_virtual_format(kAudioObjectUnknown).is_err());
+    assert!(
+        run_serially_forward_panics(|| get_stream_virtual_format(kAudioObjectUnknown)).is_err()
+    );
 }
 
 // get_stream_terminal_type
@@ -442,10 +500,12 @@ fn test_get_stream_terminal_type() {
         }
     }
     if let Some(device) = test_get_default_device(Scope::Input) {
-        let streams = get_device_streams(device, DeviceType::INPUT).unwrap();
+        let streams = run_serially(|| get_device_streams(device, DeviceType::INPUT)).unwrap();
         for stream in streams {
             assert_eq!(
-                terminal_type_to_device_type(get_stream_terminal_type(stream).unwrap()),
+                terminal_type_to_device_type(
+                    run_serially(|| get_stream_terminal_type(stream)).unwrap()
+                ),
                 Some(DeviceType::INPUT)
             );
         }
@@ -454,10 +514,12 @@ fn test_get_stream_terminal_type() {
     }
 
     if let Some(device) = test_get_default_device(Scope::Output) {
-        let streams = get_device_streams(device, DeviceType::OUTPUT).unwrap();
+        let streams = run_serially(|| get_device_streams(device, DeviceType::OUTPUT)).unwrap();
         for stream in streams {
             assert_eq!(
-                terminal_type_to_device_type(get_stream_terminal_type(stream).unwrap()),
+                terminal_type_to_device_type(
+                    run_serially(|| get_stream_terminal_type(stream)).unwrap()
+                ),
                 Some(DeviceType::OUTPUT)
             );
         }

--- a/src/backend/tests/device_property.rs
+++ b/src/backend/tests/device_property.rs
@@ -501,28 +501,20 @@ fn test_get_stream_terminal_type() {
     }
     if let Some(device) = test_get_default_device(Scope::Input) {
         let streams = run_serially(|| get_device_streams(device, DeviceType::INPUT)).unwrap();
-        for stream in streams {
-            assert_eq!(
-                terminal_type_to_device_type(
-                    run_serially(|| get_stream_terminal_type(stream)).unwrap()
-                ),
-                Some(DeviceType::INPUT)
-            );
-        }
+        assert!(streams.iter().any(|&s| {
+            terminal_type_to_device_type(run_serially(|| get_stream_terminal_type(s)).unwrap())
+                == Some(DeviceType::INPUT)
+        }));
     } else {
         println!("No input device.");
     }
 
     if let Some(device) = test_get_default_device(Scope::Output) {
         let streams = run_serially(|| get_device_streams(device, DeviceType::OUTPUT)).unwrap();
-        for stream in streams {
-            assert_eq!(
-                terminal_type_to_device_type(
-                    run_serially(|| get_stream_terminal_type(stream)).unwrap()
-                ),
-                Some(DeviceType::OUTPUT)
-            );
-        }
+        assert!(streams.iter().any(|&s| {
+            terminal_type_to_device_type(run_serially(|| get_stream_terminal_type(s)).unwrap())
+                == Some(DeviceType::OUTPUT)
+        }));
     } else {
         println!("No output device.");
     }

--- a/src/backend/tests/interfaces.rs
+++ b/src/backend/tests/interfaces.rs
@@ -1071,6 +1071,82 @@ fn test_ops_duplex_voice_stream_stop() {
 
 #[test]
 #[ignore]
+fn test_ops_timing_sensitive_duplex_voice_stream_with_primer() {
+    test_ops_context_operation("duplex voice stream with primer", |context_ptr| {
+        let ctx = unsafe { &mut *(context_ptr as *mut AudioUnitContext) };
+        let start = Instant::now();
+        let mut d1 = start.elapsed();
+        // First stream doesn't prefer voice, so should be quick. Primes the vpio.
+        test_default_duplex_stream_operation_on_context(
+            "duplex voice stream with primer: primer",
+            context_ptr,
+            |stream| {
+                d1 = start.elapsed();
+                let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+                assert!(!stm.core_stream_data.using_voice_processing_unit());
+            },
+        );
+        ctx.serial_queue.run_sync(|| {});
+        // Primed and ready.
+        let d2 = start.elapsed() - d1;
+        // Second stream uses vpio, allows use of the primed unit.
+        test_default_duplex_voice_stream_operation_on_context(
+            "duplex voice stream with primer: voice",
+            context_ptr,
+            |stream| {
+                let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+                assert!(stm.core_stream_data.using_voice_processing_unit());
+            },
+        );
+        let d3 = start.elapsed() - d2 - d1;
+        // d1 and d3 should both be reasonably quick.
+        assert!(
+            d1 < Duration::from_secs(1),
+            "Failed d1={}s < 1",
+            d1.as_secs_f32()
+        );
+        assert!(
+            d3 < Duration::from_secs(1),
+            "Failed d3={}s < 1",
+            d3.as_secs_f32()
+        );
+        // d2 is the time it took to prime, it should be significantly longer.
+        assert!(
+            d2 > d3 * 2,
+            "Failed d2={}s > d3={}s * 2",
+            d2.as_secs_f32(),
+            d3.as_secs_f32()
+        );
+    });
+}
+
+#[test]
+fn test_ops_duplex_voice_stream_while_priming() {
+    test_ops_context_operation("duplex voice stream while priming", |context_ptr| {
+        // First stream doesn't prefer voice, so should be quick. Primes async the vpio.
+        test_default_duplex_stream_operation_on_context(
+            "duplex voice stream while priming: primer",
+            context_ptr,
+            |stream| {
+                let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+                assert!(!stm.core_stream_data.using_voice_processing_unit());
+            },
+        );
+        // Second stream uses vpio, should wait for the priming to finish,
+        // rather than fail to get vpio.
+        test_default_duplex_voice_stream_operation_on_context(
+            "duplex voice stream while priming: voice",
+            context_ptr,
+            |stream| {
+                let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+                assert!(stm.core_stream_data.using_voice_processing_unit());
+            },
+        );
+    });
+}
+
+#[test]
+#[ignore]
 fn test_ops_timing_sensitive_multiple_duplex_voice_stream_init_and_destroy() {
     test_ops_context_operation("multiple duplex voice streams", |context_ptr| {
         let start = Instant::now();

--- a/src/backend/tests/interfaces.rs
+++ b/src/backend/tests/interfaces.rs
@@ -1044,16 +1044,18 @@ fn test_ops_stereo_input_duplex_stream_stop() {
 
 #[test]
 fn test_ops_duplex_voice_stream_init_and_destroy() {
-    test_default_duplex_voice_stream_operation(
-        "duplex voice stream: init and destroy",
-        |_stream| {},
-    );
+    test_default_duplex_voice_stream_operation("duplex voice stream: init and destroy", |stream| {
+        let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+        assert!(stm.core_stream_data.using_voice_processing_unit());
+    });
 }
 
 #[test]
 fn test_ops_duplex_voice_stream_start() {
     test_default_duplex_voice_stream_operation("duplex voice stream: start", |stream| {
         assert_eq!(unsafe { OPS.stream_start.unwrap()(stream) }, ffi::CUBEB_OK);
+        let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+        assert!(stm.core_stream_data.using_voice_processing_unit());
     });
 }
 
@@ -1061,6 +1063,8 @@ fn test_ops_duplex_voice_stream_start() {
 fn test_ops_duplex_voice_stream_stop() {
     test_default_duplex_voice_stream_operation("duplex voice stream: stop", |stream| {
         assert_eq!(unsafe { OPS.stream_stop.unwrap()(stream) }, ffi::CUBEB_OK);
+        let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+        assert!(stm.core_stream_data.using_voice_processing_unit());
     });
 }
 
@@ -1071,6 +1075,8 @@ fn test_ops_duplex_voice_stream_set_input_mute() {
             unsafe { OPS.stream_set_input_mute.unwrap()(stream, 1) },
             ffi::CUBEB_OK
         );
+        let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+        assert!(stm.core_stream_data.using_voice_processing_unit());
     });
 }
 
@@ -1084,6 +1090,8 @@ fn test_ops_duplex_voice_stream_set_input_mute_before_start() {
                 ffi::CUBEB_OK
             );
             assert_eq!(unsafe { OPS.stream_start.unwrap()(stream) }, ffi::CUBEB_OK);
+            let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+            assert!(stm.core_stream_data.using_voice_processing_unit());
         },
     );
 }
@@ -1101,6 +1109,7 @@ fn test_ops_duplex_voice_stream_set_input_mute_before_start_with_reinit() {
 
             // Hacky cast, but testing this here was simplest for now.
             let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+            assert!(stm.core_stream_data.using_voice_processing_unit());
             stm.reinit_async();
             let queue = stm.queue.clone();
             let mut mute_after_reinit = false;
@@ -1130,6 +1139,8 @@ fn test_ops_duplex_voice_stream_set_input_mute_after_start() {
             unsafe { OPS.stream_set_input_mute.unwrap()(stream, 1) },
             ffi::CUBEB_OK
         );
+        let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+        assert!(stm.core_stream_data.using_voice_processing_unit());
     });
 }
 
@@ -1144,6 +1155,8 @@ fn test_ops_duplex_voice_stream_set_input_processing_params() {
             unsafe { OPS.stream_set_input_processing_params.unwrap()(stream, params) },
             ffi::CUBEB_OK
         );
+        let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+        assert!(stm.core_stream_data.using_voice_processing_unit());
     });
 }
 
@@ -1161,6 +1174,8 @@ fn test_ops_duplex_voice_stream_set_input_processing_params_before_start() {
                 ffi::CUBEB_OK
             );
             assert_eq!(unsafe { OPS.stream_start.unwrap()(stream) }, ffi::CUBEB_OK);
+            let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+            assert!(stm.core_stream_data.using_voice_processing_unit());
         },
     );
 }
@@ -1182,6 +1197,7 @@ fn test_ops_duplex_voice_stream_set_input_processing_params_before_start_with_re
 
             // Hacky cast, but testing this here was simplest for now.
             let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+            assert!(stm.core_stream_data.using_voice_processing_unit());
             stm.reinit_async();
             let queue = stm.queue.clone();
             let mut params_after_reinit: ffi::cubeb_input_processing_params =
@@ -1229,6 +1245,8 @@ fn test_ops_duplex_voice_stream_set_input_processing_params_after_start() {
     test_default_duplex_voice_stream_operation(
         "duplex voice stream: processing after start",
         |stream| {
+            let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+            assert!(stm.core_stream_data.using_voice_processing_unit());
             assert_eq!(unsafe { OPS.stream_start.unwrap()(stream) }, ffi::CUBEB_OK);
             let params: ffi::cubeb_input_processing_params =
                 ffi::CUBEB_INPUT_PROCESSING_PARAM_ECHO_CANCELLATION
@@ -1246,7 +1264,10 @@ fn test_ops_duplex_voice_stream_set_input_processing_params_after_start() {
 fn test_ops_stereo_input_duplex_voice_stream_init_and_destroy() {
     test_stereo_input_duplex_voice_stream_operation(
         "stereo-input duplex voice stream: init and destroy",
-        |_stream| {},
+        |stream| {
+            let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+            assert!(stm.core_stream_data.using_voice_processing_unit());
+        },
     );
 }
 
@@ -1255,6 +1276,8 @@ fn test_ops_stereo_input_duplex_voice_stream_start() {
     test_stereo_input_duplex_voice_stream_operation(
         "stereo-input duplex voice stream: start",
         |stream| {
+            let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+            assert!(stm.core_stream_data.using_voice_processing_unit());
             assert_eq!(unsafe { OPS.stream_start.unwrap()(stream) }, ffi::CUBEB_OK);
         },
     );
@@ -1265,6 +1288,8 @@ fn test_ops_stereo_input_duplex_voice_stream_stop() {
     test_stereo_input_duplex_voice_stream_operation(
         "stereo-input duplex voice stream: stop",
         |stream| {
+            let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+            assert!(stm.core_stream_data.using_voice_processing_unit());
             assert_eq!(unsafe { OPS.stream_stop.unwrap()(stream) }, ffi::CUBEB_OK);
         },
     );

--- a/src/backend/tests/manual.rs
+++ b/src/backend/tests/manual.rs
@@ -337,6 +337,23 @@ fn test_stream_tester() {
                 params.set(InputProcessingParams::ECHO_CANCELLATION, true);
                 params.set(InputProcessingParams::NOISE_SUPPRESSION, true);
             }
+            let mut agc = u32::from(false);
+            let mut size: usize = mem::size_of::<u32>();
+            assert_eq!(
+                audio_unit_get_property(
+                    stm.core_stream_data.input_unit,
+                    kAUVoiceIOProperty_VoiceProcessingEnableAGC,
+                    kAudioUnitScope_Global,
+                    AU_IN_BUS,
+                    &mut agc,
+                    &mut size,
+                ),
+                NO_ERR
+            );
+            assert_eq!(size, mem::size_of::<u32>());
+            if agc == 1 {
+                params.set(InputProcessingParams::AUTOMATIC_GAIN_CONTROL, true);
+            }
         }
         let mut done = false;
         while !done {

--- a/src/backend/tests/manual.rs
+++ b/src/backend/tests/manual.rs
@@ -4,7 +4,6 @@ use super::utils::{
 };
 use super::*;
 use std::io;
-use std::sync::atomic::AtomicBool;
 
 #[ignore]
 #[test]

--- a/src/backend/tests/parallel.rs
+++ b/src/backend/tests/parallel.rs
@@ -537,14 +537,16 @@ fn test_set_buffer_frame_size_in_parallel_in_scope(scope: Scope) {
         units.push(test_get_default_audiounit(scope.clone()).unwrap());
         let unit_value = units.last().unwrap().get_inner() as usize;
         join_handles.push(thread::spawn(move || {
-            let status = audio_unit_set_property(
-                unit_value as AudioUnit,
-                kAudioDevicePropertyBufferFrameSize,
-                unit_scope,
-                unit_element,
-                &latency_frames,
-                mem::size_of::<u32>(),
-            );
+            let status = run_serially(|| {
+                audio_unit_set_property(
+                    unit_value as AudioUnit,
+                    kAudioDevicePropertyBufferFrameSize,
+                    unit_scope,
+                    unit_element,
+                    &latency_frames,
+                    mem::size_of::<u32>(),
+                )
+            });
             (latency_frames, status)
         }));
     }

--- a/src/backend/tests/tone.rs
+++ b/src/backend/tests/tone.rs
@@ -1,6 +1,6 @@
 use super::utils::{test_get_default_device, test_ops_stream_operation, Scope};
 use super::*;
-use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::atomic::AtomicI64;
 
 #[test]
 fn test_dial_tone() {


### PR DESCRIPTION
This set of patches create a singleton dispatch queue that all other dispatch queues (contexts, streams) sit on top of. In practice this means all calls into CoreAudio are serialized, though not necessarily called from the same thread.

This makes the test suite pass locally on macOS 14, and does seem to help somewhat in CI, although TSAN runs still report an issue with VPIO.

There are also some other fixes and cleanups. The PR is best reviewed patch-by-patch.