### PR TITLE
Provide a way to prevent inclusion of code that relies on private APIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ audio-dump = []
 vpio-forcelist = []
 gecko-in-tree = ["cubeb-backend/gecko-in-tree"]
 tsan-annotations = []
+no-private-apis = ["coreaudio-sys-utils/no-private-apis"]
 
 # Workaround for https://github.com/rust-lang/cargo/issues/6745 to allow this
 # Cargo.toml file to appear under a subdirectory of a workspace without being in

--- a/coreaudio-sys-utils/Cargo.toml
+++ b/coreaudio-sys-utils/Cargo.toml
@@ -12,3 +12,6 @@ core-foundation-sys = { version = "0.8" }
 default-features = false
 features = ["audio_unit", "core_audio", "io_kit_audio"]
 version = "0.2.18"
+
+[features]
+no-private-apis = []

--- a/coreaudio-sys-utils/src/audio_device_extensions.rs
+++ b/coreaudio-sys-utils/src/audio_device_extensions.rs
@@ -1,9 +1,12 @@
+#[allow(unused_imports)]
 use crate::dispatch::*;
+#[allow(unused_imports)]
 use coreaudio_sys::*;
 
 // See https://opensource.apple.com/source/WebCore/WebCore-7604.5.6/platform/spi/cf/CoreAudioSPI.h.auto.html
 // Per https://github.com/WebKit/WebKit/commit/7c4c851bc80f14b4cf907f76d65baee013a45eea,
 // this first appeared in MacOS 10.13 and iOS 11.0.
+#[cfg(not(feature = "no-private-apis"))]
 extern "C" {
     fn AudioDeviceDuck(
         inDevice: AudioDeviceID,
@@ -14,6 +17,7 @@ extern "C" {
 }
 
 // See https://github.com/mozilla/cubeb-coreaudio-rs/issues/237
+#[cfg(not(feature = "no-private-apis"))]
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn audio_device_duck(
     in_device: AudioDeviceID,

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -21,6 +21,7 @@ use self::aggregate_device::*;
 use self::auto_release::*;
 use self::buffer_manager::*;
 use self::coreaudio_sys_utils::aggregate_device::*;
+#[allow(unused_imports)]
 use self::coreaudio_sys_utils::audio_device_extensions::*;
 use self::coreaudio_sys_utils::audio_object::*;
 use self::coreaudio_sys_utils::audio_unit::*;
@@ -1515,6 +1516,7 @@ fn create_voiceprocessing_audiounit() -> Result<VoiceProcessingUnit> {
         return Err(Error::Error);
     }
 
+    #[cfg(not(feature = "no-private-apis"))]
     match get_default_device(DeviceType::OUTPUT) {
         None => {
             cubeb_log!("Could not get default output device in order to undo vpio ducking");
@@ -4423,6 +4425,7 @@ impl<'ctx> CoreStreamData<'ctx> {
             }
         }
 
+        #[cfg(not(feature = "no-private-apis"))]
         if using_voice_processing_unit {
             // The VPIO AudioUnit automatically ducks other audio streams on the VPIO
             // output device. Its ramp duration is 0.5s when ducking, so unduck similarly


### PR DESCRIPTION
Applications that rely on private APIs may and will get rejected by Apple. This change introduces a feature 'no-private-apis' that, when turned on, ensures that no private APIs are used. Currently, the only private API in the codebase seems to be AudioDeviceDuck, but in the future there may be more.

Caveat: when 'no-private-apis' is turned on, calls to disable audio device ducking will be removed, but no alternative method to disable ducking is provided.