### PR TITLE
Only apply VPIO properties while running

### DIFF
--- a/src/backend/tests/interfaces.rs
+++ b/src/backend/tests/interfaces.rs
@@ -1623,6 +1623,7 @@ fn test_ops_timing_sensitive_multiple_duplex_voice_stream_params() {
             |stream| {
                 let stm = unsafe { &mut *(stream as *mut AudioUnitStream) };
                 assert!(stm.core_stream_data.using_voice_processing_unit());
+                assert_eq!(unsafe { OPS.stream_start.unwrap()(stream) }, ffi::CUBEB_OK);
                 let queue = stm.queue.clone();
                 // Test that input processing params does not carry over when reusing vpio.
                 let mut bypass: u32 = 0;


### PR DESCRIPTION
An Apple bug breaks, at least, the bypass property if it is set prior to starting the VPIO unit. Broken here means that the property can be set to any value later while running, without having an effect.

The VPIO defaults is bypass OFF and AGC ON. Starting like that and then turning on bypass as requested is not going to cause an unexpected glitch. We reset the VPIO to defaults before stopping so that on reuse it doesn't risk causing a glitch either.