### PR TITLE
chore: Switch from `mach` to `mach2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ dependencies = [
  "float-cmp",
  "itertools 0.11.0",
  "libc",
- "mach",
+ "mach2",
  "num",
  "ringbuf",
  "triple_buffer",
@@ -240,10 +240,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "mach"
-version = "0.3.2"
+name = "mach2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ coreaudio-sys-utils = { path = "coreaudio-sys-utils" }
 cubeb-backend = "0.26"
 float-cmp = "0.6"
 libc = "0.2"
-mach = "0.3"
+mach2 = "0.4"
 num = "0.4.3"
 audio-mixer = "0.2"
 ringbuf = "0.2.6"

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -40,7 +40,7 @@ use cubeb_backend::{
     Error, InputProcessingParams, Ops, Result, SampleFormat, State, Stream, StreamOps,
     StreamParams, StreamParamsRef, StreamPrefs,
 };
-use mach::mach_time::{mach_absolute_time, mach_timebase_info};
+use mach2::mach_time::{mach_absolute_time, mach_timebase_info};
 use std::cmp;
 use std::ffi::{CStr, CString};
 use std::fmt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ extern crate bitflags;
 extern crate cubeb_backend;
 #[macro_use]
 extern crate float_cmp;
-extern crate mach;
+extern crate mach2;
 
 extern crate num;
 


### PR DESCRIPTION
`mach` is unmaintained, and this is one of the last two packages in Gecko depending on it:
```
Crate:     mach
Version:   0.3.2
Warning:   unmaintained
Title:     mach is unmaintained
Date:      2020-07-14
ID:        RUSTSEC-2020-0168
URL:       https://rustsec.org/advisories/RUSTSEC-2020-0168
Dependency tree:
mach 0.3.2
├── cubeb-coreaudio 0.1.0
│   └── gkrust-shared 0.1.0
│       ├── gkrust-gtest 0.1.0
│       └── gkrust 0.1.0
└── audio_thread_priority 0.32.0
    ├── gkrust-shared 0.1.0
    ├── audioipc2-server 0.6.0
    │   └── gkrust-shared 0.1.0
    ├── audioipc2-client 0.6.0
    │   └── gkrust-shared 0.1.0
    └── audioipc2 0.6.0
        ├── audioipc2-server 0.6.0
        └── audioipc2-client 0.6.0
```