### PR TITLE
Fix build/link on macOS 13 with Xcode 15.

### DIFF
--- a/coreaudio-sys-utils/Cargo.toml
+++ b/coreaudio-sys-utils/Cargo.toml
@@ -11,4 +11,4 @@ core-foundation-sys = { version = "0.8" }
 [dependencies.coreaudio-sys]
 default-features = false
 features = ["audio_unit", "core_audio", "io_kit_audio"]
-version = "0.2.14"
+version = "0.2.16"

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -9,6 +9,8 @@ if [[ -z "${RUST_BACKTRACE}" ]]; then
 fi
 echo "RUST_BACKTRACE is set to ${RUST_BACKTRACE}\n"
 
+export MACOSX_DEPLOYMENT_TARGET="10.15"
+
 # Run tests in the sub crate
 # Run the tests by `cargo * -p <SUB_CRATE>` if it's possible. By doing so, the duplicate compiling
 # between this crate and the <SUB_CRATE> can be saved. The compiling for <SUB_CRATE> can be reused


### PR DESCRIPTION
- Bump coreaudio-sys version.
- Set MACOSX_DEPLOYMENT_TARGET explicitly in run_tests.sh.
