### PR TITLE
Do not send extra channels for aggregate devices.

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3612,16 +3612,15 @@ impl<'ctx> CoreStreamData<'ctx> {
                 self.stm_ptr,
                 input_hw_desc
             );
-            // Notice: when we are using aggregate device, the input_hw_desc.mChannelsPerFrame is
-            // the total of all the input channel count of the devices added in the aggregate device.
-            // Due to our aggregate device settings, the data captured by the output device's input
-            // channels will be put in the beginning of the raw data given by the input callback.
-
-            // Always request all the input channels of the device, and only pass the correct
-            // channels to the audio callback.
+            // Notice: when we are using aggregate device, input_hw_desc.mChannelsPerFrame is the
+            // total of all the input channel count of the devices added in the aggregate device.
+            // Because we set the input device first on the aggregate device, the input device's
+            // input channels will also be first among all the aggregate device's channels, when
+            // accessed in the input callback. By requesting only the input device's channels here,
+            // any other input channels, i.e. from the output device, will be truncated away.
             let params = unsafe {
                 let mut p = *self.input_stream_params.as_ptr();
-                p.channels = input_hw_desc.mChannelsPerFrame;
+                p.channels = device_channel_count;
                 // Input AudioUnit must be configured with device's sample rate.
                 // we will resample inside input callback.
                 p.rate = input_hw_desc.mSampleRate as _;


### PR DESCRIPTION
We drop the **first** several channels if there are extras (e.g. for aggregate devices) After f8df86f753d81c3ef2e8a6661b11ed65af579919, this is often incorrect
(because the first device is the input device), and also is inefficient.

So, only request the channels we're planning to use.