### PR TITLE
audiounit: reset async logger thread id before starting audio units

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,18 +138,18 @@ dependencies = [
 
 [[package]]
 name = "cubeb-backend"
-version = "0.32.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce8285b1c22e9e0acc34df19f2d9d267e5b5a70f692316ec8c45e86f5c1bcd1a"
+checksum = "7a4142b6c7b9cc47f0b5f6b8c4d0f07a1b4083460a748e4a10da5f68514409c9"
 dependencies = [
  "cubeb-core",
 ]
 
 [[package]]
 name = "cubeb-core"
-version = "0.32.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37474eec8b294455ef28b792ec0a09923fcb22ac5a454e426c7691bc279c26cd"
+checksum = "c4a73f927bd4fa1a316b1364e7b09b3e240de7b66414a2da9a5d025b37e8ca5e"
 dependencies = [
  "bitflags 1.3.2",
  "cc",
@@ -177,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "cubeb-sys"
-version = "0.32.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa823446c78d8ea1a9ea682bf2a910890206813b8eb4f6c2769d0a9c66709975"
+checksum = "ab47a6096fa88b4235602514a44441b855d6803bcb9a5987480a4ca18722d078"
 dependencies = [
  "cmake",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["staticlib", "rlib"]
 atomic = "0.4"
 bitflags = "2"
 coreaudio-sys-utils = { path = "coreaudio-sys-utils" }
-cubeb-backend = "0.32"
+cubeb-backend = "0.34.1"
 float-cmp = "0.6"
 libc = "0.2"
 mach2 = "0.4"

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3415,6 +3415,12 @@ impl<'ctx> CoreStreamData<'ctx> {
         // and before the stream is destroyed.
         debug_assert!(!self.input_unit.is_null() || !self.output_unit.is_null());
 
+        // Match other cubeb backends: reset the async logger's recorded
+        // producer thread id before the CoreAudio I/O proc begins logging.
+        unsafe {
+            ffi::cubeb_async_log_reset_threads();
+        }
+
         if !self.input_unit.is_null() {
             start_audiounit(self.input_unit)?;
         }


### PR DESCRIPTION
Match the WASAPI, OpenSL and AAudio backends which call
`cubeb_async_log_reset_threads()` before spawning or starting the render
thread that will produce async log messages.

Without this, the `cubeb_async_logger` ring buffer's `assert_correct_thread`
fires in debug builds when `VERBOSE` logging is enabled on an active session
(e.g. turning on the WebRTC log profile during an active call) because the
CoreAudio I/O proc thread differs from whatever thread previously recorded
itself as the ring buffer's producer.

Requires `cubeb-sys` 0.34.1 for the corrected FFI declaration of
`cubeb_async_log_reset_threads`.

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1909711