### PR TITLE
Use a context-global shared VPIO unit

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -40,6 +40,9 @@ cargo clippy -- -D warnings
 # Regular Tests
 cargo test --verbose
 
+# Timing sensitive tests must run serially so they cannot be impacted by other tasks on the queue
+cargo test test_ops_timing_sensitive -- --ignored --test-threads=1
+
 # Parallel Tests
 cargo test test_parallel -- --ignored --nocapture --test-threads=1
 

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1770,6 +1770,17 @@ fn test_shared_voice_processing_unit() {
 }
 
 #[test]
+fn test_shared_voice_processing_unit_after_priming() {
+    let queue = Queue::new_with_target(
+        "test_shared_voice_processing_unit_after_priming",
+        get_serial_queue_singleton(),
+    );
+    let mut shared = SharedVoiceProcessingUnit::new(queue.clone());
+    shared.prime();
+    assert!(queue.run_sync(|| shared.take()).unwrap().is_ok());
+}
+
+#[test]
 #[should_panic]
 fn test_shared_voice_processing_unit_bad_release_order() {
     let queue = Queue::new_with_target(

--- a/src/backend/tests/device_property.rs
+++ b/src/backend/tests/device_property.rs
@@ -501,28 +501,20 @@ fn test_get_stream_terminal_type() {
     }
     if let Some(device) = test_get_default_device(Scope::Input) {
         let streams = run_serially(|| get_device_streams(device, DeviceType::INPUT)).unwrap();
-        for stream in streams {
-            assert_eq!(
-                terminal_type_to_device_type(
-                    run_serially(|| get_stream_terminal_type(stream)).unwrap()
-                ),
-                Some(DeviceType::INPUT)
-            );
-        }
+        assert!(streams.iter().any(|&s| {
+            terminal_type_to_device_type(run_serially(|| get_stream_terminal_type(s)).unwrap())
+                == Some(DeviceType::INPUT)
+        }));
     } else {
         println!("No input device.");
     }
 
     if let Some(device) = test_get_default_device(Scope::Output) {
         let streams = run_serially(|| get_device_streams(device, DeviceType::OUTPUT)).unwrap();
-        for stream in streams {
-            assert_eq!(
-                terminal_type_to_device_type(
-                    run_serially(|| get_stream_terminal_type(stream)).unwrap()
-                ),
-                Some(DeviceType::OUTPUT)
-            );
-        }
+        assert!(streams.iter().any(|&s| {
+            terminal_type_to_device_type(run_serially(|| get_stream_terminal_type(s)).unwrap())
+                == Some(DeviceType::OUTPUT)
+        }));
     } else {
         println!("No output device.");
     }

--- a/src/backend/tests/interfaces.rs
+++ b/src/backend/tests/interfaces.rs
@@ -1071,6 +1071,82 @@ fn test_ops_duplex_voice_stream_stop() {
 
 #[test]
 #[ignore]
+fn test_ops_timing_sensitive_duplex_voice_stream_with_primer() {
+    test_ops_context_operation("duplex voice stream with primer", |context_ptr| {
+        let ctx = unsafe { &mut *(context_ptr as *mut AudioUnitContext) };
+        let start = Instant::now();
+        let mut d1 = start.elapsed();
+        // First stream doesn't prefer voice, so should be quick. Primes the vpio.
+        test_default_duplex_stream_operation_on_context(
+            "duplex voice stream with primer: primer",
+            context_ptr,
+            |stream| {
+                d1 = start.elapsed();
+                let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+                assert!(!stm.core_stream_data.using_voice_processing_unit());
+            },
+        );
+        ctx.serial_queue.run_sync(|| {});
+        // Primed and ready.
+        let d2 = start.elapsed() - d1;
+        // Second stream uses vpio, allows use of the primed unit.
+        test_default_duplex_voice_stream_operation_on_context(
+            "duplex voice stream with primer: voice",
+            context_ptr,
+            |stream| {
+                let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+                assert!(stm.core_stream_data.using_voice_processing_unit());
+            },
+        );
+        let d3 = start.elapsed() - d2 - d1;
+        // d1 and d3 should both be reasonably quick.
+        assert!(
+            d1 < Duration::from_secs(1),
+            "Failed d1={}s < 1",
+            d1.as_secs_f32()
+        );
+        assert!(
+            d3 < Duration::from_secs(1),
+            "Failed d3={}s < 1",
+            d3.as_secs_f32()
+        );
+        // d2 is the time it took to prime, it should be significantly longer.
+        assert!(
+            d2 > d3 * 2,
+            "Failed d2={}s > d3={}s * 2",
+            d2.as_secs_f32(),
+            d3.as_secs_f32()
+        );
+    });
+}
+
+#[test]
+fn test_ops_duplex_voice_stream_while_priming() {
+    test_ops_context_operation("duplex voice stream while priming", |context_ptr| {
+        // First stream doesn't prefer voice, so should be quick. Primes async the vpio.
+        test_default_duplex_stream_operation_on_context(
+            "duplex voice stream while priming: primer",
+            context_ptr,
+            |stream| {
+                let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+                assert!(!stm.core_stream_data.using_voice_processing_unit());
+            },
+        );
+        // Second stream uses vpio, should wait for the priming to finish,
+        // rather than fail to get vpio.
+        test_default_duplex_voice_stream_operation_on_context(
+            "duplex voice stream while priming: voice",
+            context_ptr,
+            |stream| {
+                let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+                assert!(stm.core_stream_data.using_voice_processing_unit());
+            },
+        );
+    });
+}
+
+#[test]
+#[ignore]
 fn test_ops_timing_sensitive_multiple_duplex_voice_stream_init_and_destroy() {
     test_ops_context_operation("multiple duplex voice streams", |context_ptr| {
         let start = Instant::now();

--- a/src/backend/tests/interfaces.rs
+++ b/src/backend/tests/interfaces.rs
@@ -1044,16 +1044,18 @@ fn test_ops_stereo_input_duplex_stream_stop() {
 
 #[test]
 fn test_ops_duplex_voice_stream_init_and_destroy() {
-    test_default_duplex_voice_stream_operation(
-        "duplex voice stream: init and destroy",
-        |_stream| {},
-    );
+    test_default_duplex_voice_stream_operation("duplex voice stream: init and destroy", |stream| {
+        let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+        assert!(stm.core_stream_data.using_voice_processing_unit());
+    });
 }
 
 #[test]
 fn test_ops_duplex_voice_stream_start() {
     test_default_duplex_voice_stream_operation("duplex voice stream: start", |stream| {
         assert_eq!(unsafe { OPS.stream_start.unwrap()(stream) }, ffi::CUBEB_OK);
+        let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+        assert!(stm.core_stream_data.using_voice_processing_unit());
     });
 }
 
@@ -1061,6 +1063,8 @@ fn test_ops_duplex_voice_stream_start() {
 fn test_ops_duplex_voice_stream_stop() {
     test_default_duplex_voice_stream_operation("duplex voice stream: stop", |stream| {
         assert_eq!(unsafe { OPS.stream_stop.unwrap()(stream) }, ffi::CUBEB_OK);
+        let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+        assert!(stm.core_stream_data.using_voice_processing_unit());
     });
 }
 
@@ -1071,6 +1075,8 @@ fn test_ops_duplex_voice_stream_set_input_mute() {
             unsafe { OPS.stream_set_input_mute.unwrap()(stream, 1) },
             ffi::CUBEB_OK
         );
+        let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+        assert!(stm.core_stream_data.using_voice_processing_unit());
     });
 }
 
@@ -1084,6 +1090,8 @@ fn test_ops_duplex_voice_stream_set_input_mute_before_start() {
                 ffi::CUBEB_OK
             );
             assert_eq!(unsafe { OPS.stream_start.unwrap()(stream) }, ffi::CUBEB_OK);
+            let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+            assert!(stm.core_stream_data.using_voice_processing_unit());
         },
     );
 }
@@ -1101,6 +1109,7 @@ fn test_ops_duplex_voice_stream_set_input_mute_before_start_with_reinit() {
 
             // Hacky cast, but testing this here was simplest for now.
             let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+            assert!(stm.core_stream_data.using_voice_processing_unit());
             stm.reinit_async();
             let queue = stm.queue.clone();
             let mut mute_after_reinit = false;
@@ -1130,6 +1139,8 @@ fn test_ops_duplex_voice_stream_set_input_mute_after_start() {
             unsafe { OPS.stream_set_input_mute.unwrap()(stream, 1) },
             ffi::CUBEB_OK
         );
+        let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+        assert!(stm.core_stream_data.using_voice_processing_unit());
     });
 }
 
