### PR TITLE
Add TSan annotations to avoid false-positive TSan failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,10 @@ jobs:
     - name: Regular Test
       run: sh run_tests.sh
     
-    - name: Sanitizer Test
+    - name: AddressSanitizer Test
       if: ${{ matrix.rust == 'nightly' }}
-      run: sh run_sanitizers.sh
+      run: sh run_sanitizers.sh address
+
+    - name: ThreadSanitizer Test
+      if: ${{ matrix.rust == 'nightly' }}
+      run: sh run_sanitizers.sh thread

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ itertools = "0.11"
 audio-dump = []
 vpio-forcelist = []
 gecko-in-tree = ["cubeb-backend/gecko-in-tree"]
+tsan-annotations = []
 
 # Workaround for https://github.com/rust-lang/cargo/issues/6745 to allow this
 # Cargo.toml file to appear under a subdirectory of a workspace without being in

--- a/run_sanitizers.sh
+++ b/run_sanitizers.sh
@@ -56,12 +56,36 @@ do
     # See: https://github.com/rust-lang/rust/issues/146465
     if [[ "${san}" == "thread" ]]; then
         export RUSTFLAGS="${RUSTFLAGS} -Cunsafe-allow-abi-mismatch=sanitizer"
+        # TSan false-positive tests: these trigger races in CoreAudio's
+        # internal synchronization that TSan cannot observe. They are
+        # skipped in pass 1 and re-run with annotations in pass 2.
+        tsan_false_positive_tests=(
+            "test_ops_duplex_voice_stream_set_input_processing_params"
+        )
+        tsan_skip_flags=""
+        for t in "${tsan_false_positive_tests[@]}"; do
+            tsan_skip_flags="${tsan_skip_flags} --skip ${t}"
+        done
+        export TSAN_SKIP_FLAGS="${tsan_skip_flags}"
     fi
     export CARGO_HOST_RUSTFLAGS=""
     # Set SANITIZER_BUILD so run_tests.sh can detect sanitizer mode.
     export SANITIZER_BUILD=1
     cargo_test_flags="-Z build-std --target ${TARGET}"
+    # Pass 1: Run all tests (TSan false-positive tests are skipped via
+    # TSAN_SKIP_FLAGS, picked up by run_tests.sh).
     sh run_tests.sh "${cargo_test_flags}"
+    # Pass 2 (TSan only): Re-run false-positive tests with annotations
+    # enabled so TSan can see CoreAudio's internal synchronization.
+    if [[ "${san}" == "thread" ]]; then
+        echo "\n\nRe-running TSan false-positive tests with annotations\n------------------------------"
+        cargo_test_flags_annotated="${cargo_test_flags} --features tsan-annotations"
+        for t in "${tsan_false_positive_tests[@]}"; do
+            echo "Running ${t} with tsan-annotations..."
+            cargo test --verbose --lib --tests ${cargo_test_flags_annotated} -- ${t}
+        done
+        unset TSAN_SKIP_FLAGS
+    fi
     unset RUSTFLAGS
     unset CARGO_HOST_RUSTFLAGS
     unset SANITIZER_BUILD

--- a/run_sanitizers.sh
+++ b/run_sanitizers.sh
@@ -19,11 +19,25 @@ set -e
 TARGET=$(rustc -vV | grep host | cut -d' ' -f2)
 echo "Target: $TARGET"
 
+# Accept sanitizers as command line arguments.
+# Usage: ./run_sanitizers.sh [address] [thread]
+# Default: Run all sanitizers (address and thread)
+# For public CI: ./run_sanitizers.sh address (ASan only)
+# For maintainer CI: ./run_sanitizers.sh address thread (or no args for all)
 # Ideally, sanitizers should be ("address" "leak" "memory" "thread") but
 # - `memory`: It doesn't works with target x86_64-apple-darwin
 # - `leak`: Get some errors that are out of our control. See:
 #   https://github.com/mozilla/cubeb-coreaudio-rs/issues/45#issuecomment-591642931
