### PR TITLE
Expose device audio I/O workgroup via capi

### DIFF
--- a/src/backend/device_property.rs
+++ b/src/backend/device_property.rs
@@ -429,6 +429,30 @@ pub fn get_clock_domain(
     }
 }
 
+// Query the OS workgroup associated with the device's audio I/O thread.
+//
+// Returns a retained (+1) `os_workgroup_t` on success; the caller is
+// responsible for releasing it.  Not all devices publish a workgroup
+// (e.g. virtual devices on older OS versions), in which case this returns
+// an error.
+pub fn get_device_workgroup(
+    id: AudioDeviceID,
+    devtype: DeviceType,
+) -> std::result::Result<os_workgroup_t, OSStatus> {
+    assert_ne!(id, kAudioObjectUnknown);
+    debug_assert_running_serially();
+
+    let address = get_property_address(Property::IOThreadOSWorkgroup, devtype);
+    let mut size = mem::size_of::<os_workgroup_t>();
+    let mut wg: os_workgroup_t = ptr::null_mut();
+    let err = audio_object_get_property_data(id, &address, &mut size, &mut wg);
+    if err == NO_ERR {
+        Ok(wg)
+    } else {
+        Err(err)
+    }
+}
+
 pub enum Property {
     DeviceBufferFrameSizeRange,
     DeviceIsAlive,
@@ -445,6 +469,7 @@ pub enum Property {
     HardwareDefaultOutputDevice,
     HardwareDeviceForUID,
     HardwareDevices,
+    IOThreadOSWorkgroup,
     ModelUID,
     StreamLatency,
     StreamTerminalType,
@@ -471,6 +496,7 @@ impl From<Property> for AudioObjectPropertySelector {
             Property::HardwareDefaultOutputDevice => kAudioHardwarePropertyDefaultOutputDevice,
             Property::HardwareDeviceForUID => kAudioHardwarePropertyDeviceForUID,
             Property::HardwareDevices => kAudioHardwarePropertyDevices,
+            Property::IOThreadOSWorkgroup => kAudioDevicePropertyIOThreadOSWorkgroup,
             Property::ModelUID => kAudioDevicePropertyModelUID,
             Property::StreamLatency => kAudioStreamPropertyLatency,
             Property::StreamTerminalType => kAudioStreamPropertyTerminalType,

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -16,6 +16,7 @@ mod intern;
 mod mixer;
 mod resampler;
 mod utils;
+mod workgroup;
 
 use self::aggregate_device::*;
 use self::auto_release::*;
@@ -32,6 +33,7 @@ use self::device_property::*;
 use self::mixer::*;
 use self::resampler::*;
 use self::utils::*;
+use self::workgroup::WorkGroup;
 use backend::ringbuf::RingBuffer;
 #[cfg(feature = "audio-dump")]
 use cubeb_backend::ffi::cubeb_audio_dump_stream_t;
@@ -3290,6 +3292,13 @@ struct CoreStreamData<'ctx> {
     audio_dump_input: ffi::cubeb_audio_dump_stream_t,
     #[cfg(feature = "audio-dump")]
     audio_dump_output: ffi::cubeb_audio_dump_stream_t,
+    // OS workgroups associated with each device's audio I/O thread, queried
+    // from kAudioDevicePropertyIOThreadOSWorkgroup during setup().  Auxiliary
+    // threads that cooperate on this stream's audio deadline (e.g. audioipc's
+    // cross-process callback dispatch thread) can join these to participate
+    // in the workgroup's scheduling.
+    output_workgroup: Option<WorkGroup>,
+    input_workgroup: Option<WorkGroup>,
 }
 
 impl Default for CoreStreamData<'_> {
@@ -3341,6 +3350,8 @@ impl Default for CoreStreamData<'_> {
             audio_dump_input: ptr::null_mut(),
             #[cfg(feature = "audio-dump")]
             audio_dump_output: ptr::null_mut(),
+            output_workgroup: None,
+            input_workgroup: None,
         }
     }
 }
@@ -3398,6 +3409,8 @@ impl<'ctx> CoreStreamData<'ctx> {
             audio_dump_input: ptr::null_mut(),
             #[cfg(feature = "audio-dump")]
             audio_dump_output: ptr::null_mut(),
+            output_workgroup: None,
+            input_workgroup: None,
         }
     }
 
@@ -4468,6 +4481,39 @@ impl<'ctx> CoreStreamData<'ctx> {
                         || self.output_alive_listener.is_some()))
         );
 
