### PR TITLE
Bump coreaudio-sys to 0.2.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,9 +121,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "coreaudio-sys"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceec7a6067e62d6f931a2baf6f3a751f4a892595bcec1461a3c94ef9949864b6"
+checksum = "b9b4739a805a62757a83e5654fa3faabec0442666b263bb2287d5a8185bfd953"
 dependencies = [
  "bindgen",
 ]

--- a/coreaudio-sys-utils/Cargo.toml
+++ b/coreaudio-sys-utils/Cargo.toml
@@ -11,4 +11,4 @@ core-foundation-sys = { version = "0.8" }
 [dependencies.coreaudio-sys]
 default-features = false
 features = ["audio_unit", "core_audio", "io_kit_audio"]
-version = "0.2.14"
+version = "0.2.18"


### PR DESCRIPTION
`dispatch_queue_create_with_target` is aliased as `_dispatch_queue_create_with_target$V2` on macOS, but prior to 0.2.18 `coreaudio-sys` mistakenly thought that it was not aliased resulting in App Store review rejections for any Mac apps that linked against cubeb.