### PR TITLE
Handle unknown device IDs and empty aggregate devices gracefully

### DIFF
--- a/src/backend/aggregate_device.rs
+++ b/src/backend/aggregate_device.rs
@@ -565,7 +565,7 @@ impl AggregateDevice {
         if status != NO_ERR {
             return Err(Error::from(status));
         }
-        assert!(size > 0);
+        debug_assert!(size > 0);
         let subdevices_num = size / mem::size_of::<AudioObjectID>();
         if subdevices_num < 2 {
             cubeb_log!(

--- a/src/backend/device_property.rs
+++ b/src/backend/device_property.rs
@@ -4,7 +4,11 @@ pub fn get_device_uid(
     id: AudioDeviceID,
     devtype: DeviceType,
 ) -> std::result::Result<StringRef, OSStatus> {
-    assert_ne!(id, kAudioObjectUnknown);
+    debug_assert_ne!(id, kAudioObjectUnknown);
+    if id == kAudioObjectUnknown {
+        cubeb_log!("get_device_uid: device id is kAudioObjectUnknown");
+        return Err(kAudioHardwareBadObjectError as OSStatus);
+    }
     debug_assert_running_serially();
 
     let address = get_property_address(Property::DeviceUID, devtype);

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1687,7 +1687,11 @@ fn get_channel_count(
     devid: AudioObjectID,
     devtype: DeviceType,
 ) -> std::result::Result<u32, OSStatus> {
-    assert_ne!(devid, kAudioObjectUnknown);
+    debug_assert_ne!(devid, kAudioObjectUnknown);
+    if devid == kAudioObjectUnknown {
+        cubeb_log!("get_channel_count: device id is kAudioObjectUnknown");
+        return Err(kAudioHardwareBadObjectError as OSStatus);
+    }
     debug_assert_running_serially();
 
     let devstreams = get_device_streams(devid, devtype)?;


### PR DESCRIPTION
During device enumeration, devices can disappear between the list query and the property query, resulting in
kAudioObjectUnknown being passed to get_device_uid and get_channel_count.  These asserts crash the process (~48 crash pings per 30 days on macOS).  Replace with error returns using kAudioHardwareBadObjectError, which callers already handle.

Also convert the assert!(size > 0) in
activate_clock_drift_compensation to debug_assert.  When size is 0, the existing subdevices_num < 2 check immediately below returns the appropriate error, so the assert is redundant but was crashing the process (~40 crash pings per 30 days).