-sanitizers=("address" "thread")
+if [ $# -eq 0 ]; then
+    # Default: Run all available sanitizers
+    sanitizers=("address" "thread")
+else
+    # Use provided arguments
+    sanitizers=("$@")
+fi
+
+echo "Running sanitizers: ${sanitizers[*]}"
+
 for san in "${sanitizers[@]}"
 do
     San="$(tr '[:lower:]' '[:upper:]' <<< ${san:0:1})${san:1}"

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -48,6 +48,12 @@ if [[ -n "${SANITIZER_ENABLED}" ]]; then
     # queues under sanitizers, allowing these tests to run.
     SKIP_TEST_FLAGS="--skip test_panic_"
     echo "Skipping #[should_panic] tests (incompatible with sanitizers)\n"
+    # TSan false-positive tests are skipped in the main run and re-run
+    # separately with annotations in run_sanitizers.sh.
+    if [[ -n "${TSAN_SKIP_FLAGS}" ]]; then
+        SKIP_TEST_FLAGS="${SKIP_TEST_FLAGS} ${TSAN_SKIP_FLAGS}"
+        echo "Skipping TSan false-positive tests (will re-run with annotations)\n"
+    fi
 fi
 
 # Run tests in the sub crate

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -686,6 +686,19 @@ extern "C" fn audiounit_input_callback(
         });
     }
 
+    // AudioOutputUnitStop waits for in-flight callbacks, but TSan cannot see
+    // CoreAudio's internal synchronization. Release on the AudioUnit handle to
+    // pair with the acquire in stop_audiounit, modeling the per-unit HALB_Mutex.
+    #[cfg(feature = "tsan-annotations")]
+    {
+        extern "C" {
+            fn __tsan_release(addr: *mut c_void);
+        }
+        unsafe {
+            __tsan_release(stm.core_stream_data.input_unit as *mut c_void);
+        }
+    }
+
     match handle {
         ErrorHandle::Reinit => {
             stm.reinit_async();
@@ -986,6 +999,17 @@ extern "C" fn audiounit_output_callback(
             output_frames * stm.core_stream_data.output_dev_desc.mChannelsPerFrame,
         );
     }
+
+    #[cfg(feature = "tsan-annotations")]
+    {
+        extern "C" {
+            fn __tsan_release(addr: *mut c_void);
+        }
+        unsafe {
+            __tsan_release(stm.core_stream_data.output_unit as *mut c_void);
+        }
+    }
+
     NO_ERR
 }
 
@@ -1229,6 +1253,18 @@ fn start_audiounit(unit: AudioUnit) -> Result<()> {
 
 fn stop_audiounit(unit: AudioUnit) -> Result<()> {
     let status = audio_output_unit_stop(unit);
+    // AudioOutputUnitStop waits for in-flight callbacks, but TSan cannot see
+    // CoreAudio's internal HALB_Mutex synchronization. Acquire on the AudioUnit
+    // handle to pair with the release at the end of each callback.
+    #[cfg(feature = "tsan-annotations")]
+    {
+        extern "C" {
+            fn __tsan_acquire(addr: *mut c_void);
+        }
+        unsafe {
+            __tsan_acquire(unit as *mut c_void);
+        }
+    }
     if status == NO_ERR {
         Ok(())
     } else {


### PR DESCRIPTION
ThreadSanitizer reports false-positive data races in `test_ops_duplex_voice_stream_set_input_processing_params*` because it cannot observe CoreAudio's internal synchronization. `AudioOutputUnitStop `waits for in-flight callbacks via an internal `HALB_Mutex`, establishing a happens-before relationship, but this is invisible to TSan since it occurs inside Apple's closed-source framework.

This PR teaches TSan about CoreAudio's internal synchronization by adding TSan annotations (gated behind a `tsan-annotations` feature flag), and run TSan in two passes so annotations are only applied to known false-positive tests while maximizing unmodified TSan coverage on everything else.