### PR TITLE
Add empty [workspace] to Cargo.toml.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,8 @@ itertools = "0.11"
 
 [features]
 audio-dump = []
+
+# Workaround for https://github.com/rust-lang/cargo/issues/6745 to allow this
+# Cargo.toml file to appear under a subdirectory of a workspace without being in
+# that workspace (e.g. in cubeb-rs).
+[workspace]

--- a/coreaudio-sys-utils/src/audio_device_extensions.rs
+++ b/coreaudio-sys-utils/src/audio_device_extensions.rs
@@ -13,6 +13,8 @@ extern "C" {
     ) -> OSStatus;
 }
 
+// See https://github.com/mozilla/cubeb-coreaudio-rs/issues/237
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn audio_device_duck(
     in_device: AudioDeviceID,
     in_ducked_level: f32,

--- a/coreaudio-sys-utils/src/audio_unit.rs
+++ b/coreaudio-sys-utils/src/audio_unit.rs
@@ -4,6 +4,9 @@ use std::convert::TryFrom;
 use std::os::raw::c_void;
 use std::ptr;
 
+// See https://github.com/mozilla/cubeb-coreaudio-rs/issues/237 for this and
+// all other such warning suppressions in this file.
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn audio_unit_get_property_info(
     unit: AudioUnit,
     property: AudioUnitPropertyID,
@@ -27,6 +30,7 @@ pub fn audio_unit_get_property_info(
     }
 }
 
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn audio_unit_get_property<T>(
     unit: AudioUnit,
     property: AudioUnitPropertyID,
@@ -50,6 +54,7 @@ pub fn audio_unit_get_property<T>(
     }
 }
 
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn audio_unit_set_property<T>(
     unit: AudioUnit,
     property: AudioUnitPropertyID,
@@ -72,6 +77,7 @@ pub fn audio_unit_set_property<T>(
     }
 }
 
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn audio_unit_get_parameter(
     unit: AudioUnit,
     id: AudioUnitParameterID,
@@ -92,6 +98,7 @@ pub fn audio_unit_get_parameter(
     }
 }
 
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn audio_unit_set_parameter(
     unit: AudioUnit,
     id: AudioUnitParameterID,
@@ -105,35 +112,41 @@ pub fn audio_unit_set_parameter(
     unsafe { AudioUnitSetParameter(unit, id, scope, element, value, buffer_offset_in_frames) }
 }
 
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn audio_unit_initialize(unit: AudioUnit) -> OSStatus {
     assert!(!unit.is_null());
     debug_assert_running_serially();
     unsafe { AudioUnitInitialize(unit) }
 }
 
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn audio_unit_uninitialize(unit: AudioUnit) -> OSStatus {
     assert!(!unit.is_null());
     debug_assert_running_serially();
     unsafe { AudioUnitUninitialize(unit) }
 }
 
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn dispose_audio_unit(unit: AudioUnit) -> OSStatus {
     debug_assert_running_serially();
     unsafe { AudioComponentInstanceDispose(unit) }
 }
 
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn audio_output_unit_start(unit: AudioUnit) -> OSStatus {
     assert!(!unit.is_null());
     debug_assert_running_serially();
     unsafe { AudioOutputUnitStart(unit) }
 }
 
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn audio_output_unit_stop(unit: AudioUnit) -> OSStatus {
     assert!(!unit.is_null());
     debug_assert_running_serially();
     unsafe { AudioOutputUnitStop(unit) }
 }
 
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn audio_unit_render(
     in_unit: AudioUnit,
     io_action_flags: &mut AudioUnitRenderActionFlags,
@@ -159,6 +172,7 @@ pub fn audio_unit_render(
 pub type audio_unit_property_listener_proc =
     extern "C" fn(*mut c_void, AudioUnit, AudioUnitPropertyID, AudioUnitScope, AudioUnitElement);
 
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn audio_unit_add_property_listener<T>(
     unit: AudioUnit,
     id: AudioUnitPropertyID,
@@ -170,6 +184,7 @@ pub fn audio_unit_add_property_listener<T>(
     unsafe { AudioUnitAddPropertyListener(unit, id, Some(listener), data as *mut c_void) }
 }
 
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn audio_unit_remove_property_listener_with_user_data<T>(
     unit: AudioUnit,
     id: AudioUnitPropertyID,

--- a/coreaudio-sys-utils/src/dispatch.rs
+++ b/coreaudio-sys-utils/src/dispatch.rs
@@ -32,14 +32,14 @@ pub fn run_serially<F, B>(work: F) -> B
 where
     F: FnOnce() -> B,
 {
-    get_serial_queue_singleton().run_sync(|| work()).unwrap()
+    get_serial_queue_singleton().run_sync(work).unwrap()
 }
 
 pub fn run_serially_forward_panics<F, B>(work: F) -> B
 where
     F: panic::UnwindSafe + FnOnce() -> B,
 {
-    match run_serially(|| panic::catch_unwind(|| work())) {
+    match run_serially(|| panic::catch_unwind(work)) {
         Ok(res) => res,
         Err(e) => panic::resume_unwind(e),
     }

--- a/coreaudio-sys-utils/src/string.rs
+++ b/coreaudio-sys-utils/src/string.rs
@@ -102,7 +102,7 @@ fn utf8_from_cfstringref(string_ref: CFStringRef) -> Vec<u8> {
             kCFStringEncodingUTF8,
             0,
             false as Boolean,
-            ptr::null_mut() as *mut u8,
+            ptr::null_mut(),
             0,
             &mut size,
         )

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2647,7 +2647,9 @@ impl ContextOps for AudioUnitContext {
     fn backend_id(&mut self) -> &'static CStr {
         // https://github.com/rust-lang/rust-clippy/issues/13531
         #[allow(clippy::manual_c_str_literals)]
-        unsafe { CStr::from_ptr(b"audiounit-rust\0".as_ptr() as *const _) }
+        unsafe {
+            CStr::from_ptr(b"audiounit-rust\0".as_ptr() as *const _)
+        }
     }
     #[cfg(target_os = "ios")]
     fn max_channel_count(&mut self) -> Result<u32> {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3049,7 +3049,7 @@ struct CoreStreamData<'ctx> {
     audio_dump_output: ffi::cubeb_audio_dump_stream_t,
 }
 
-impl<'ctx> Default for CoreStreamData<'ctx> {
+impl Default for CoreStreamData<'_> {
     fn default() -> Self {
         Self {
             stm_ptr: ptr::null(),
@@ -4556,7 +4556,7 @@ impl<'ctx> CoreStreamData<'ctx> {
     }
 }
 
-impl<'ctx> Drop for CoreStreamData<'ctx> {
+impl Drop for CoreStreamData<'_> {
     fn drop(&mut self) {
         self.debug_assert_is_on_stream_queue();
         self.stop_audiounits();
@@ -4881,7 +4881,7 @@ impl<'ctx> AudioUnitStream<'ctx> {
     }
 }
 
-impl<'ctx> Drop for AudioUnitStream<'ctx> {
+impl Drop for AudioUnitStream<'_> {
     fn drop(&mut self) {
         // Execute destroy in serial queue to avoid collision with reinit when un/plug devices
         self.queue.clone().run_final(|| {
@@ -4891,7 +4891,7 @@ impl<'ctx> Drop for AudioUnitStream<'ctx> {
     }
 }
 
-impl<'ctx> StreamOps for AudioUnitStream<'ctx> {
+impl StreamOps for AudioUnitStream<'_> {
     fn start(&mut self) -> Result<()> {
         let was_stopped = self.stopped.load(Ordering::SeqCst);
         let was_draining = self.draining.load(Ordering::SeqCst);
@@ -5175,8 +5175,8 @@ impl<'ctx> StreamOps for AudioUnitStream<'ctx> {
 }
 
 #[allow(clippy::non_send_fields_in_send_ty)]
-unsafe impl<'ctx> Send for AudioUnitStream<'ctx> {}
-unsafe impl<'ctx> Sync for AudioUnitStream<'ctx> {}
+unsafe impl Send for AudioUnitStream<'_> {}
+unsafe impl Sync for AudioUnitStream<'_> {}
 
 #[cfg(test)]
 mod tests;

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2645,6 +2645,8 @@ impl ContextOps for AudioUnitContext {
     }
 
     fn backend_id(&mut self) -> &'static CStr {
+        // https://github.com/rust-lang/rust-clippy/issues/13531
+        #[allow(clippy::manual_c_str_literals)]
         unsafe { CStr::from_ptr(b"audiounit-rust\0".as_ptr() as *const _) }
     }
     #[cfg(target_os = "ios")]


### PR DESCRIPTION
This works around https://github.com/rust-lang/cargo/issues/6745 and allows cubeb-coreaudio-rs to appear as a subdirectory of a workspace member in another project (for instance, cubeb-rs).