@@ -1144,6 +1155,8 @@ fn test_ops_duplex_voice_stream_set_input_processing_params() {
             unsafe { OPS.stream_set_input_processing_params.unwrap()(stream, params) },
             ffi::CUBEB_OK
         );
+        let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+        assert!(stm.core_stream_data.using_voice_processing_unit());
     });
 }
 
@@ -1161,6 +1174,8 @@ fn test_ops_duplex_voice_stream_set_input_processing_params_before_start() {
                 ffi::CUBEB_OK
             );
             assert_eq!(unsafe { OPS.stream_start.unwrap()(stream) }, ffi::CUBEB_OK);
+            let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+            assert!(stm.core_stream_data.using_voice_processing_unit());
         },
     );
 }
@@ -1182,6 +1197,7 @@ fn test_ops_duplex_voice_stream_set_input_processing_params_before_start_with_re
 
             // Hacky cast, but testing this here was simplest for now.
             let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+            assert!(stm.core_stream_data.using_voice_processing_unit());
             stm.reinit_async();
             let queue = stm.queue.clone();
             let mut params_after_reinit: ffi::cubeb_input_processing_params =
@@ -1229,6 +1245,8 @@ fn test_ops_duplex_voice_stream_set_input_processing_params_after_start() {
     test_default_duplex_voice_stream_operation(
         "duplex voice stream: processing after start",
         |stream| {
+            let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+            assert!(stm.core_stream_data.using_voice_processing_unit());
             assert_eq!(unsafe { OPS.stream_start.unwrap()(stream) }, ffi::CUBEB_OK);
             let params: ffi::cubeb_input_processing_params =
                 ffi::CUBEB_INPUT_PROCESSING_PARAM_ECHO_CANCELLATION
@@ -1246,7 +1264,10 @@ fn test_ops_duplex_voice_stream_set_input_processing_params_after_start() {
 fn test_ops_stereo_input_duplex_voice_stream_init_and_destroy() {
     test_stereo_input_duplex_voice_stream_operation(
         "stereo-input duplex voice stream: init and destroy",
-        |_stream| {},
+        |stream| {
+            let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+            assert!(stm.core_stream_data.using_voice_processing_unit());
+        },
     );
 }
 
@@ -1255,6 +1276,8 @@ fn test_ops_stereo_input_duplex_voice_stream_start() {
     test_stereo_input_duplex_voice_stream_operation(
         "stereo-input duplex voice stream: start",
         |stream| {
+            let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+            assert!(stm.core_stream_data.using_voice_processing_unit());
             assert_eq!(unsafe { OPS.stream_start.unwrap()(stream) }, ffi::CUBEB_OK);
         },
     );
@@ -1265,6 +1288,8 @@ fn test_ops_stereo_input_duplex_voice_stream_stop() {
     test_stereo_input_duplex_voice_stream_operation(
         "stereo-input duplex voice stream: stop",
         |stream| {
+            let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
+            assert!(stm.core_stream_data.using_voice_processing_unit());
             assert_eq!(unsafe { OPS.stream_stop.unwrap()(stream) }, ffi::CUBEB_OK);
         },
     );

--- a/src/backend/tests/manual.rs
+++ b/src/backend/tests/manual.rs
@@ -337,6 +337,23 @@ fn test_stream_tester() {
                 params.set(InputProcessingParams::ECHO_CANCELLATION, true);
                 params.set(InputProcessingParams::NOISE_SUPPRESSION, true);
             }
+            let mut agc = u32::from(false);
+            let mut size: usize = mem::size_of::<u32>();
+            assert_eq!(
+                audio_unit_get_property(
+                    stm.core_stream_data.input_unit,
+                    kAUVoiceIOProperty_VoiceProcessingEnableAGC,
+                    kAudioUnitScope_Global,
+                    AU_IN_BUS,
+                    &mut agc,
+                    &mut size,
+                ),
+                NO_ERR
+            );
+            assert_eq!(size, mem::size_of::<u32>());
+            if agc == 1 {
+                params.set(InputProcessingParams::AUTOMATIC_GAIN_CONTROL, true);
+            }
         }
         let mut done = false;
         while !done {

--- a/src/backend/tests/manual.rs
+++ b/src/backend/tests/manual.rs
@@ -4,7 +4,6 @@ use super::utils::{
 };
 use super::*;
 use std::io;
-use std::sync::atomic::AtomicBool;
 
 #[ignore]
 #[test]

--- a/src/backend/tests/tone.rs
+++ b/src/backend/tests/tone.rs
@@ -1,6 +1,6 @@
 use super::utils::{test_get_default_device, test_ops_stream_operation, Scope};
 use super::*;
-use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::atomic::AtomicI64;
 
 #[test]
 fn test_dial_tone() {


### PR DESCRIPTION
The shared VPIO unit gets created on the first creation of a duplex stream. It will be used by any request for a duplex VOICE stream, if allowed and possible given the requested devices. With this PR there cannot be two VPIO units for a given context.