### PR TITLE
Mark some spammy logs as verbose.

### DIFF
--- a/src/backend/device_property.rs
+++ b/src/backend/device_property.rs
@@ -265,7 +265,7 @@ pub fn get_device_streams(
         debug_assert!(devices.contains(&id));
         devices.sort();
         let next_id = devices.into_iter().skip_while(|&i| i != id).nth(1);
-        cubeb_log!(
+        cubeb_logv!(
             "Filtering input streams {:?} for device {}. Next device is {:?}.",
             device_streams
                 .iter()
@@ -279,7 +279,7 @@ pub fn get_device_streams(
         } else {
             device_streams.retain(|ds| ds.stream > id);
         }
-        cubeb_log!(
+        cubeb_logv!(
             "Input stream filtering for device {} retained {:?}.",
             id,
             device_streams

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1712,7 +1712,7 @@ fn get_device_group_id(
     debug_assert_running_serially();
     match get_device_transport_type(id, devtype) {
         Ok(kAudioDeviceTransportTypeBuiltIn) => {
-            cubeb_log!(
+            cubeb_logv!(
                 "The transport type is {:?}",
                 convert_uint32_into_string(kAudioDeviceTransportTypeBuiltIn)
             );
@@ -1724,7 +1724,7 @@ fn get_device_group_id(
             };
         }
         Ok(trans_type) => {
-            cubeb_log!(
+            cubeb_logv!(
                 "The transport type is {:?}. Getting model UID instead.",
                 convert_uint32_into_string(trans_type)
             );
@@ -1755,7 +1755,7 @@ fn get_custom_group_id(id: AudioDeviceID, devtype: DeviceType) -> Option<CString
     match get_device_source(id, devtype) {
         s @ Ok(IMIC) | s @ Ok(ISPK) => {
             const GROUP_ID: &str = "builtin-internal-mic|spk";
-            cubeb_log!(
+            cubeb_logv!(
                 "Using hardcode group id: {} when source is: {:?}.",
                 GROUP_ID,
                 convert_uint32_into_string(s.unwrap())
@@ -1764,7 +1764,7 @@ fn get_custom_group_id(id: AudioDeviceID, devtype: DeviceType) -> Option<CString
         }
         s @ Ok(EMIC) | s @ Ok(HDPN) => {
             const GROUP_ID: &str = "builtin-external-mic|hdpn";
-            cubeb_log!(
+            cubeb_logv!(
                 "Using hardcode group id: {} when source is: {:?}.",
                 GROUP_ID,
                 convert_uint32_into_string(s.unwrap())
@@ -2011,7 +2011,7 @@ fn audiounit_get_devices_of_type(devtype: DeviceType) -> Vec<AudioObjectID> {
         let info = format!("{} ({})", device, label);
 
         if let Ok(channels) = get_channel_count(device, devtype) {
-            cubeb_log!("Device {} has {} {:?}-channels", info, channels, devtype);
+            cubeb_logv!("Device {} has {} {:?}-channels", info, channels, devtype);
             if channels > 0 {
                 devices_in_scope.push(device);
             }
@@ -3271,7 +3271,7 @@ impl<'ctx> CoreStreamData<'ctx> {
         debug_assert_running_serially();
         match get_device_transport_type(id, DeviceType::INPUT) {
             Ok(kAudioDeviceTransportTypeBuiltIn) => {
-                cubeb_log!(
+                cubeb_logv!(
                     "Input device {} is on the VPIO force list because it is built in, \
                      and its volume is known to be very low without VPIO whenever VPIO \
                      is hooked up to it elsewhere.",


### PR DESCRIPTION
In a very brief usage of cubeb-coreaudio-rs, I observed substantial log output from the following lines: (format is "&lt;count&gt; &lt;file&gt;:&lt;line&gt;")

 880  mod.rs:1767
 880  mod.rs:1848
1479  mod.rs:3274
1618  mod.rs:1758
2498  mod.rs:1715
3236  mod.rs:1727
8870  device_property.rs:268
8870  device_property.rs:282
9708  mod.rs:2014

Of these, only one (mod.rs:1848) is an error. The others are informational, so make them verbose logs.