+        // Cache each device's audio I/O workgroup so auxiliary threads that
+        // cooperate on this stream's audio deadline can query and join it.
+        // Not every device publishes a workgroup (older OS versions, virtual
+        // devices); a query failure here is non-fatal.
+        if self.has_output() && self.output_device.id != kAudioObjectUnknown {
+            match get_device_workgroup(self.output_device.id, DeviceType::OUTPUT) {
+                Ok(wg) => {
+                    self.output_workgroup = unsafe { WorkGroup::from_retained(wg) };
+                }
+                Err(e) => {
+                    cubeb_log!(
+                        "({:p}) output device workgroup query failed: {}",
+                        self.stm_ptr,
+                        e
+                    );
+                }
+            }
+        }
+        if self.has_input() && self.input_device.id != kAudioObjectUnknown {
+            match get_device_workgroup(self.input_device.id, DeviceType::INPUT) {
+                Ok(wg) => {
+                    self.input_workgroup = unsafe { WorkGroup::from_retained(wg) };
+                }
+                Err(e) => {
+                    cubeb_log!(
+                        "({:p}) input device workgroup query failed: {}",
+                        self.stm_ptr,
+                        e
+                    );
+                }
+            }
+        }
+
         Ok(())
     }
 
@@ -4534,6 +4580,10 @@ impl<'ctx> CoreStreamData<'ctx> {
         self.resampler.destroy();
         self.mixer = None;
         self.aggregate_device = None;
+        // Release workgroup references.  On reinit, setup() re-queries against
+        // the new device IDs.
+        self.output_workgroup = None;
+        self.input_workgroup = None;
 
         if self.uninstall_system_changed_callback().is_err() {
             cubeb_log!(
@@ -4836,7 +4886,7 @@ struct OutputCallbackTimingData {
 // #[repr(C)] is used to prevent any padding from being added in the beginning of the AudioUnitStream.
 #[repr(C)]
 #[derive(Debug)]
-struct AudioUnitStream<'ctx> {
+pub(crate) struct AudioUnitStream<'ctx> {
     context: &'ctx mut AudioUnitContext,
     user_ptr: *mut c_void,
     // Task queue for the stream.
@@ -5138,6 +5188,30 @@ impl<'ctx> AudioUnitStream<'ctx> {
             "Cubeb stream ({:p}) destroyed successful.",
             self as *const AudioUnitStream
         );
+    }
+
+    // Returns a retained (+1) reference to this stream's audio workgroup.
+    // Prefers the output device's workgroup; falls back to the input device's
+    // workgroup for input-only streams.  Returns NULL if neither is available.
+    //
+    // The query runs on the stream's serial queue to avoid racing with reinit
+    // (which replaces CoreStreamData).  The caller owns the returned reference
+    // and must release it with `os_release`.
+    pub(crate) fn workgroup_retained(&self) -> os_workgroup_t {
+        let mut result: os_workgroup_t = ptr::null_mut();
+        let result_ = &mut result;
+        let stream = &self;
+        self.queue.run_sync(move || {
+            let wg = stream
+                .core_stream_data
+                .output_workgroup
+                .as_ref()
+                .or(stream.core_stream_data.input_workgroup.as_ref());
+            if let Some(wg) = wg {
+                *result_ = wg.retained();
+            }
+        });
+        result
     }
 }
 

--- a/src/backend/tests/interfaces.rs
+++ b/src/backend/tests/interfaces.rs
@@ -1944,3 +1944,45 @@ fn test_ops_stereo_input_duplex_voice_stream_stop() {
         },
     );
 }
+
+#[test]
+fn test_ops_stream_get_workgroup_null_stream() {
+    // NULL input returns NULL, no crash.
+    let wg = unsafe { crate::capi::audiounit_stream_get_workgroup(ptr::null_mut()) };
+    assert!(wg.is_null());
+}
+
+#[test]
+fn test_ops_stream_get_workgroup() {
+    use coreaudio_sys_utils::sys::os_release;
+
+    test_default_output_stream_operation("stream: get workgroup", |stream| {
+        // Direct struct peek: setup() should have populated the output workgroup
+        // (this is true on any macOS version CoreAudio has published one for the
+        // default output device, which is the common case on recent releases).
+        let stm = unsafe { &*(stream as *const AudioUnitStream) };
+        let populated = stm.core_stream_data.output_workgroup.is_some();
+
+        // Query via the public capi and verify the result matches the internal state.
+        let wg = unsafe { crate::capi::audiounit_stream_get_workgroup(stream) };
+        if populated {
+            assert!(
+                !wg.is_null(),
+                "workgroup present internally but capi returned null"
+            );
+
+            // Querying a second time should return a fresh retained reference,
+            // not the same pointer invalidated.  Both must be released.
+            let wg2 = unsafe { crate::capi::audiounit_stream_get_workgroup(stream) };
+            assert!(!wg2.is_null());
+
+            unsafe { os_release(wg as *mut c_void) };
+            unsafe { os_release(wg2 as *mut c_void) };
+        } else {
+            // Some older devices / OS versions may not publish a workgroup.
+            // In that case both internal state and the capi should agree on null.
+            assert!(wg.is_null());
+            println!("default output device publishes no workgroup; skipping positive case");
+        }
+    });
+}

