### PR TITLE
Dispose audio units asynchronously during stream teardown

### DIFF
--- a/coreaudio-sys-utils/src/audio_unit.rs
+++ b/coreaudio-sys-utils/src/audio_unit.rs
@@ -132,6 +132,33 @@ pub fn dispose_audio_unit(unit: AudioUnit) -> OSStatus {
     unsafe { AudioComponentInstanceDispose(unit) }
 }
 
+// Dispose an audio unit on a background queue instead of blocking the caller.
+//
+// AudioComponentInstanceDispose makes a synchronous round-trip to coreaudiod,
+// which can stall for a long time when the active output device is slow to
+// respond (e.g. a third-party virtual audio device). When the caller is the
+// shared AudioIPC server RPC thread, that stall blocks every audio client (e.g.
+// connection setup and AudioContext creation), freezing the UI
+// (https://bugzilla.mozilla.org/show_bug.cgi?id=2045209). Use this only during
+// final stream teardown, where `unit` has already been uninitialized and
+// detached from its stream, so it is solely owned here and safe to dispose off
+// the serial queue.
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+pub fn dispose_audio_unit_async(unit: AudioUnit) {
+    // `AudioUnit` is a raw pointer to a detached, solely-owned component
+    // instance, so it is safe to move to the disposing queue.
+    struct SendAudioUnit(AudioUnit);
+    unsafe impl Send for SendAudioUnit {}
+
+    let unit = SendAudioUnit(unit);
+    crate::dispatch::Queue::get_global_queue().run_async(move || {
+        let unit = unit;
+        unsafe {
+            AudioComponentInstanceDispose(unit.0);
+        }
+    });
+}
+
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn audio_output_unit_start(unit: AudioUnit) -> OSStatus {
     assert!(!unit.is_null());

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -4510,7 +4510,13 @@ impl<'ctx> CoreStreamData<'ctx> {
         Ok(())
     }
 
-    fn close(&mut self) {
+    // `defer_dispose` disposes the (non-shared) audio units on a background
+    // queue rather than synchronously, so a stalled coreaudiod cannot block the
+    // caller. It is only safe during final teardown, where the units are not
+    // recreated afterwards; reinit and error paths must dispose synchronously.
+    // See https://bugzilla.mozilla.org/show_bug.cgi?id=2045209 and
+    // `dispose_audio_unit_async`.
+    fn close(&mut self, defer_dispose: bool) {
         self.debug_assert_is_on_stream_queue();
         if !self.input_unit.is_null() {
             audio_unit_uninitialize(self.input_unit);
@@ -4525,14 +4531,22 @@ impl<'ctx> CoreStreamData<'ctx> {
 
         if !self.output_unit.is_null() {
             audio_unit_uninitialize(self.output_unit);
-            dispose_audio_unit(self.output_unit);
+            if defer_dispose {
+                dispose_audio_unit_async(self.output_unit);
+            } else {
+                dispose_audio_unit(self.output_unit);
+            }
             self.output_unit = ptr::null_mut();
         }
 
         if !self.input_unit.is_null() {
             if !self.using_voice_processing_unit() {
                 // The VPIO unit is shared and must not be disposed.
-                dispose_audio_unit(self.input_unit);
+                if defer_dispose {
+                    dispose_audio_unit_async(self.input_unit);
+                } else {
+                    dispose_audio_unit(self.input_unit);
+                }
             }
             self.input_unit = ptr::null_mut();
         }
@@ -4859,7 +4873,7 @@ impl Drop for CoreStreamData<'_> {
     fn drop(&mut self) {
         self.debug_assert_is_on_stream_queue();
         self.stop_audiounits();
-        self.close();
+        self.close(false);
     }
 }
 
@@ -5017,7 +5031,7 @@ impl<'ctx> AudioUnitStream<'ctx> {
             get_volume(self.core_stream_data.output_unit)
         };
 
-        self.core_stream_data.close();
+        self.core_stream_data.close(false);
 
         // Use the new default device if this stream was set to follow the output device.
         if self.core_stream_data.has_output()
@@ -5106,7 +5120,7 @@ impl<'ctx> AudioUnitStream<'ctx> {
             }
 
             if self.reinit().is_err() {
-                self.core_stream_data.close();
+                self.core_stream_data.close(false);
                 self.stopped.store(true, Ordering::SeqCst);
                 self.notify_state_changed(State::Error);
                 cubeb_log!(
@@ -5123,7 +5137,7 @@ impl<'ctx> AudioUnitStream<'ctx> {
         self.queue.debug_assert_is_current();
         let stm_ptr = self as *const AudioUnitStream;
 
-        self.core_stream_data.close();
+        self.core_stream_data.close(false);
         self.notify_state_changed(State::Error);
         cubeb_log!("({:p}) Close the stream due to an error.", stm_ptr);
 
@@ -5132,7 +5146,11 @@ impl<'ctx> AudioUnitStream<'ctx> {
 
     fn destroy_internal(&mut self) {
         self.queue.debug_assert_is_current();
-        self.core_stream_data.close();
+        // Defer the (potentially coreaudiod-blocking) audio unit disposal to a
+        // background queue so final teardown cannot wedge the shared AudioIPC
+        // server RPC thread and stall other audio clients.
+        // See https://bugzilla.mozilla.org/show_bug.cgi?id=2045209.
+        self.core_stream_data.close(true);
         assert!(self.context.active_streams() >= 1);
         self.context.update_latency_by_removing_stream();
     }


### PR DESCRIPTION
AudioComponentInstanceDispose makes a synchronous round-trip through coreaudiod to the active output device's HAL driver. When that device is slow to respond, the call can block for a long time. This was observed on macOS with a third-party virtual audio device selected as the default output: tearing down a stream stalled in AudioComponentInstanceDispose for an extended period.

In Gecko's remoted-cubeb configuration the audio server runs every client on a single shared RPC thread (with the cubeb context as a thread-local on that thread). A stalled disposal during one stream's teardown therefore blocks that thread, which blocks every other audio client behind it: new audio-IPC connection setup and content-process AudioContext creation both hang, freezing the browser UI. See https://bugzilla.mozilla.org/show_bug.cgi?id=2045209.

Defer the audio unit disposal to a background dispatch queue, but only during final stream teardown (destroy_internal). By that point the units have been uninitialized and detached from the stream, so they are solely owned and safe to dispose off the serial queue, and AudioComponentInstanceDispose does not touch the cubeb context. The shared VPIO unit is still never disposed here, and the reinit and error paths continue to dispose synchronously since they recreate or reuse the units. This does not change the device's behavior; it keeps a slow teardown from blocking the thread other clients depend on.

Testing: cargo build, cargo fmt, and cargo clippy are clean. The change was validated in a Firefox build (macOS gtest and mochitest-media green on try) and confirmed by the bug reporter to resolve the freezes on their machine.
