### PR TITLE
Pass gecko-in-tree feature to cubeb-backend.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ itertools = "0.11"
 
 [features]
 audio-dump = []
+gecko-in-tree = ["cubeb-backend/gecko-in-tree"]
 
 # Workaround for https://github.com/rust-lang/cargo/issues/6745 to allow this
 # Cargo.toml file to appear under a subdirectory of a workspace without being in


### PR DESCRIPTION
This lets us break a circular dependency when cubeb includes cubeb-coreaudio-rs.