### PR TITLE
Use a stable identifier for the device when returning a cubeb_devid.

### DIFF
--- a/src/backend/device_property.rs
+++ b/src/backend/device_property.rs
@@ -18,6 +18,45 @@ pub fn get_device_uid(
     }
 }
 
+pub fn get_device_from_devid(
+    devid: ffi::cubeb_devid,
+) -> std::result::Result<AudioDeviceID, OSStatus> {
+    debug_assert_running_serially();
+    if devid.is_null() {
+        return Ok(kAudioObjectUnknown);
+    }
+
+    let devid_cstr = unsafe { CStr::from_ptr(devid as _) };
+    let mut devid_cfsr = cfstringref_from_string(devid_cstr.to_str().unwrap());
+
+    let mut device_id: AudioDeviceID = kAudioObjectUnknown;
+
+    let mut translation_value = AudioValueTranslation {
+        mInputData: &mut devid_cfsr as *mut CFStringRef as *mut c_void,
+        mInputDataSize: mem::size_of::<CFStringRef>() as u32,
+        mOutputData: &mut device_id as *mut AudioDeviceID as *mut c_void,
+        mOutputDataSize: mem::size_of::<AudioDeviceID>() as u32,
+    };
+
+    let address = get_property_address(
+        Property::HardwareDeviceForUID,
+        DeviceType::INPUT | DeviceType::OUTPUT,
+    );
+
+    let mut translation_size: usize = mem::size_of::<AudioValueTranslation>();
+    let ret = audio_object_get_property_data(
+        kAudioObjectSystemObject,
+        &address,
+        &mut translation_size,
+        &mut translation_value,
+    );
+    if ret != NO_ERR {
+        return Err(ret);
+    }
+
+    Ok(device_id)
+}
+
 pub fn get_devices() -> Vec<AudioObjectID> {
     debug_assert_running_serially();
     let mut size: usize = 0;
@@ -404,6 +443,7 @@ pub enum Property {
     DeviceUID,
     HardwareDefaultInputDevice,
     HardwareDefaultOutputDevice,
+    HardwareDeviceForUID,
     HardwareDevices,
     ModelUID,
     StreamLatency,
@@ -429,6 +469,7 @@ impl From<Property> for AudioObjectPropertySelector {
             Property::DeviceUID => kAudioDevicePropertyDeviceUID,
             Property::HardwareDefaultInputDevice => kAudioHardwarePropertyDefaultInputDevice,
             Property::HardwareDefaultOutputDevice => kAudioHardwarePropertyDefaultOutputDevice,
+            Property::HardwareDeviceForUID => kAudioHardwarePropertyDeviceForUID,
             Property::HardwareDevices => kAudioHardwarePropertyDevices,
             Property::ModelUID => kAudioDevicePropertyModelUID,
             Property::StreamLatency => kAudioStreamPropertyLatency,

--- a/src/backend/intern.rs
+++ b/src/backend/intern.rs
@@ -1,0 +1,58 @@
+// Copyright © 2017-2018 Mozilla Foundation
+//
+// This program is made available under an ISC-style license.  See the
+// accompanying file LICENSE for details.
+
+use std::ffi::{CStr, CString};
+use std::os::raw::c_char;
+
+#[derive(Debug)]
+pub struct Intern {
+    vec: Vec<CString>,
+}
+
+impl Intern {
+    pub fn new() -> Intern {
+        Intern { vec: Vec::new() }
+    }
+
+    pub fn add(&mut self, string: &CStr) -> *const c_char {
+        fn eq(s1: &CStr, s2: &CStr) -> bool {
+            s1 == s2
+        }
+        for s in &self.vec {
+            if eq(s, string) {
+                return s.as_ptr();
+            }
+        }
+
+        self.vec.push(string.to_owned());
+        self.vec.last().unwrap().as_ptr()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Intern;
+    use std::ffi::CStr;
+
+    #[test]
+    fn intern() {
+        fn cstr(str: &[u8]) -> &CStr {
+            CStr::from_bytes_with_nul(str).unwrap()
+        }
+
+        let mut intern = Intern::new();
+
+        let foo_ptr = intern.add(cstr(b"foo\0"));
+        let bar_ptr = intern.add(cstr(b"bar\0"));
+        assert!(!foo_ptr.is_null());
+        assert!(!bar_ptr.is_null());
+        assert!(foo_ptr != bar_ptr);
+
+        assert!(foo_ptr == intern.add(cstr(b"foo\0")));
+        assert!(foo_ptr != intern.add(cstr(b"fo\0")));
+        assert!(foo_ptr != intern.add(cstr(b"fool\0")));
+        assert!(foo_ptr != intern.add(cstr(b"not foo\0")));
+    }
+}

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -12,6 +12,7 @@ mod aggregate_device;
 mod auto_release;
 mod buffer_manager;
 mod device_property;
+mod intern;
 mod mixer;
 mod resampler;
 mod utils;
@@ -1799,6 +1800,7 @@ fn get_device_global_uid(id: AudioDeviceID) -> std::result::Result<StringRef, OS
 
 #[allow(clippy::cognitive_complexity)]
 fn create_cubeb_device_info(
+    intern: &Arc<Mutex<intern::Intern>>,
     devid: AudioObjectID,
     devtype: DeviceType,
 ) -> Result<ffi::cubeb_device_info> {
@@ -1819,15 +1821,11 @@ fn create_cubeb_device_info(
         ..Default::default()
     };
 
-    assert!(
-        mem::size_of::<ffi::cubeb_devid>() >= mem::size_of_val(&devid),
-        "cubeb_devid can't represent devid"
-    );
-    dev_info.devid = devid as ffi::cubeb_devid;
-
     match get_device_uid(devid, devtype) {
         Ok(uid) => {
             let c_string = uid.into_cstring();
+            // Intern the device UID to provide a stable devid pointer for the lifetime of the context.
+            dev_info.devid = intern.lock().unwrap().add(&c_string) as ffi::cubeb_devid;
             dev_info.device_id = c_string.into_raw();
         }
         Err(e) => {
@@ -2478,6 +2476,7 @@ pub struct AudioUnitContext {
     // Storage for a context-global vpio unit. Duplex streams that need one will take this
     // and return it when done.
     shared_voice_processing_unit: SharedVoiceProcessingUnitManager,
+    devids: Arc<Mutex<intern::Intern>>,
 }
 
 impl AudioUnitContext {
@@ -2503,6 +2502,7 @@ impl AudioUnitContext {
             devices: Mutex::new(SharedDevices::default()),
             host_time_to_ns_ratio,
             shared_voice_processing_unit: SharedVoiceProcessingUnitManager::new(shared_vp_queue),
+            devids: Arc::new(Mutex::new(intern::Intern::new())),
         }
     }
 
@@ -2735,6 +2735,7 @@ impl ContextOps for AudioUnitContext {
         devtype: DeviceType,
         collection: &DeviceCollectionRef,
     ) -> Result<()> {
+        let intern = self.devids.clone();
         let device_infos = self
             .serial_queue
             .run_sync(|| {
@@ -2748,7 +2749,7 @@ impl ContextOps for AudioUnitContext {
                 let mut device_infos = Vec::with_capacity(count);
                 for (dt, dev_ids) in device_ids {
                     for dev_id in dev_ids {
-                        if let Ok(info) = create_cubeb_device_info(dev_id, dt) {
+                        if let Ok(info) = create_cubeb_device_info(&intern, dev_id, dt) {
                             device_infos.push(info);
                         }
                     }
@@ -2817,7 +2818,12 @@ impl ContextOps for AudioUnitContext {
         let in_stm_settings = if let Some(params) = input_stream_params {
             let in_device = match self
                 .serial_queue
-                .run_sync(|| create_device_info(input_device as AudioDeviceID, DeviceType::INPUT))
+                .run_sync(|| {
+                    create_device_info(
+                        get_device_from_devid(input_device).unwrap(),
+                        DeviceType::INPUT,
+                    )
+                })
                 .unwrap()
             {
                 None => {
@@ -2835,7 +2841,12 @@ impl ContextOps for AudioUnitContext {
         let out_stm_settings = if let Some(params) = output_stream_params {
             let out_device = match self
                 .serial_queue
-                .run_sync(|| create_device_info(output_device as AudioDeviceID, DeviceType::OUTPUT))
+                .run_sync(|| {
+                    create_device_info(
+                        get_device_from_devid(output_device).unwrap(),
+                        DeviceType::OUTPUT,
+                    )
+                })
                 .unwrap()
             {
                 None => {

--- a/src/backend/tests/api.rs
+++ b/src/backend/tests/api.rs
@@ -1445,14 +1445,16 @@ fn test_get_device_global_uid_by_unknwon_device() {
 fn test_create_cubeb_device_info() {
     use std::collections::VecDeque;
 
-    test_create_device_from_hwdev_in_scope(Scope::Input);
-    test_create_device_from_hwdev_in_scope(Scope::Output);
+    let intern = Arc::new(Mutex::new(intern::Intern::new()));
 
-    fn test_create_device_from_hwdev_in_scope(scope: Scope) {
+    test_create_device_from_hwdev_in_scope(&intern, Scope::Input);
+    test_create_device_from_hwdev_in_scope(&intern, Scope::Output);
+
+    fn test_create_device_from_hwdev_in_scope(intern: &Arc<Mutex<intern::Intern>>, scope: Scope) {
         if let Some(device) = test_get_default_device(scope.clone()) {
             let is_input = test_device_in_scope(device, Scope::Input);
             let is_output = test_device_in_scope(device, Scope::Output);
-            let mut results = test_create_device_infos_by_device(device);
+            let mut results = test_create_device_infos_by_device(intern, device);
             assert_eq!(results.len(), 2);
             // Input device type:
             let input_result = results.pop_front().unwrap();
@@ -1478,13 +1480,14 @@ fn test_create_cubeb_device_info() {
     }
 
     fn test_create_device_infos_by_device(
+        intern: &Arc<Mutex<intern::Intern>>,
         id: AudioObjectID,
     ) -> VecDeque<std::result::Result<ffi::cubeb_device_info, Error>> {
         let dev_types = [DeviceType::INPUT, DeviceType::OUTPUT];
         let mut results = VecDeque::new();
         for dev_type in dev_types.iter() {
             results.push_back(run_serially_forward_panics(|| {
-                create_cubeb_device_info(id, *dev_type)
+                create_cubeb_device_info(intern, id, *dev_type)
             }));
         }
         results
@@ -1492,8 +1495,7 @@ fn test_create_cubeb_device_info() {
 
     fn check_device_info_by_device(info: &ffi::cubeb_device_info, id: AudioObjectID, scope: Scope) {
         assert!(!info.devid.is_null());
-        assert!(mem::size_of_val(&info.devid) >= mem::size_of::<AudioObjectID>());
-        assert_eq!(info.devid as AudioObjectID, id);
+        assert_ne!(info.devid, info.device_id as _);
         assert!(!info.device_id.is_null());
         assert!(!info.friendly_name.is_null());
         assert!(!info.group_id.is_null());
@@ -1535,7 +1537,8 @@ fn test_create_cubeb_device_info() {
 #[test]
 #[should_panic]
 fn test_create_device_info_by_unknown_device() {
-    assert!(create_cubeb_device_info(kAudioObjectUnknown, DeviceType::OUTPUT).is_err());
+    let intern = Arc::new(Mutex::new(intern::Intern::new()));
+    assert!(create_cubeb_device_info(&intern, kAudioObjectUnknown, DeviceType::OUTPUT).is_err());
 }
 
 #[test]
@@ -1544,8 +1547,10 @@ fn test_create_device_info_with_unknown_type() {
     test_create_device_info_with_unknown_type_by_scope(Scope::Output);
 
     fn test_create_device_info_with_unknown_type_by_scope(scope: Scope) {
+        let intern = Arc::new(Mutex::new(intern::Intern::new()));
         if let Some(device) = test_get_default_device(scope.clone()) {
             assert!(run_serially_forward_panics(|| create_cubeb_device_info(
+                &intern,
                 device,
                 DeviceType::UNKNOWN
             ))
@@ -1580,8 +1585,10 @@ fn test_create_device_from_hwdev_with_inout_type() {
 
     fn test_create_device_from_hwdev_with_inout_type_by_scope(scope: Scope) {
         if let Some(device) = test_get_default_device(scope.clone()) {
+            let intern = Arc::new(Mutex::new(intern::Intern::new()));
             // Get a kAudioHardwareUnknownPropertyError in get_channel_count actually.
             assert!(run_serially_forward_panics(|| create_cubeb_device_info(
+                &intern,
                 device,
                 DeviceType::INPUT | DeviceType::OUTPUT
             ))

--- a/src/backend/tests/interfaces.rs
+++ b/src/backend/tests/interfaces.rs
@@ -3,8 +3,9 @@ extern crate itertools;
 use self::itertools::iproduct;
 use super::utils::{
     draining_data_callback, get_devices_info_in_scope, noop_data_callback, state_tracking_cb,
-    test_device_channels_in_scope, test_get_default_device, test_ops_context_operation,
-    test_ops_stream_operation, test_ops_stream_operation_on_context, Scope, StateCallbackData,
+    test_device_channels_in_scope, test_get_default_device, test_object_id_to_devid,
+    test_ops_context_operation, test_ops_stream_operation, test_ops_stream_operation_on_context,
+    Scope, StateCallbackData,
 };
 use super::*;
 use std::thread;
@@ -523,13 +524,15 @@ fn test_ops_context_stream_init_no_input_stream_params() {
     test_ops_context_operation(name, |context_ptr| {
         let mut stream: *mut ffi::cubeb_stream = ptr::null_mut();
         let stream_name = CString::new(name).expect("Failed to create stream name");
+        let input_device =
+            test_object_id_to_devid(context_ptr, input_device.unwrap(), DeviceType::INPUT);
         assert_eq!(
             unsafe {
                 OPS.stream_init.unwrap()(
                     context_ptr,
                     &mut stream,
                     stream_name.as_ptr(),
-                    input_device.unwrap() as ffi::cubeb_devid,
+                    input_device,
                     ptr::null_mut(), // No input parameters.
                     ptr::null_mut(), // Use default output device.
                     ptr::null_mut(), // No output parameters.
@@ -822,10 +825,12 @@ fn test_stereo_input_duplex_stream_operation_on_context_with_callback<F>(
     output_params.layout = ffi::CUBEB_LAYOUT_UNDEFINED;
     output_params.prefs = ffi::CUBEB_STREAM_PREF_NONE;
 
+    let input_device = test_object_id_to_devid(context_ptr, input_devices[0].id, DeviceType::INPUT);
+
     test_ops_stream_operation_on_context(
         name,
         context_ptr,
-        input_devices[0].id as ffi::cubeb_devid,
+        input_device,
         &mut input_params,
         ptr::null_mut(), // Use default output device.
         &mut output_params,

--- a/src/backend/tests/utils.rs
+++ b/src/backend/tests/utils.rs
@@ -632,6 +632,20 @@ pub fn test_get_drift_compensations(id: AudioObjectID) -> std::result::Result<u3
     }
 }
 
+pub fn test_object_id_to_devid(
+    context_ptr: *mut ffi::cubeb,
+    id: AudioObjectID,
+    devtype: DeviceType,
+) -> ffi::cubeb_devid {
+    if id == kAudioObjectUnknown {
+        return ptr::null();
+    }
+    let context = unsafe { &mut *(context_ptr as *mut AudioUnitContext) };
+    let uid = run_serially_forward_panics(|| get_device_uid(id, devtype).unwrap());
+    let c_string = uid.into_cstring();
+    context.devids.lock().unwrap().add(&c_string) as _
+}
+
 pub fn test_audiounit_scope_is_enabled(unit: AudioUnit, scope: Scope) -> bool {
     assert!(!unit.is_null());
     debug_assert_not_running_serially();
@@ -1279,6 +1293,11 @@ pub fn test_ops_stream_operation<F>(
     F: FnOnce(*mut ffi::cubeb_stream),
 {
     test_ops_context_operation("context: stream operation", |context_ptr| {
+        let input_device =
+            test_object_id_to_devid(context_ptr, input_device as _, DeviceType::INPUT);
+        let output_device =
+            test_object_id_to_devid(context_ptr, output_device as _, DeviceType::OUTPUT);
+
         test_ops_stream_operation_on_context(
             name,
             context_ptr,


### PR DESCRIPTION
Previously we used the AudioObjectID associated with the device, but this value is not stable (e.g. disconnecting and reconnecting the same audio device can result in the AudioObjectID changing).  Instead, use the device's UID after interning it in the cubeb context to provide a stable (for the lifetime of the context) opaque pointer that can be mapped back to the UID and associated AudioObjectID as needed.

Fixes issue #250.

This is similar to the approach we already use for the [PulseAudio](https://github.com/mozilla/cubeb-pulse-rs/blob/6bac666467e4a37cf057f0e17e8c9e8a024b060b/src/backend/context.rs#L352) and [WASAPI](https://github.com/mozilla/cubeb/blob/f8633c0c9217ed5499fdda391946d416c52e6809/src/cubeb_wasapi.cpp#L2411) backends.