--- a/src/backend/workgroup.rs
+++ b/src/backend/workgroup.rs
@@ -1,0 +1,59 @@
+// Copyright © 2026 Mozilla Foundation
+//
+// This program is made available under an ISC-style license.  See the
+// accompanying file LICENSE for details.
+
+//! RAII wrapper around `os_workgroup_t`.
+//!
+//! `os_workgroup_t` is a refcounted kernel object.  Functions that return a
+//! workgroup (e.g. `AudioObjectGetPropertyData(kAudioDevicePropertyIOThreadOSWorkgroup)`)
+//! do so with a retain count of +1, transferring ownership to the caller.
+//! `WorkGroup` owns that +1 and releases it on drop.
+
+use super::coreaudio_sys_utils::sys::{os_release, os_retain, os_workgroup_s, os_workgroup_t};
+use std::fmt;
+use std::os::raw::c_void;
+
+pub struct WorkGroup(os_workgroup_t);
+
+impl WorkGroup {
+    /// Take ownership of an `os_workgroup_t` that already has a +1 retain count.
+    ///
+    /// Returns `None` if `wg` is null.
+    ///
+    /// # Safety
+    ///
+    /// `wg` must either be null or a valid workgroup pointer with a +1 retain
+    /// that is transferred to the returned `WorkGroup`.  The caller must not
+    /// release `wg` after this call.
+    pub unsafe fn from_retained(wg: os_workgroup_t) -> Option<Self> {
+        if wg.is_null() {
+            None
+        } else {
+            Some(Self(wg))
+        }
+    }
+
+    /// Return a fresh +1 retained reference to the underlying workgroup.  The
+    /// caller is responsible for releasing it via `os_release`.
+    pub fn retained(&self) -> *mut os_workgroup_s {
+        unsafe { os_retain(self.0 as *mut c_void) as *mut os_workgroup_s }
+    }
+}
+
+impl Drop for WorkGroup {
+    fn drop(&mut self) {
+        unsafe { os_release(self.0 as *mut c_void) }
+    }
+}
+
+// `os_workgroup_t` is a thread-safe refcounted kernel object, so the wrapper
+// is safe to send and share across threads.
+unsafe impl Send for WorkGroup {}
+unsafe impl Sync for WorkGroup {}
+
+impl fmt::Debug for WorkGroup {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("WorkGroup").field(&self.0).finish()
+    }
+}

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -3,9 +3,11 @@
 // This program is made available under an ISC-style license.  See the
 // accompanying file LICENSE for details.
 
-use crate::backend::AudioUnitContext;
+use crate::backend::{AudioUnitContext, AudioUnitStream};
+use coreaudio_sys_utils::sys::os_workgroup_t;
 use cubeb_backend::{capi, ffi};
 use std::os::raw::{c_char, c_int};
+use std::ptr;
 
 /// # Safety
 ///
@@ -16,4 +18,24 @@ pub unsafe extern "C" fn audiounit_rust_init(
     context_name: *const c_char,
 ) -> c_int {
     capi::capi_init::<AudioUnitContext>(c, context_name)
+}
+
+/// Returns a retained (+1) reference to the audio workgroup associated with
+/// `stm`'s output device, or the input device for input-only streams.  Returns
+/// NULL if `stm` is NULL or no workgroup is available.
+///
+/// The caller owns the returned reference and must release it with `os_release`.
+///
+/// # Safety
+///
+/// `stm` must be a valid cubeb stream pointer created by this backend, or NULL.
+#[no_mangle]
+pub unsafe extern "C" fn audiounit_stream_get_workgroup(
+    stm: *mut ffi::cubeb_stream,
+) -> os_workgroup_t {
+    if stm.is_null() {
+        return ptr::null_mut();
+    }
+    let stream = &*(stm as *const AudioUnitStream);
+    stream.workgroup_retained()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 extern crate atomic;
 #[macro_use]
 extern crate bitflags;
+extern crate coreaudio_sys_utils;
 #[macro_use]
 extern crate cubeb_backend;
 #[macro_use]
@@ -18,3 +19,4 @@ mod backend;
 mod capi;
 
 pub use crate::capi::audiounit_rust_init;
+pub use crate::capi::audiounit_stream_get_workgroup;


### PR DESCRIPTION
Query kAudioDevicePropertyIOThreadOSWorkgroup for each stream's output and input device during setup() and cache the result in CoreStreamData. Add a C-ABI entry point, audiounit_stream_get_workgroup, returning a retained os_workgroup_t so auxiliary threads that cooperate on a stream's audio deadline (e.g. audioipc's cross-process callback dispatch thread) can join the workgroup.

Introduces a small RAII WorkGroup wrapper over os_workgroup_t to manage the +1 retain transferred from CoreAudio and from the capi.  Query failures are non-fatal: older OS versions and some virtual devices do not publish a workgroup.