### PR TITLE
Handle zero rate/channels from hardware description gracefully

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -267,8 +267,22 @@ fn create_device_info(devid: AudioDeviceID, devtype: DeviceType) -> Option<devic
 }
 
 fn create_stream_description(stream_params: &StreamParams) -> Result<AudioStreamBasicDescription> {
-    assert!(stream_params.rate() > 0);
-    assert!(stream_params.channels() > 0);
+    debug_assert!(stream_params.rate() > 0);
+    debug_assert!(stream_params.channels() > 0);
+    if stream_params.rate() == 0 {
+        cubeb_log!(
+            "create_stream_description: invalid rate 0 (channels={})",
+            stream_params.channels()
+        );
+        return Err(Error::Error);
+    }
+    if stream_params.channels() == 0 {
+        cubeb_log!(
+            "create_stream_description: invalid channel count 0 (rate={})",
+            stream_params.rate()
+        );
+        return Err(Error::Error);
+    }
 
     let mut desc = AudioStreamBasicDescription::default();
 
@@ -3848,6 +3862,16 @@ impl<'ctx> CoreStreamData<'ctx> {
                 self.stm_ptr,
                 input_hw_desc
             );
+            // These have been observed in the wild.
+            if input_hw_desc.mSampleRate <= 0.0 || input_hw_desc.mChannelsPerFrame == 0 {
+                cubeb_log!(
+                    "({:p}) Invalid input hardware description: rate={}, channels={}",
+                    self.stm_ptr,
+                    input_hw_desc.mSampleRate,
+                    input_hw_desc.mChannelsPerFrame
+                );
+                return Err(Error::Error);
+            }
             // Notice: when we are using an aggregate device, input_hw_desc.mChannelsPerFrame is the
             // sum of all input channels of all devices added to the aggregate device.
             // Because we set the input device first on the aggregate device, the input device's
@@ -4056,11 +4080,13 @@ impl<'ctx> CoreStreamData<'ctx> {
                 output_hw_desc
             );
 
-            // This has been observed in the wild.
-            if output_hw_desc.mChannelsPerFrame == 0 {
+            // These have been observed in the wild.
+            if output_hw_desc.mSampleRate <= 0.0 || output_hw_desc.mChannelsPerFrame == 0 {
                 cubeb_log!(
-                    "({:p}) Output hardware description channel count is zero",
-                    self.stm_ptr
+                    "({:p}) Invalid output hardware description: rate={}, channels={}",
+                    self.stm_ptr,
+                    output_hw_desc.mSampleRate,
+                    output_hw_desc.mChannelsPerFrame
                 );
                 return Err(Error::Error);
             }


### PR DESCRIPTION
CoreAudio can report zero sample rate or channel count in the hardware stream description during device transitions (e.g. device unplug, default device change).  This is the #1 cubeb-coreaudio crash signature, with ~240 crash pings per 30 days on macOS, 100% in the main (parent) process.

Previously, create_stream_description() would panic on zero rate or channels.  Now:
- Validate rate and channel count in setup() immediately after reading the hardware description, returning an error with diagnostic logging when the values are invalid.  This catches the problem at the source, where we have full context (device info, stream pointer).
- Convert the asserts in create_stream_description() to debug_assert + error return, so programming errors are still caught in dev builds but users don't crash.
- The output path already had a zero-channel check ("observed in the wild"); extend it to also check rate, and add both checks to the input path.