### PR TITLE
Block Studio Display Mic for input-only when its Speakers are default output

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3323,6 +3323,7 @@ impl<'ctx> CoreStreamData<'ctx> {
                 .map(|id| log_device_and_get_model_uid(id, DeviceType::INPUT))
                 .unwrap_or_default(),
             out_id
+                .or_else(|| get_default_device(DeviceType::OUTPUT))
                 .map(|id| log_device_and_get_model_uid(id, DeviceType::OUTPUT))
                 .unwrap_or_default(),
         );


### PR DESCRIPTION
The VPIO unit behaves the same when not setting an output as when setting the default output device as output.

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1914925.