### PR TITLE
Add cargo-audit workflow for dependency security scanning

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -14,14 +14,13 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install Rust
-      run: rustup toolchain install stable --profile minimal
-
-    - name: Install cargo-audit
-      run: cargo install cargo-audit
-
     - name: Run security audit
-      run: cargo audit
+      uses: rustsec/audit-check@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Run security audit (coreaudio-sys-utils)
-      run: cargo audit --file coreaudio-sys-utils/Cargo.lock
+      uses: rustsec/audit-check@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        working-directory: coreaudio-sys-utils

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,27 @@
+name: Security Audit
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # Weekly on Sunday at midnight UTC
+  push:
+    branches: [trailblazer]
+  pull_request:  # Run on ALL PRs to enforce security compliance
+  workflow_dispatch:  # Allow manual trigger
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Rust
+      run: rustup toolchain install stable --profile minimal
+
+    - name: Install cargo-audit
+      run: cargo install cargo-audit
+
+    - name: Run security audit
+      run: cargo audit
+
+    - name: Run security audit (coreaudio-sys-utils)
+      run: cargo audit --file coreaudio-sys-utils/Cargo.lock


### PR DESCRIPTION
Run weekly on all PRs for trailblazer to enforce security compliance. Can be set as a required check in branch protection rules to block PRs until issues are fixed.
